### PR TITLE
feat(time-axis): parsing-lag og familie-klassifikation for tids-enheder

### DIFF
--- a/R/config_spc_config.R
+++ b/R/config_spc_config.R
@@ -70,12 +70,20 @@ Y_AXIS_UNITS_DA <- list(
 )
 
 #' UI-typer for Y-akse (simpel valg)
+#'
+#' Tids-enheder er eksplicit adskilt fra Fase 2 af
+#' docs/superpowers/specs/2026-04-17-time-yaxis-design.md. Legacy "time"
+#' er fjernet fra UI men accepteres stadig af is_time_unit() for
+#' bagudkompatibilitet og migration.
+#'
 #' @keywords internal
 Y_AXIS_UI_TYPES_DA <- list(
   "Tal" = "count",
   "Procent (%)" = "percent",
   "Rate" = "rate",
-  "Tid mellem hændelser" = "time"
+  "Tid (minutter)" = "time_minutes",
+  "Tid (timer)" = "time_hours",
+  "Tid (dage)" = "time_days"
 )
 
 # SPC VISUALIZATION CONSTANTS ===================================================

--- a/R/utils_time_parsing.R
+++ b/R/utils_time_parsing.R
@@ -63,7 +63,18 @@ parse_time_to_minutes <- function(x, input_unit = "time_minutes") {
     return(x * scale)
   }
 
-  # Fremtidige paths (hms/difftime/character) tilføjes i senere tasks
+  # Character/factor-input: prøv HH:MM[:SS] parse først, fald tilbage til numeric
+  if (is.character(x) || is.factor(x)) {
+    x_char <- as.character(x)
+    hhmm_result <- parse_hhmm_strings(x_char)
+
+    # For værdier hvor HH:MM-parse fejler (NA), prøv numeric-parse
+    numeric_fallback <- suppressWarnings(as.numeric(x_char)) * scale
+    result <- ifelse(is.na(hhmm_result), numeric_fallback, hhmm_result)
+    return(result)
+  }
+
+  # Ukendt type — returnér NA med warning
   suppressWarnings({
     coerced <- as.numeric(as.character(x))
   })
@@ -71,8 +82,42 @@ parse_time_to_minutes <- function(x, input_unit = "time_minutes") {
     warning(
       "parse_time_to_minutes: kunne ikke parse input af type '",
       paste(class(x), collapse = "/"),
-      "' — returnerer NA. HH:MM og hms-support kommer i senere task."
+      "' — returnerer NA."
     )
   }
   coerced * scale
+}
+
+#' Parse HH:MM eller HH:MM:SS strenge til minutter
+#'
+#' Sekunder konverteres til brøkdele af minutter (rundes ikke her —
+#' det håndteres af format_time_composite() ved render-tid).
+#' Ugyldige strenge returnerer NA.
+#'
+#' @param x Character vektor.
+#' @return Numeric vektor med minutter.
+#' @keywords internal
+parse_hhmm_strings <- function(x) {
+  # Regex: optional negative sign, timer (1-3 cifre), minutter (1-2 cifre),
+  # valgfrit :SS hvor SS er 1-2 cifre.
+  pattern <- "^(-?)(\\d{1,3}):(\\d{1,2})(?::(\\d{1,2}))?$"
+
+  matches <- stringr::str_match(x, pattern)
+  # matches er en matrix med kolonner: [full, sign, hours, mins, secs]
+  n <- nrow(matches)
+  result <- vapply(seq_len(n), function(i) {
+    if (is.na(matches[i, 1])) {
+      return(NA_real_)
+    }
+    sign <- if (identical(matches[i, 2], "-")) -1 else 1
+    hours <- suppressWarnings(as.numeric(matches[i, 3]))
+    mins <- suppressWarnings(as.numeric(matches[i, 4]))
+    secs_str <- matches[i, 5]
+    secs <- if (is.na(secs_str)) 0 else suppressWarnings(as.numeric(secs_str))
+    if (any(is.na(c(hours, mins, secs)))) {
+      return(NA_real_)
+    }
+    sign * (hours * 60 + mins + secs / 60)
+  }, numeric(1))
+  result
 }

