### PR TITLE
Check hospital logo file before display

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,16 +17,15 @@ if(file.exists("R/modules/data_module.R")) {
 ui <- page_navbar(
   title = div(
     style = "display: flex; align-items: center;",
-    # Conditional logo display - only show if file exists
-    conditionalPanel(
-      condition = "true", # Will be made smarter later
+    # Logo display - only show if the logo file exists
+    if (file.exists(HOSPITAL_LOGO_PATH)) {
       img(
-        src = basename(HOSPITAL_LOGO_PATH), 
-        height = "30px", 
+        src = basename(HOSPITAL_LOGO_PATH),
+        height = "30px",
         style = "margin-right: 10px;",
         onerror = "this.style.display='none'" # Hide if image fails to load
       )
-    ),
+    },
     paste("SPC Analyse -", HOSPITAL_NAME)
   ),
   


### PR DESCRIPTION
## Summary
- Display hospital logo only if the logo file exists
- Update comment to reflect conditional rendering

## Testing
- `R -q -e "parse('app.R')"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b40d1ad0833097b659ee2e73a5cf