### PR TITLE
Specify chart type in centerline tests

### DIFF
--- a/tests/testthat/test-centerline-handling.R
+++ b/tests/testthat/test-centerline-handling.R
@@ -26,7 +26,7 @@ test_that("centerline anvendes korrekt for decimale datasæt", {
   config <- list(x_col = "Dato", y_col = "Måling", n_col = NULL)
 
   x_validation <- validate_x_column_format(test_data, config$x_col, "observation")
-  prepared <- prepare_qic_data_parameters(test_data, config, x_validation)
+  prepared <- prepare_qic_data_parameters(test_data, config, x_validation, "i")
 
   input_value <- "80%"
   target_value <- parse_danish_target(input_value, test_data$Måling, "percent")
@@ -63,7 +63,7 @@ test_that("centerline anvendes korrekt for procentdatasæt med nævner", {
   config <- list(x_col = "Dato", y_col = "Antal succes", n_col = "Antal total")
 
   x_validation <- validate_x_column_format(test_data, config$x_col, "observation")
-  prepared <- prepare_qic_data_parameters(test_data, config, x_validation)
+  prepared <- prepare_qic_data_parameters(test_data, config, x_validation, "run")
 
   input_value <- "80%"
   target_value <- parse_danish_target(input_value, test_data$`Antal succes`, "percent")


### PR DESCRIPTION
## Summary
- update centerline handling tests to pass the chart type to `prepare_qic_data_parameters`

## Testing
- `R -e "source('global.R'); testthat::test_file('tests/testthat/test-centerline-handling.R')"` *(fails: R command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daf938d6b48330a27def036d38c189