### PR TITLE
Normalize TEST_MODE_AUTO_LOAD environment handling

### DIFF
--- a/global.R
+++ b/global.R
@@ -178,7 +178,20 @@ detect_environment <- function() {
   # Check for explicit environment variable first
   env_var <- Sys.getenv("TEST_MODE_AUTO_LOAD", "")
   if (env_var != "") {
-    return(as.logical(env_var))
+    normalized_env_var <- tolower(trimws(env_var))
+    true_values <- c("true", "t", "1", "yes", "y", "on")
+    false_values <- c("false", "f", "0", "no", "n", "off")
+
+    if (normalized_env_var %in% true_values) {
+      return(TRUE)
+    }
+
+    if (normalized_env_var %in% false_values) {
+      return(FALSE)
+    }
+
+    # Unknown inputs fall back to safe default
+    return(FALSE)
   }
 
   # Production environments (safe default: FALSE)

--- a/tests/testthat/test-end-to-end-app-flow.R
+++ b/tests/testthat/test-end-to-end-app-flow.R
@@ -198,6 +198,52 @@ test_that("App initialisering og setup fungerer korrekt", {
   test_debug_log("App initialization tests completed\n")
 })
 
+test_that("TEST_MODE_AUTO_LOAD environment toggles auto-load sikkert", {
+
+  env_vars <- c(
+    "TEST_MODE_AUTO_LOAD",
+    "SHINY_SERVER_VERSION",
+    "CONNECT_SERVER",
+    "SHINYAPPS_SERVER",
+    "R_CONFIG_ACTIVE",
+    "RSTUDIO"
+  )
+
+  old_env <- setNames(vector("list", length(env_vars)), env_vars)
+  for (nm in env_vars) {
+    old_env[[nm]] <- Sys.getenv(nm, NA_character_)
+  }
+
+  on.exit({
+    for (nm in names(old_env)) {
+      value <- old_env[[nm]]
+      if (is.na(value)) {
+        Sys.unsetenv(nm)
+      } else {
+        do.call(Sys.setenv, setNames(list(value), nm))
+      }
+    }
+  }, add = TRUE)
+
+  # Neutraliser andre miljødetektorer for deterministiske tests
+  Sys.setenv(
+    SHINY_SERVER_VERSION = "",
+    CONNECT_SERVER = "",
+    SHINYAPPS_SERVER = "",
+    R_CONFIG_ACTIVE = "",
+    RSTUDIO = "0"
+  )
+
+  Sys.setenv(TEST_MODE_AUTO_LOAD = "TRUE")
+  expect_true(detect_environment())
+
+  Sys.setenv(TEST_MODE_AUTO_LOAD = "FALSE")
+  expect_false(detect_environment())
+
+  Sys.setenv(TEST_MODE_AUTO_LOAD = "MAYBE")
+  expect_false(detect_environment())
+})
+
 test_that("Unified state system initialization fungerer", {
 
   # Test at create_app_state eksisterer og fungerer (erstatter legacy initialize_reactive_values)


### PR DESCRIPTION
## Summary
- normalize TEST_MODE_AUTO_LOAD parsing by lower-casing values, matching against explicit truthy/falsy sets, and defaulting unknown inputs to FALSE
- add end-to-end coverage confirming TRUE enables auto-load, FALSE disables without errors, and other values safely fall back to the default

## Testing
- Rscript -e 'testthat::test_dir("tests/testthat")' *(fails: Rscript binary is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cffa4ab89c8330b78b3b6744e06ba3