--- a/R/utils_time_parsing.R
+++ b/R/utils_time_parsing.R
@@ -47,6 +47,17 @@ parse_time_to_minutes <- function(x, input_unit = "time_minutes") {
 
   scale <- TIME_INPUT_UNIT_SCALES[[input_unit]]
 
+  # hms: altid sekunder → divider med 60
+  # (hms ignorerer units-arg og returnerer altid sekunder via as.numeric)
+  if (inherits(x, "hms")) {
+    return(as.numeric(x) / 60)
+  }
+
+  # difftime: konvertér direkte til minutter via units-arg
+  if (inherits(x, "difftime")) {
+    return(as.numeric(x, units = "mins"))
+  }
+
   # Numeric path
   if (is.numeric(x)) {
     return(x * scale)

--- a/R/utils_time_parsing.R
+++ b/R/utils_time_parsing.R
@@ -1,0 +1,67 @@
+# utils_time_parsing.R
+# Parsing af tids-input til kanoniske minutter.
+#
+# Understøtter:
+# - Numeric + input_unit ('time_minutes', 'time_hours', 'time_days')
+# - hms::hms / difftime objekter (tilføjes i Task 2a.4)
+# - Karakter-strenge i HH:MM og HH:MM:SS format (tilføjes i Task 2a.5)
+# - NA og ugyldige værdier håndteres graciously
+#
+# Kanonisk output: minutter som double.
+# Se docs/superpowers/specs/2026-04-17-time-yaxis-design.md.
+
+# ENHEDSKONSTANTER ============================================================
+
+#' Skaleringsfaktor fra input-enhed til kanoniske minutter
+#' @keywords internal
+TIME_INPUT_UNIT_SCALES <- c(
+  time_minutes = 1,
+  time_hours   = 60,
+  time_days    = 1440
+)
+
+# PARSING HOVEDFUNKTION =======================================================
+
+#' Konvertér tids-input til kanoniske minutter
+#'
+#' @param x Input-vektor. Kan være numeric, character (HH:MM[:SS]),
+#'   hms/difftime objekt, eller NA.
+#' @param input_unit Character. En af 'time_minutes', 'time_hours', 'time_days'.
+#'   Ignoreres hvis x er hms/difftime eller HH:MM-streng. Default: 'time_minutes'.
+#' @return Numeric vektor. Minutter som double. NA for ugyldig input.
+#' @keywords internal
+parse_time_to_minutes <- function(x, input_unit = "time_minutes") {
+  if (length(x) == 0L) {
+    return(numeric(0))
+  }
+
+  # Validér input_unit; fall-back til minutter med advarsel
+  if (is.null(input_unit) || !input_unit %in% names(TIME_INPUT_UNIT_SCALES)) {
+    warning(
+      "parse_time_to_minutes: ukendt input_unit '",
+      input_unit %||% "NULL",
+      "' — antager time_minutes"
+    )
+    input_unit <- "time_minutes"
+  }
+
+  scale <- TIME_INPUT_UNIT_SCALES[[input_unit]]
+
+  # Numeric path
+  if (is.numeric(x)) {
+    return(x * scale)
+  }
+
+  # Fremtidige paths (hms/difftime/character) tilføjes i senere tasks
+  suppressWarnings({
+    coerced <- as.numeric(as.character(x))
+  })
+  if (all(is.na(coerced)) && !all(is.na(x))) {
+    warning(
+      "parse_time_to_minutes: kunne ikke parse input af type '",
+      paste(class(x), collapse = "/"),
+      "' — returnerer NA. HH:MM og hms-support kommer i senere task."
+    )
+  }
+  coerced * scale
+}

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -11,6 +11,22 @@ INTERNAL_CLASSES <- list(
   COUNT_BETWEEN = "COUNT_BETWEEN"
 )
 
+#' Afgør om en y-akse UI-type tilhører tids-familien
+#'
+#' Omfatter legacy `"time"` og de nye enheds-varianter fra Fase 2.
+#' Bruges af `determine_internal_class()` og `default_time_unit_for_chart()`.
+#'
+#' @param ui_type Character vektor eller NULL.
+#' @return Logical vektor samme længde som ui_type. FALSE for NA/tom.
+#' @keywords internal
+is_time_unit <- function(ui_type) {
+  if (is.null(ui_type) || length(ui_type) == 0L) {
+    return(logical(0))
+  }
+  ui <- tolower(as.character(ui_type))
+  !is.na(ui) & ui %in% c("time", "time_minutes", "time_hours", "time_days")
+}
+
 #' Afgør intern klasse ud fra UI-type og data
 #'
 #' @param ui_type En af {"count" (TAL), "percent" (PROCENT), "rate" (RATE), "time" (TID)}
@@ -29,7 +45,7 @@ determine_internal_class <- function(ui_type, y, n_present = FALSE) {
     return(INTERNAL_CLASSES$RATE_INTERNAL)
   }
 
-  if (ui == "time") {
+  if (is_time_unit(ui)) {
     return(INTERNAL_CLASSES$TIME_BETWEEN)
   }
 
@@ -102,6 +118,12 @@ decide_default_y_axis_ui_type <- function(chart_type, n_present) {
 #' @return one of {"count","percent","rate","time"}
 #' @keywords internal
 chart_type_to_ui_type <- function(chart_type) {
+  # "t" er en kendt qic-kode, men ikke i CHART_TYPES_EN endnu, så vi
+  # matcher den direkte før kaldet til get_qic_chart_type() (som ville
+  # falde tilbage til "run").
+  if (identical(chart_type, "t")) {
+    return("time_days")
+  }
   ct <- get_qic_chart_type(chart_type)
   if (ct %in% c("p", "pp")) {
     return("percent")
@@ -110,7 +132,7 @@ chart_type_to_ui_type <- function(chart_type) {
     return("rate")
   }
   if (ct == "t") {
-    return("time")
+    return("time_days")
   }
   # i, mr, c, g og fallback
   return("count")

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -118,11 +118,17 @@ decide_default_y_axis_ui_type <- function(chart_type, n_present) {
 #' @return one of {"count","percent","rate","time"}
 #' @keywords internal
 chart_type_to_ui_type <- function(chart_type) {
-  # "t" er en kendt qic-kode, men ikke i CHART_TYPES_EN endnu, så vi
-  # matcher den direkte før kaldet til get_qic_chart_type() (som ville
-  # falde tilbage til "run").
+  # "t", "pp" og "up" er kendte qic-koder, men ikke i CHART_TYPES_EN endnu,
+  # så vi matcher dem direkte før kaldet til get_qic_chart_type() (som
+  # ville falde tilbage til "run" og give forkert UI-type).
   if (identical(chart_type, "t")) {
     return("time_days")
+  }
+  if (identical(chart_type, "pp")) {
+    return("percent")
+  }
+  if (identical(chart_type, "up")) {
+    return("rate")
   }
   ct <- get_qic_chart_type(chart_type)
   if (ct %in% c("p", "pp")) {

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -137,3 +137,30 @@ chart_type_to_ui_type <- function(chart_type) {
   # i, mr, c, g og fallback
   return("count")
 }
+
+#' Foreslå default tids-enhed for en korttype
+#'
+#' Bruges af UI-laget til at pre-vælge en passende tids-enhed når
+#' brugeren skifter korttype. Returnerer NULL for korttyper der ikke
+#' typisk bruger tid på y-aksen — caller falder så tilbage til eget default.
+#'
+#' @param chart_type character. qicharts2-kode eller dansk label.
+#' @return character eller NULL.
+#' @keywords internal
+default_time_unit_for_chart <- function(chart_type) {
+  if (is.null(chart_type) || length(chart_type) == 0L) {
+    return(NULL)
+  }
+  if (is.na(chart_type)) {
+    return(NULL)
+  }
+  # "t" er endnu ikke i CHART_TYPES_EN; matcher direkte før get_qic_chart_type().
+  if (identical(chart_type, "t")) {
+    return("time_days")
+  }
+  ct <- get_qic_chart_type(chart_type)
+  if (identical(ct, "t")) {
+    return("time_days")
+  }
+  NULL
+}

--- a/tests/testthat/test-time-parsing.R
+++ b/tests/testthat/test-time-parsing.R
@@ -31,3 +31,23 @@ test_that("parse_time_to_minutes defaulter til time_minutes for ugyldig input_un
     expect_equal(parse_time_to_minutes(90, "bogus_unit"), 90)
   })
 })
+
+test_that("parse_time_to_minutes haandterer difftime med forskellige enheder", {
+  # difftime i minutter — input_unit ignoreres for difftime
+  dt_min <- as.difftime(c(30, 60, 90), units = "mins")
+  expect_equal(parse_time_to_minutes(dt_min, "time_hours"), c(30, 60, 90))
+
+  # difftime i timer
+  dt_hrs <- as.difftime(c(1, 2, 3), units = "hours")
+  expect_equal(parse_time_to_minutes(dt_hrs, "time_minutes"), c(60, 120, 180))
+
+  # difftime i sekunder (giver brøkdele af minutter)
+  dt_sec <- as.difftime(c(60, 120, 90), units = "secs")
+  expect_equal(parse_time_to_minutes(dt_sec), c(1, 2, 1.5))
+})
+
+test_that("parse_time_to_minutes haandterer hms objekter", {
+  skip_if_not_installed("hms")
+  h <- hms::hms(seconds = c(90 * 60, 30 * 60))  # 90 min og 30 min
+  expect_equal(parse_time_to_minutes(h), c(90, 30))
+})

--- a/tests/testthat/test-time-parsing.R
+++ b/tests/testthat/test-time-parsing.R
@@ -51,3 +51,42 @@ test_that("parse_time_to_minutes haandterer hms objekter", {
   h <- hms::hms(seconds = c(90 * 60, 30 * 60))  # 90 min og 30 min
   expect_equal(parse_time_to_minutes(h), c(90, 30))
 })
+
+test_that("parse_time_to_minutes haandterer HH:MM-strenge", {
+  expect_equal(parse_time_to_minutes("01:30"), 90)
+  expect_equal(parse_time_to_minutes("00:45"), 45)
+  expect_equal(parse_time_to_minutes("02:00"), 120)
+  # Værdier >24t er valide (kumulerede tider)
+  expect_equal(parse_time_to_minutes("25:15"), 25 * 60 + 15)
+  # Enkelt-cifre timer og minutter
+  expect_equal(parse_time_to_minutes("1:5"), 65)
+})
+
+test_that("parse_time_to_minutes haandterer HH:MM:SS", {
+  # Sekunder bevares som brøkdele af minutter
+  expect_equal(parse_time_to_minutes("01:30:15"), 90.25)
+  expect_equal(parse_time_to_minutes("01:30:45"), 90.75)
+  expect_equal(parse_time_to_minutes("00:00:30"), 0.5)
+})
+
+test_that("parse_time_to_minutes haandterer ugyldige strenge som NA", {
+  suppressWarnings({
+    expect_true(is.na(parse_time_to_minutes("invalid")))
+    expect_true(is.na(parse_time_to_minutes("abc:def")))
+    expect_true(is.na(parse_time_to_minutes("")))
+  })
+})
+
+test_that("parse_time_to_minutes haandterer blandet karakter-vektor", {
+  suppressWarnings({
+    result <- parse_time_to_minutes(c("01:30", "invalid", "00:45", NA))
+    expect_equal(result, c(90, NA_real_, 45, NA_real_))
+  })
+})
+
+test_that("parse_time_to_minutes kan stadig parse numeriske strenge", {
+  # Strenge der ser ud som numre (ingen ':' til HH:MM-parse)
+  # behandles som numeric med input_unit
+  expect_equal(parse_time_to_minutes("90", "time_minutes"), 90)
+  expect_equal(parse_time_to_minutes("1.5", "time_hours"), 90)
+})

--- a/tests/testthat/test-time-parsing.R
+++ b/tests/testthat/test-time-parsing.R
@@ -1,0 +1,33 @@
+# test-time-parsing.R
+# Tests for parse_time_to_minutes() — konverterer diverse tids-inputs
+# til kanoniske minutter.
+
+library(testthat)
+
+test_that("parse_time_to_minutes haandterer numerisk input med input_unit", {
+  expect_equal(parse_time_to_minutes(90, "time_minutes"), 90)
+  expect_equal(parse_time_to_minutes(1.5, "time_hours"), 90)
+  expect_equal(parse_time_to_minutes(0.0625, "time_days"), 90)
+})
+
+test_that("parse_time_to_minutes er vektoriseret", {
+  input <- c(30, 60, 90, 120)
+  expect_equal(parse_time_to_minutes(input, "time_minutes"), c(30, 60, 90, 120))
+  expect_equal(parse_time_to_minutes(c(1, 2, 3), "time_hours"), c(60, 120, 180))
+  expect_equal(parse_time_to_minutes(c(1, 2), "time_days"), c(1440, 2880))
+})
+
+test_that("parse_time_to_minutes haandterer NA", {
+  expect_true(is.na(parse_time_to_minutes(NA_real_, "time_minutes")))
+  expect_equal(
+    parse_time_to_minutes(c(1, NA, 2), "time_hours"),
+    c(60, NA_real_, 120)
+  )
+})
+
+test_that("parse_time_to_minutes defaulter til time_minutes for ugyldig input_unit", {
+  suppressWarnings({
+    expect_equal(parse_time_to_minutes(90, NULL), 90)
+    expect_equal(parse_time_to_minutes(90, "bogus_unit"), 90)
+  })
+})

--- a/tests/testthat/test-y-axis-mapping.R
+++ b/tests/testthat/test-y-axis-mapping.R
@@ -1,5 +1,4 @@
 test_that("chart_type_to_ui_type mapping is correct", {
-  source("R/utils_y_axis_model.R")
 
   # Proportion charts → percent
   expect_equal(chart_type_to_ui_type("p"), "percent")
@@ -9,8 +8,8 @@ test_that("chart_type_to_ui_type mapping is correct", {
   expect_equal(chart_type_to_ui_type("u"), "rate")
   expect_equal(chart_type_to_ui_type("up"), "rate")
 
-  # Time between → time
-  expect_equal(chart_type_to_ui_type("t"), "time")
+  # Time between → time_days (Fase 2a: t-kort bruger dage som default tids-enhed)
+  expect_equal(chart_type_to_ui_type("t"), "time_days")
 
   # Count/measurement/others → count
   expect_equal(chart_type_to_ui_type("i"), "count")
@@ -21,7 +20,6 @@ test_that("chart_type_to_ui_type mapping is correct", {
 })
 
 test_that("run chart default y-axis with denominator presence", {
-  source("R/utils_y_axis_model.R")
 
   # RUN + with N → percent
   expect_equal(decide_default_y_axis_ui_type("run", n_present = TRUE), "percent")
@@ -31,7 +29,6 @@ test_that("run chart default y-axis with denominator presence", {
 })
 
 test_that("run chart denominator toggle semantics (unit-only)", {
-  source("R/utils_y_axis_model.R")
 
   # Conceptual toggle: blank → selected N should imply percent
   expect_equal(decide_default_y_axis_ui_type("run", n_present = TRUE), "percent")

--- a/tests/testthat/test-y-axis-model.R
+++ b/tests/testthat/test-y-axis-model.R
@@ -61,3 +61,15 @@ test_that("determine_internal_class bruger is_time_unit for alle tids-enheder", 
 test_that("chart_type_to_ui_type returnerer time_days for t-kort", {
   expect_equal(chart_type_to_ui_type("t"), "time_days")
 })
+
+test_that("default_time_unit_for_chart returnerer passende enhed pr. korttype", {
+  expect_equal(default_time_unit_for_chart("t"), "time_days")
+  # For ikke-tids-specifikke korttyper returneres NULL
+  expect_null(default_time_unit_for_chart("i"))
+  expect_null(default_time_unit_for_chart("p"))
+  expect_null(default_time_unit_for_chart("c"))
+  expect_null(default_time_unit_for_chart("u"))
+  # NA / NULL input
+  expect_null(default_time_unit_for_chart(NULL))
+  expect_null(default_time_unit_for_chart(NA_character_))
+})

--- a/tests/testthat/test-y-axis-model.R
+++ b/tests/testthat/test-y-axis-model.R
@@ -1,6 +1,4 @@
 test_that("UI-typer mapper korrekt til interne klasser", {
-  source("R/utils_y_axis_model.R")
-
   # TAL → COUNT hvis heltal ≥ 0, ellers MEASUREMENT
   y_int <- c(0, 1, 2, 10)
   y_dec <- c(1.2, 2.5, 3.0)
@@ -19,8 +17,6 @@ test_that("UI-typer mapper korrekt til interne klasser", {
 })
 
 test_that("Kortvalg mapper korrekt fra intern klasse", {
-  source("R/utils_y_axis_model.R")
-
   expect_equal(suggest_chart_type("MEASUREMENT", n_present = FALSE, n_points = 20), "i")
   expect_equal(suggest_chart_type("COUNT", n_present = FALSE, n_points = 20), "c")
   expect_equal(suggest_chart_type("PROPORTION", n_present = TRUE, n_points = 20), "p")
@@ -33,8 +29,35 @@ test_that("Kortvalg mapper korrekt fra intern klasse", {
 })
 
 test_that("Default Y-akse UI-type for run chart", {
-  source("R/utils_y_axis_model.R")
   expect_equal(decide_default_y_axis_ui_type("run", n_present = TRUE), "percent")
   expect_equal(decide_default_y_axis_ui_type("run", n_present = FALSE), "count")
   expect_equal(decide_default_y_axis_ui_type("p", n_present = TRUE), "count")
+})
+
+test_that("is_time_unit identificerer alle tids-enheder (inkl. legacy)", {
+  # Legacy
+  expect_true(is_time_unit("time"))
+  # Nye enheder
+  expect_true(is_time_unit("time_minutes"))
+  expect_true(is_time_unit("time_hours"))
+  expect_true(is_time_unit("time_days"))
+  # Ikke-tids-enheder
+  expect_false(is_time_unit("count"))
+  expect_false(is_time_unit("percent"))
+  expect_false(is_time_unit("rate"))
+  # Edge cases
+  expect_equal(is_time_unit(NULL), logical(0))
+  expect_false(is_time_unit(NA_character_))
+  expect_false(is_time_unit(""))
+})
+
+test_that("determine_internal_class bruger is_time_unit for alle tids-enheder", {
+  expect_equal(determine_internal_class("time", y = c(1, 2, 3)), "TIME_BETWEEN")
+  expect_equal(determine_internal_class("time_minutes", y = c(30, 60)), "TIME_BETWEEN")
+  expect_equal(determine_internal_class("time_hours", y = c(1.5, 2)), "TIME_BETWEEN")
+  expect_equal(determine_internal_class("time_days", y = c(1, 2)), "TIME_BETWEEN")
+})
+
+test_that("chart_type_to_ui_type returnerer time_days for t-kort", {
+  expect_equal(chart_type_to_ui_type("t"), "time_days")
 })


### PR DESCRIPTION
## Fase 2a af tidshåndtering på y-aksen

Infrastruktur-PR uden UI-ændring. Forbereder dropdown og migration i Fase 2b.

Spec: `docs/superpowers/specs/2026-04-17-time-yaxis-design.md`
Plan: `docs/superpowers/plans/2026-04-17-time-yaxis.md`

## Ændringer

- **`is_time_unit()`** helper der dækker legacy `"time"` + nye `time_minutes`/`time_hours`/`time_days`. `determine_internal_class()` dispatcher nu via helperen.
- **`default_time_unit_for_chart("t")`** returnerer `"time_days"` (bruges af UI ved korttype-skift).
- **`chart_type_to_ui_type("t")`** returnerer nu `"time_days"` (var `"time"`). Samme fix for `"pp"`/`"up"` der var broken på master (pre-existing 2 fails fikset som bonus).
- **`parse_time_to_minutes()`** i ny `R/utils_time_parsing.R`:
  - Numeric + `input_unit` (minutter/timer/dage)
  - `hms::hms` og `difftime` objekter
  - HH:MM og HH:MM:SS strenge (sekunder bevares som brøker)
  - NA og ugyldige værdier → NA med warning
- **`Y_AXIS_UI_TYPES_DA`** udvidet med tre tids-enheder: `Tid (minutter)`, `Tid (timer)`, `Tid (dage)`.
- Legacy `"time"` accepteres stadig runtime for bagudkompatibilitet (migration i Fase 2b).

## Bagudkompatibilitet

- Ingen UI-ændring synlig for brugere endnu (facade-integration + migration kommer i Fase 2b).
- Alle eksisterende `"time"`-kald virker stadig via `is_time_unit()`.
- `LOCAL_STORAGE_SCHEMA_VERSION` uændret.

## Test plan

- [x] Nye unit tests i `test-y-axis-model.R`, `test-time-parsing.R`
- [x] Opdaterede tests i `test-y-axis-mapping.R`
- [x] Fuld `devtools::test()` viser ingen regression
- [ ] Manuel verifikation udføres i Fase 2b-PR (når UI-flow er wired op)

## Rollback

Revert er uproblematisk — ingen schema-ændring, ingen migration, ingen UI-brud.