### PR TITLE
Pass custom port to runApp

### DIFF
--- a/R/run_app.R
+++ b/R/run_app.R
@@ -92,11 +92,18 @@ run_app <- function(port = NULL,
   }
 
   # Run the app
-  runApp(
-    app,
-    # port = port,
-    launch.browser = browser_option
-  )
+  if (is.null(port)) {
+    runApp(
+      app,
+      launch.browser = browser_option
+    )
+  } else {
+    runApp(
+      app,
+      port = port,
+      launch.browser = browser_option
+    )
+  }
 }
 
 #' Get the UI function

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ R -e "shiny::runApp('.', port = 3838)"
 
 # Alternative med development settings
 R -e "source('global.R'); shiny::runApp('.', port = 4040)"
+
+# Kør via pakkefunktionen og vælg selv porten
+R -e "claudespc::run_app(port = 5050)"
 ```
 
 ### Development Mode

--- a/tests/testthat/test-run-app.R
+++ b/tests/testthat/test-run-app.R
@@ -1,0 +1,73 @@
+library(testthat)
+
+# Ensure global variables required by run_app are present to avoid sourcing heavy dependencies
+setup_required_globals <- function() {
+  vars <- list(
+    HOSPITAL_NAME = "Test Hospital",
+    my_theme = NULL,
+    HOSPITAL_LOGO_PATH = "logo.png"
+  )
+
+  original <- list()
+  for (nm in names(vars)) {
+    if (exists(nm, envir = .GlobalEnv, inherits = FALSE)) {
+      original[[nm]] <- get(nm, envir = .GlobalEnv, inherits = FALSE)
+    } else {
+      original[[nm]] <- NULL
+    }
+    assign(nm, vars[[nm]], envir = .GlobalEnv)
+  }
+
+  original
+}
+
+restore_globals <- function(original) {
+  for (nm in names(original)) {
+    if (is.null(original[[nm]])) {
+      if (exists(nm, envir = .GlobalEnv, inherits = FALSE)) {
+        rm(list = nm, envir = .GlobalEnv)
+      }
+    } else {
+      assign(nm, original[[nm]], envir = .GlobalEnv)
+    }
+  }
+}
+
+test_that("run_app forwards custom port to runApp", {
+  original <- setup_required_globals()
+  on.exit(restore_globals(original), add = TRUE)
+
+  captured <- new.env(parent = emptyenv())
+
+  fake_runApp <- function(app, port = NULL, launch.browser = TRUE) {
+    captured$app <- app
+    captured$port <- port
+    captured$launch.browser <- launch.browser
+    "runApp-called"
+  }
+
+  fake_shinyApp <- function(ui, server, ...) {
+    list(ui = ui, server = server, options = list(...))
+  }
+
+  fake_set_app_options <- function(options) invisible(options)
+  fake_get_app_option <- function(option, default = NULL) NULL
+  fake_log_debug <- function(...) invisible(NULL)
+
+  result <- with_mocked_bindings(
+    run_app(port = 5050, launch_browser = TRUE),
+    runApp = fake_runApp,
+    shinyApp = fake_shinyApp,
+    set_app_options = fake_set_app_options,
+    get_app_option = fake_get_app_option,
+    log_debug = fake_log_debug,
+    app_ui = function() "ui",
+    app_server = function(...) NULL,
+    `shiny::addResourcePath` = function(...) NULL,
+    `rstudioapi::isAvailable` = function() FALSE
+  )
+
+  expect_equal(result, "runApp-called")
+  expect_equal(captured$port, 5050)
+  expect_true(captured$launch.browser)
+})


### PR DESCRIPTION
## Summary
- forward the `run_app()` port argument to `shiny::runApp()` so custom ports are respected
- add a targeted test that verifies a user-specified port is forwarded to `runApp`
- update the README with an example of launching the app on a chosen port via `run_app()`

## Testing
- Rscript -e "testthat::test_file('tests/testthat/test-run-app.R')" *(fails: `Rscript` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cffa1ab1788330907f9831483d9a2e