### PR TITLE
chore(deps): bump BFHcharts to 0.8.0 og fjern tids-akse workaround

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     ggpp (>= 0.5.0),
     ggrepel (>= 0.9.0),
     geomtextpath (>= 0.1.0),
-    BFHcharts (>= 0.7.2),
+    BFHcharts (>= 0.8.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -546,21 +546,6 @@ compute_spc_results_bfh <- function(
         standardized$plot <- standardized$plot + x_scale + x_theme
       }
 
-      # 7d3. [MIDLERTIDIG] Override BFHcharts y-akse-formatering for tids-enhed
-      # BFHcharts sætter selv scale_y_continuous med nsmall=1-lignende format
-      # ("0,6666667 timer"). Vi tilsidesætter med biSPCharts' komposit-format
-      # ("40m") via format_y_axis_time(). ggplot2 viser en "Scale already
-      # present"-besked, som undertrykkes her.
-      #
-      # FJERN: Når BFHcharts får indbygget komposit-tidsformat (se issue-tracker).
-      # Se: R/utils_y_axis_formatting.R::format_y_axis_time()
-      if (identical(y_axis_unit, "time") && !is.null(standardized$plot) &&
-        !is.null(standardized$qic_data)) {
-        standardized$plot <- suppressMessages(
-          standardized$plot + format_y_axis_time(standardized$qic_data)
-        )
-      }
-
       # 7e. Anhøj metadata: brug BFHcharts' allerede beregnede metadata
       # transform_bfh_output() udtrækker Anhøj-regler fra BFHcharts qic_data.
       # compute_anhoej_metadata_local() (qicharts2::qic) er FJERNET da den var


### PR DESCRIPTION
## Ændringer

Bumper `BFHcharts` lower-bound fra `0.7.2` til `0.8.0` og fjerner den midlertidige y-akse override-workaround indført i PR #204.

### Hvad BFHcharts 0.8.0 leverer
BFHcharts har nu indbygget komposit tidsformat (`1t 30m`, `2d 4t`) og tids-naturlige tick-breaks direkte i `bfh_qic()`. Se [BFHcharts#138](https://github.com/johanreventlow/BFHcharts/issues/138) for detaljer og scope (y-akse-ticks, CL/target/UCL/LCL-labels, NUV. NIVEAU-indikator).

### Diff
- `DESCRIPTION`: `BFHcharts (>= 0.7.2)` → `BFHcharts (>= 0.8.0)`
- `R/fct_spc_bfh_facade.R`: fjerner 15-linjers `[MIDLERTIDIG]` override-blok (7d3) der tidligere tilsidesatte BFHcharts' y-akse-scale med biSPCharts' `format_y_axis_time()`

### Hvad bevares
`R/utils_time_formatting.R` (komposit-helpers + tick-kandidater) beholdes fordi:
- Referenceret fra `apply_y_axis_formatting()` og `format_y_value()` (testet infrastruktur)
- Planlagt brugt i Fase 2a/2b når vi tilføjer `Tid (minutter)` / `Tid (timer)` / `Tid (dage)` dropdown-valg

## Test plan

**Automatiseret:**
- [x] `testthat::test_dir('tests/testthat', filter='(time|label|y-axis)-formatting')` — samme pass/fail-profil som på master (6 pre-existing baseline-fejl i `format_scaled_number`/`format_unscaled_number`/decimal precision, ingen nye regressioner)
- [ ] CI (automatisk)

**Manuel (anbefalet før merge):**
- [ ] Start app (`golem::run_dev()`)
- [ ] Upload tids-data (y-værdier i minutter, fx range 40-80)
- [ ] Verificér at y-aksen stadig viser komposit-format (`40m`, `1t`, `1t 10m`...) — nu leveret direkte af BFHcharts uden override
- [ ] Verificér at CL/target/UCL/LCL-labels også bruger komposit-format (det kunne de ikke med workaround'en — kun akse-ticks blev overridet)

## Cross-repo

Følger VERSIONING_POLICY.md §E (Cross-repo bump-protokol). Separat `chore(deps):`-PR efter sibling-release.

Closes koordinering i BFHcharts#138.