### PR TITLE
Refactor startup flow to avoid premature qic execution

### DIFF
--- a/R/app_run.R
+++ b/R/app_run.R
@@ -84,18 +84,27 @@ run_app <- function(port = NULL,
     enable_test_mode <- interactive() || Sys.getenv("GOLEM_CONFIG_ACTIVE", "production") == "development"
   }
 
+  enable_test_mode <- isTRUE(enable_test_mode)
+  options(spc.test_mode = enable_test_mode)
+
+  if (exists("get_claudespc_environment", mode = "function")) {
+    claudespc_env <- get_claudespc_environment()
+    claudespc_env$TEST_MODE_AUTO_LOAD <- enable_test_mode
+    claudespc_env$TEST_MODE_FILE_PATH <- if (enable_test_mode) {
+      "inst/extdata/spc_exampledata.csv"
+    } else {
+      NULL
+    }
+  }
+
   if (enable_test_mode) {
     # Enable test mode with automatic data loading
     Sys.setenv(TEST_MODE_AUTO_LOAD = "TRUE")
     Sys.setenv(GOLEM_CONFIG_ACTIVE = "development")
     Sys.setenv(TEST_MODE_FILE_PATH = "inst/extdata/spc_exampledata.csv")
-
-    # Update package configuration to ensure it takes effect
-    if (exists("get_claudespc_environment", mode = "function")) {
-      claudespc_env <- get_claudespc_environment()
-      claudespc_env$TEST_MODE_AUTO_LOAD <- TRUE
-      claudespc_env$TEST_MODE_FILE_PATH <- "inst/extdata/spc_exampledata.csv"
-    }
+  } else {
+    Sys.setenv(TEST_MODE_AUTO_LOAD = "FALSE")
+    Sys.unsetenv("TEST_MODE_FILE_PATH")
   }
 
   # Create the Shiny app using golem pattern


### PR DESCRIPTION
## Summary
- defer test-mode dataset loading until after the first UI flush and guard against duplicate autoloads
- track test-mode options centrally in run_app and reset environment variables when test mode is disabled
- restructure the visualization module so qic and plot generation run only when data is available, add caching keys, instrumentation, and placeholder rendering for empty states

## Testing
- Rscript -e "source('global.R'); testthat::test_file('tests/testthat/test-startup-performance.R')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d681203fb08330913646781f0f208d