### PR TITLE
Adjust freeze handling when cleaning qic call args

### DIFF
--- a/tests/testthat/test-clean-qic-call-args.R
+++ b/tests/testthat/test-clean-qic-call-args.R
@@ -1,0 +1,34 @@
+# test-clean-qic-call-args.R
+# Focused unit tests for clean_qic_call_args utility
+
+test_that("clean_qic_call_args adjusts freeze position after removing incomplete rows", {
+  skip_if_not_installed("purrr")
+
+  call_args <- list(
+    x = 1:6,
+    y = c(NA, 2, 3, 4, 5, 6),
+    freeze = 5
+  )
+
+  cleaned_args <- clean_qic_call_args(call_args)
+
+  expect_equal(cleaned_args$freeze, 4)
+  expect_length(cleaned_args$x, 5)
+  expect_length(cleaned_args$y, 5)
+})
+
+test_that("clean_qic_call_args drops invalid freeze positions", {
+  skip_if_not_installed("purrr")
+
+  call_args <- list(
+    x = 1:4,
+    y = c(NA, NA, 3, 4),
+    freeze = 2
+  )
+
+  cleaned_args <- clean_qic_call_args(call_args)
+
+  expect_false("freeze" %in% names(cleaned_args))
+  expect_length(cleaned_args$x, 2)
+  expect_length(cleaned_args$y, 2)
+})


### PR DESCRIPTION
## Summary
- adjust freeze positions in `clean_qic_call_args()` when rows are removed so baseline calculations remain valid
- clamp or drop invalid freeze indices after data cleaning to avoid empty centerline calculations
- add focused unit tests that cover freeze adjustment behaviour

## Testing
- Rscript -e "source('global.R'); testthat::test_file('tests/testthat/test-clean-qic-call-args.R')" *(fails: `Rscript` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d464cc5fc88330a208baa77901672d