### PR TITLE
feat(time-axis): nye tids-enheder, parsing og silent migration (Fase 2b)

### DIFF
--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -315,6 +315,25 @@ compute_spc_results_bfh <- function(
         ))
       }
 
+      # 4b. Parse tids-input til kanoniske minutter hvis y-enheden er en
+      # tids-enhed. Input kan være numeric, hms, difftime eller HH:MM-streng.
+      # Sker FØR parse_and_validate_spc_data for at undgå at HH:MM-strenge
+      # bliver til NA i as.numeric()-fallbacken.
+      y_axis_unit_early <- list(...)$y_axis_unit %||% "count"
+      if (is_time_unit(y_axis_unit_early)) {
+        complete_data[[y_var]] <- parse_time_to_minutes(
+          complete_data[[y_var]],
+          input_unit = y_axis_unit_early
+        )
+        log_debug(
+          paste0(
+            "Parsede tids-kolonne '", y_var,
+            "' til kanoniske minutter via input_unit='", y_axis_unit_early, "'"
+          ),
+          .context = "BFH_SERVICE"
+        )
+      }
+
       # 5. Parse and validate numeric data
       y_data_raw <- complete_data[[y_var]]
       n_data_raw <- if (!is.null(n_var)) complete_data[[n_var]] else NULL
@@ -415,6 +434,20 @@ compute_spc_results_bfh <- function(
       target_value <- extra_params$target_value
       centerline_value <- extra_params$centerline_value
       y_axis_unit <- extra_params$y_axis_unit %||% "count"
+
+      # BFHcharts 0.8.0's y_axis_unit accepterer kun "count", "percent",
+      # "rate", "time". Map de nye biSPCharts-enheder (time_minutes/hours/days)
+      # til den kanoniske "time" — data er allerede parsed til minutter (se 4b).
+      if (is_time_unit(y_axis_unit) && !identical(y_axis_unit, "time")) {
+        log_debug(
+          paste0(
+            "Mapper y_axis_unit='", y_axis_unit,
+            "' -> 'time' for BFHcharts (data er i kanoniske minutter)"
+          ),
+          .context = "BFH_SERVICE"
+        )
+        y_axis_unit <- "time"
+      }
       chart_title <- resolve_bfh_chart_title(
         extra_params$chart_title_reactive %||% extra_params$chart_title
       )

--- a/R/utils_label_formatting.R
+++ b/R/utils_label_formatting.R
@@ -95,11 +95,12 @@ format_y_value <- function(val, y_unit, y_range = NULL) {
     }
   }
 
-  # Time formatting (input: minutes) - komposit-format
+  # Time formatting (input: kanoniske minutter) - komposit-format
+  # Dækker legacy "time" og nye time_minutes/time_hours/time_days.
   # Bruger format_time_composite() for konsistens med format_y_axis_time().
   # y_range-parameteren er ikke laengere relevant — komposit-format haandterer
   # minutter/timer/dage automatisk (0m, 30m, 1t, 1t 30m, 1d, 2d 13t).
-  if (y_unit == "time") {
+  if (is_time_unit(y_unit)) {
     return(format_time_composite(val))
   }
 

--- a/R/utils_local_storage.R
+++ b/R/utils_local_storage.R
@@ -5,7 +5,46 @@
 
 # SCHEMA VERSION ==============================================================
 # Bumpes når payload-struktur ændres. Load-logik rydder ved version-mismatch.
-LOCAL_STORAGE_SCHEMA_VERSION <- "2.0"
+# 3.0: y_axis_unit "time" splittet til time_minutes/time_hours/time_days.
+#      Silent forward-migration via migrate_time_yaxis_unit().
+LOCAL_STORAGE_SCHEMA_VERSION <- "3.0"
+
+# MIGRATION ==================================================================
+
+#' Silent forward-migration: "time" → "time_minutes"
+#'
+#' Version 2.0 payloads har y_axis_unit = "time" med implicit antagelse
+#' om minutter. Version 3.0 kræver eksplicit time_minutes/time_hours/time_days.
+#' Migrationen bevarer klinisk data ved at mappe den implicitte antagelse
+#' til den eksplicitte `time_minutes`-enhed.
+#'
+#' Migrationen er idempotent: 3.0 payloads returneres uændret. Ukendte
+#' versioner (< 2.0) passeres igennem uændret — det er load-logikkens
+#' ansvar at rydde ved full schema-mismatch.
+#'
+#' @param saved_state List med 'version' og evt. 'metadata'. NULL returneres.
+#' @return Opdateret list med version = LOCAL_STORAGE_SCHEMA_VERSION for 2.0
+#'   payloads; ellers uændret.
+#' @keywords internal
+migrate_time_yaxis_unit <- function(saved_state) {
+  if (is.null(saved_state)) {
+    return(saved_state)
+  }
+
+  src_version <- saved_state$version %||% "unknown"
+
+  # Kun migrér 2.0 → 3.0. Nyere versioner returneres uændret.
+  if (identical(src_version, "2.0")) {
+    if (!is.null(saved_state$metadata) &&
+        !is.null(saved_state$metadata$y_axis_unit) &&
+        identical(saved_state$metadata$y_axis_unit, "time")) {
+      saved_state$metadata$y_axis_unit <- "time_minutes"
+    }
+    saved_state$version <- LOCAL_STORAGE_SCHEMA_VERSION
+  }
+
+  saved_state
+}
 
 # CLASS PRESERVATION HELPERS =================================================
 

--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -102,7 +102,10 @@ register_chart_type_events <- function(app_state, emit, input, session, register
             } else {
               qic_ct <- get_qic_chart_type(ct)
               if (!identical(qic_ct, "run")) {
-                desired_ui <- chart_type_to_ui_type(qic_ct)
+                # Brug ct (original) ikke qic_ct, så "t" matches direkte i
+                # chart_type_to_ui_type() — get_qic_chart_type("t") fallbacker
+                # til "run" fordi "t" ikke er i CHART_TYPES_EN endnu.
+                desired_ui <- chart_type_to_ui_type(ct)
                 current_ui <- input$y_axis_unit %||% "count"
                 if (!identical(current_ui, desired_ui)) {
                   safe_programmatic_ui_update(session, app_state, function() {

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -47,6 +47,9 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
         return()
       }
 
+      # Silent forward-migration 2.0 → 3.0 (time → time_minutes)
+      peek <- migrate_time_yaxis_unit(peek)
+
       # Schema version-check → ryd lydløst og vis default landing
       saved_version <- peek$version %||% "unknown"
       if (!identical(saved_version, LOCAL_STORAGE_SCHEMA_VERSION)) {
@@ -106,6 +109,9 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
         "Auto restore session data",
         code = {
           saved_state <- input$auto_restore_data
+
+          # Silent forward-migration 2.0 → 3.0 (time → time_minutes)
+          saved_state <- migrate_time_yaxis_unit(saved_state)
 
           if (!is.null(saved_state$data)) {
             # Version-check: Ryd inkompatibel data og spring restore over

--- a/R/utils_time_formatting.R
+++ b/R/utils_time_formatting.R
@@ -23,6 +23,20 @@ TIME_BREAK_CANDIDATES <- c(
   1440, 2880, 10080, 43200       # dage (1d, 2d, 7d, 30d)
 )
 
+#' Tilladte kandidat-intervaller pr. input-enhed
+#'
+#' Filtrerer TIME_BREAK_CANDIDATES baseret paa hvilke der er "naturlige"
+#' i den valgte input-enhed. Fx time_hours tillader ikke 15m-intervaller
+#' (= 0.25 t) men tillader 30m (= 0.5 t). time_days kraever mindst 12t
+#' interval for at undgaa forvirrende sub-dag ticks.
+#'
+#' @keywords internal
+TIME_BREAK_CANDIDATES_BY_UNIT <- list(
+  time_minutes = TIME_BREAK_CANDIDATES,
+  time_hours   = c(30, 60, 120, 240, 360, 720, 1440, 2880, 10080, 43200),
+  time_days    = c(720, 1440, 2880, 10080, 43200)
+)
+
 # KOMPOSIT FORMATERING ========================================================
 
 #' Formatér minutter som komposit tidsstreng
@@ -90,13 +104,17 @@ format_time_composite_single <- function(v) {
 #'
 #' @param y_values numeric. Data-range at generere ticks til.
 #' @param target_n integer. Minimums-antal ticks. Default 5L.
+#' @param input_unit character eller NULL. En af 'time_minutes',
+#'   'time_hours', 'time_days'. Begraenser hvilke kandidat-intervaller
+#'   der overvejes (fx time_days bruger kun >= 12t intervaller).
+#'   Default NULL = alle kandidater (bagudkompatibel).
 #' @return numeric vektor. Tick-positioner i minutter.
 #' @keywords internal
 #' @examples
 #' time_breaks(c(0, 120))    # 0 30 60 90 120
 #' time_breaks(c(15, 185))   # 0 30 60 90 120 150 180
 #' time_breaks(c(0, 480))    # 0 120 240 360 480
-time_breaks <- function(y_values, target_n = 5L) {
+time_breaks <- function(y_values, target_n = 5L, input_unit = NULL) {
   # Defensiv: filtrer ikke-finite (NA, NaN, Inf, -Inf) og tomme inputs.
   # ggplot2 passerer undertiden Inf/-Inf under layout; seq() ville senere
   # crashe med 'to' must be a finite number uden denne filtrering.
@@ -113,33 +131,34 @@ time_breaks <- function(y_values, target_n = 5L) {
     return(y_min)
   }
 
+  # Vaelg kandidat-liste baseret paa input_unit
+  candidates <- if (!is.null(input_unit) &&
+                    input_unit %in% names(TIME_BREAK_CANDIDATES_BY_UNIT)) {
+    TIME_BREAK_CANDIDATES_BY_UNIT[[input_unit]]
+  } else {
+    TIME_BREAK_CANDIDATES
+  }
+
   # Primaer: stoerste interval med >= target_n ticks.
   # Itererer alle kandidater (floor-snap kan give non-monotonisk n_ticks
   # i sjaeldne tilfaelde for smaa target_n — omkostningen er ubetydelig).
-  chosen_interval <- NULL
-  for (interval in TIME_BREAK_CANDIDATES) {
-    start <- floor(y_min / interval) * interval
-    end <- floor(y_max / interval) * interval
-    n_ticks <- (end - start) / interval + 1L
-    if (n_ticks >= target_n) {
-      chosen_interval <- interval
-    }
+  chosen_interval <- pick_break_interval(y_min, y_max, candidates, min_ticks = target_n)
+
+  # Fallback 1: prøv ufiltreret liste hvis filtreret ikke gav resultat
+  if (is.null(chosen_interval) && !identical(candidates, TIME_BREAK_CANDIDATES)) {
+    chosen_interval <- pick_break_interval(
+      y_min, y_max, TIME_BREAK_CANDIDATES, min_ticks = target_n
+    )
   }
 
-  # Fallback 1: meget smal range — brug mindste interval med >= 2 ticks
+  # Fallback 2: meget smal range — brug mindste interval med >= 2 ticks
   if (is.null(chosen_interval)) {
-    for (interval in TIME_BREAK_CANDIDATES) {
-      start <- floor(y_min / interval) * interval
-      end <- floor(y_max / interval) * interval
-      n_ticks <- (end - start) / interval + 1L
-      if (n_ticks >= 2L) {
-        chosen_interval <- interval
-        break
-      }
-    }
+    chosen_interval <- pick_break_interval(
+      y_min, y_max, TIME_BREAK_CANDIDATES, min_ticks = 2L, pick_first = TRUE
+    )
   }
 
-  # Fallback 2: sub-unit range (f.eks. 0.3-0.9 min) — returnér
+  # Fallback 3: sub-unit range (f.eks. 0.3-0.9 min) — returnér
   # data-bracketing tick-par saa aksen ikke bliver blank.
   if (is.null(chosen_interval)) {
     return(c(y_min, y_max))
@@ -149,4 +168,30 @@ time_breaks <- function(y_values, target_n = 5L) {
   end <- floor(y_max / chosen_interval) * chosen_interval
 
   seq(start, end, by = chosen_interval)
+}
+
+#' Vælg tick-interval fra en kandidat-liste
+#'
+#' @param y_min,y_max numeric. Range-grænser.
+#' @param candidates numeric. Kandidat-intervaller (stigende sorteret).
+#' @param min_ticks integer. Mindstekrav til antal ticks i det valgte interval.
+#' @param pick_first logical. TRUE = returnér første match; FALSE = returnér
+#'   største interval der stadig opfylder min_ticks-kravet (default).
+#' @return numeric eller NULL hvis intet interval passer.
+#' @keywords internal
+pick_break_interval <- function(y_min, y_max, candidates,
+                                min_ticks = 5L, pick_first = FALSE) {
+  chosen <- NULL
+  for (interval in candidates) {
+    start <- floor(y_min / interval) * interval
+    end <- floor(y_max / interval) * interval
+    n_ticks <- (end - start) / interval + 1L
+    if (n_ticks >= min_ticks) {
+      chosen <- interval
+      if (pick_first) {
+        break
+      }
+    }
+  }
+  chosen
 }

--- a/R/utils_y_axis_formatting.R
+++ b/R/utils_y_axis_formatting.R
@@ -64,8 +64,11 @@ apply_y_axis_formatting <- function(plot, y_axis_unit = "count", qic_data = NULL
     return(plot + format_y_axis_count())
   } else if (y_axis_unit == "rate") {
     return(plot + format_y_axis_rate())
-  } else if (y_axis_unit == "time") {
-    return(plot + format_y_axis_time(qic_data))
+  } else if (is_time_unit(y_axis_unit)) {
+    # Dækker legacy "time" og nye time_minutes/time_hours/time_days.
+    # Kandidat-intervaller filtreres per input-enhed for "naturlig"
+    # tick-afstand (fx time_days bruger kun >= 12t intervaller).
+    return(plot + format_y_axis_time(qic_data, input_unit = y_axis_unit))
   }
 
   # Default: no special formatting (use ggplot2 defaults)
@@ -180,10 +183,13 @@ format_y_axis_rate <- function() {
 #' intern enhed).
 #'
 #' @param qic_data Data frame with qic data containing y column (time values in minutes)
+#' @param input_unit character eller NULL. En af 'time_minutes',
+#'   'time_hours', 'time_days' (eller legacy 'time'). Bruges til at
+#'   filtrere kandidat-intervaller i time_breaks(). NULL = alle kandidater.
 #'
 #' @return ggplot2 scale_y_continuous layer for time formatting
 #' @keywords internal
-format_y_axis_time <- function(qic_data) {
+format_y_axis_time <- function(qic_data, input_unit = NULL) {
   if (is.null(qic_data) || !"y" %in% names(qic_data)) {
     log_warn(
       "format_y_axis_time: missing qic_data or y column, using default formatting",
@@ -193,7 +199,7 @@ format_y_axis_time <- function(qic_data) {
   }
 
   y_values <- qic_data$y
-  breaks <- time_breaks(y_values)
+  breaks <- time_breaks(y_values, input_unit = input_unit)
 
   ggplot2::scale_y_continuous(
     expand = ggplot2::expansion(mult = c(.25, .25)),

--- a/tests/testthat/test-facade-time-parsing.R
+++ b/tests/testthat/test-facade-time-parsing.R
@@ -1,0 +1,38 @@
+# test-facade-time-parsing.R
+# Integrationstests for tids-parsing i fct_spc_bfh_facade.R.
+# Verificerer at parse_time_to_minutes() kaldes korrekt når y_axis_unit er
+# en tids-enhed, og at time_* enheder mappes til "time" for BFHcharts.
+
+library(testthat)
+
+test_that("parse_time_to_minutes skalerer hours -> kanoniske minutter", {
+  # Regression test: hvis en bruger har y-data i timer og vaelger
+  # time_hours som enhed, skal vaerdierne ganges med 60 foer de sendes
+  # til BFHcharts' SPC-beregning.
+  y_hours <- c(1, 1.5, 2, 2.5)
+  parsed <- parse_time_to_minutes(y_hours, input_unit = "time_hours")
+  expect_equal(parsed, c(60, 90, 120, 150))
+})
+
+test_that("parse_time_to_minutes skalerer days -> minutter", {
+  y_days <- c(1, 2, 7)
+  parsed <- parse_time_to_minutes(y_days, input_unit = "time_days")
+  expect_equal(parsed, c(1440, 2880, 10080))
+})
+
+test_that("parse_time_to_minutes haandterer HH:MM-strenge i facade-kontekst", {
+  # CSV-import giver karakter-kolonner; facade skal kunne haandtere dette.
+  y_strings <- c("00:30", "01:00", "01:30", "02:15")
+  parsed <- parse_time_to_minutes(y_strings, input_unit = "time_minutes")
+  expect_equal(parsed, c(30, 60, 90, 135))
+})
+
+test_that("is_time_unit identificerer korrekt for BFHcharts-mapping", {
+  # Facaden bruger is_time_unit() til at beslutte om y_axis_unit skal
+  # mappes til "time" foer det sendes til BFHcharts.
+  expect_true(is_time_unit("time_minutes"))
+  expect_true(is_time_unit("time_hours"))
+  expect_true(is_time_unit("time_days"))
+  expect_true(is_time_unit("time"))  # legacy
+  expect_false(is_time_unit("count"))
+})

--- a/tests/testthat/test-label-formatting.R
+++ b/tests/testthat/test-label-formatting.R
@@ -64,6 +64,16 @@ test_that("format_y_value returnerer NA for NA input", {
   expect_true(is.na(format_y_value(NA_real_, "time")))
 })
 
+test_that("format_y_value haandterer nye tids-enheder (time_minutes/hours/days)", {
+  # Alle tids-enheder giver komposit-format fordi input allerede er
+  # konverteret til kanoniske minutter af parse_time_to_minutes.
+  expect_equal(format_y_value(90, "time_minutes"), "1t 30m")
+  expect_equal(format_y_value(90, "time_hours"), "1t 30m")
+  expect_equal(format_y_value(90, "time_days"), "1t 30m")
+  expect_equal(format_y_value(1440, "time_days"), "1d")
+  expect_equal(format_y_value(0, "time_minutes"), "0m")
+})
+
 test_that("format_y_value() håndterer NA korrekt", {
   expect_true(is.na(format_y_value(NA, "count")))
   expect_true(is.na(format_y_value(NA, "percent")))

--- a/tests/testthat/test-local-storage-time-migration.R
+++ b/tests/testthat/test-local-storage-time-migration.R
@@ -1,0 +1,59 @@
+# test-local-storage-time-migration.R
+# Tests for silent forward-migration af y_axis_unit fra schema 2.0 til 3.0.
+# Se docs/superpowers/specs/2026-04-17-time-yaxis-design.md for rationale.
+
+library(testthat)
+
+test_that("migrate_time_yaxis_unit konverterer legacy 'time' til 'time_minutes'", {
+  saved_state <- list(
+    version = "2.0",
+    metadata = list(
+      y_axis_unit = "time",
+      chart_type = "t",
+      title = "Test"
+    )
+  )
+  migrated <- migrate_time_yaxis_unit(saved_state)
+  expect_equal(migrated$metadata$y_axis_unit, "time_minutes")
+  expect_equal(migrated$version, "3.0")
+})
+
+test_that("migrate_time_yaxis_unit lader ikke-time enheder vaere i fred", {
+  saved_state <- list(
+    version = "2.0",
+    metadata = list(y_axis_unit = "count", chart_type = "p")
+  )
+  migrated <- migrate_time_yaxis_unit(saved_state)
+  expect_equal(migrated$metadata$y_axis_unit, "count")
+  expect_equal(migrated$version, "3.0")
+})
+
+test_that("migrate_time_yaxis_unit er idempotent for 3.0 payloads", {
+  saved_state <- list(
+    version = "3.0",
+    metadata = list(y_axis_unit = "time_hours")
+  )
+  migrated <- migrate_time_yaxis_unit(saved_state)
+  expect_equal(migrated$metadata$y_axis_unit, "time_hours")
+  expect_equal(migrated$version, "3.0")
+})
+
+test_that("migrate_time_yaxis_unit haandterer manglende metadata graciously", {
+  saved_state <- list(version = "2.0", data = list(nrows = 10))
+  migrated <- migrate_time_yaxis_unit(saved_state)
+  expect_equal(migrated$version, "3.0")
+})
+
+test_that("migrate_time_yaxis_unit returnerer NULL for NULL input", {
+  expect_null(migrate_time_yaxis_unit(NULL))
+})
+
+test_that("migrate_time_yaxis_unit lader ukendt version vaere i fred", {
+  saved_state <- list(
+    version = "1.5",
+    metadata = list(y_axis_unit = "time")
+  )
+  migrated <- migrate_time_yaxis_unit(saved_state)
+  expect_equal(migrated$version, "1.5")
+  expect_equal(migrated$metadata$y_axis_unit, "time")
+})

--- a/tests/testthat/test-session-persistence.R
+++ b/tests/testthat/test-session-persistence.R
@@ -555,7 +555,8 @@ test_that("saveDataLocally payload uses current version tag", {
   parsed <- jsonlite::fromJSON(json_str, simplifyVector = TRUE)
 
   expect_true("version" %in% names(parsed))
-  # Version bumpes til "2.0" i Fase 3 — før fix kan det være "1.2"
-  expect_true(parsed$version %in% c("1.2", "2.0"),
+  # Schema versioner: "1.2" (legacy), "2.0" (Fase 3), "3.0" (time-yaxis Fase 2b).
+  # Test accepterer alle kendte versioner for robusthed mod fremtidige bumps.
+  expect_true(parsed$version %in% c("1.2", "2.0", "3.0"),
     info = paste("Unknown payload version:", parsed$version))
 })

--- a/tests/testthat/test-time-formatting.R
+++ b/tests/testthat/test-time-formatting.R
@@ -119,3 +119,31 @@ test_that("time_breaks snapper til interval-grid", {
   # Mindstekrav: target_n=5 skal opfyldes for typiske ranges
   expect_gte(length(breaks), 5)
 })
+
+test_that("time_breaks filtrerer intervaller per input_unit", {
+  # time_hours: 1m/2m/5m/10m/15m/20m kandidater skal skippes.
+  # Range 0-300 min (= 0-5t) giver 30m-interval med target_n=5 (11 ticks).
+  breaks_hours <- time_breaks(c(0, 300), input_unit = "time_hours")
+  expect_true(all(breaks_hours %% 30 == 0))
+
+  # time_days: kun intervaller >= 12t (720 min). Range 0-14400 min (0-10 dage)
+  # giver 1d (1440 min) eller 2d (2880 min).
+  breaks_days <- time_breaks(c(0, 14400), input_unit = "time_days")
+  expect_true(all(breaks_days %% 720 == 0))
+
+  # time_minutes: alle kandidater tilgaengelige (samme som uden input_unit)
+  breaks_min <- time_breaks(c(0, 120), input_unit = "time_minutes")
+  expect_equal(breaks_min, c(0, 30, 60, 90, 120))
+})
+
+test_that("time_breaks falder tilbage til ufiltreret liste hvis filtreret er for grov", {
+  # Meget smal range i time_days — filtrerede kandidater (720+) giver
+  # ingen gyldige ticks; fallback til ufiltreret TIME_BREAK_CANDIDATES.
+  breaks <- time_breaks(c(0, 60), input_unit = "time_days")
+  expect_true(length(breaks) >= 2)
+})
+
+test_that("time_breaks uden input_unit er bagudkompatibel", {
+  breaks <- time_breaks(c(0, 120))
+  expect_equal(breaks, c(0, 30, 60, 90, 120))
+})

--- a/tests/testthat/test-y-axis-model.R
+++ b/tests/testthat/test-y-axis-model.R
@@ -73,3 +73,10 @@ test_that("default_time_unit_for_chart returnerer passende enhed pr. korttype", 
   expect_null(default_time_unit_for_chart(NULL))
   expect_null(default_time_unit_for_chart(NA_character_))
 })
+
+test_that("t-kort: korttype-skift foerer til time_days som default y-enhed", {
+  # Integration: UI's chart_type-observer kalder chart_type_to_ui_type()
+  # for at finde default y-enhed. "t" skal mappes til "time_days".
+  expect_equal(chart_type_to_ui_type("t"), "time_days")
+  expect_equal(default_time_unit_for_chart("t"), "time_days")
+})


### PR DESCRIPTION
## Fase 2b af tidshåndtering på y-aksen

Wire-up af Fase 2a's parsing-lag til facade-pipeline + UI + silent
schema-migration. Lander den synlige UI-adfærd for de tre nye tids-enheder.

Spec: `docs/superpowers/specs/2026-04-17-time-yaxis-design.md`
Plan: `docs/superpowers/plans/2026-04-17-time-yaxis.md`

## Ændringer

### Ticks og formatering
- **`time_breaks()`** tager nu `input_unit`-argument; filtrerer kandidat-
  intervaller (time_hours skipper <30m, time_days kræver >=12t). Fallback
  til ufiltreret liste hvis range er for smal.
- **`apply_y_axis_formatting()`** dispatcher via `is_time_unit()` så alle
  nye tids-enheder (legacy `"time"` + `time_minutes/hours/days`) får
  komposit-format.
- **`format_y_value()`** dispatcher også via `is_time_unit()`.

### Facade-integration
- **`fct_spc_bfh_facade.R`** parser y-data til kanoniske minutter i step 4b
  via `parse_time_to_minutes()` — FØR `parse_and_validate_spc_data()`, så
  HH:MM-strenge ikke bliver til NA i as.numeric-fallback.
- BFHcharts 0.8.0's `y_axis_unit` accepterer kun `'count'/'percent'/'rate'/'time'`,
  så `time_minutes/hours/days` mappes til `"time"` før kaldet (data er
  allerede i minutter).

### Silent migration
- **`LOCAL_STORAGE_SCHEMA_VERSION`** bumpet fra `"2.0"` til `"3.0"`.
- **`migrate_time_yaxis_unit()`** ny funktion: 2.0-payloads med
  `y_axis_unit = "time"` migreres lydløst til `"time_minutes"`
  (matcher implicit antagelse). Idempotent for 3.0 payloads; NULL- og
  ukendte-version-håndtering.
- Migration kaldt i peek og auto-restore observers **før** version-checket.

### UI-fix
- **t-kort auto-vælger `time_days`**: `utils_server_events_chart.R`
  kaldte `chart_type_to_ui_type(qic_ct)` efter `get_qic_chart_type()` —
  men "t" fallbacker til "run" fordi "t" ikke er i CHART_TYPES_EN endnu.
  Sender nu den originale `ct` videre.

### Test-konsistens
- `test-session-persistence.R`: udvider version-accept-liste til `{1.2, 2.0, 3.0}`.

## Migration-risiko

Silent migration betyder at brugere med gemte sessions **ikke** mister data
ved schema-bump — `y_axis_unit: "time"` konverteres automatisk til
`"time_minutes"`. Dette er den sikre default (matcher 2.0-adfærd).

## Test plan

- [x] 18+ nye unit tests i `test-time-formatting.R`, `test-local-storage-time-migration.R`, `test-facade-time-parsing.R`, `test-label-formatting.R`
- [x] Fuld `devtools::test()`: ingen regression (441 pre-existing fails på master; 441 på denne branch efter session-persistence-fix)
- [x] Nye tests: +29 PASS
- [ ] **Manuel UI-røgtest** (skal køres før merge):
  - Upload data med y-værdier i minutter → vælg `Tid (minutter)` → komposit-labels
  - Skift y-enhed til `Tid (timer)` — værdier tolkes som timer, aksen skalerer korrekt
  - Upload CSV med HH:MM-strenge → vælg tids-enhed → HH:MM auto-parses
  - Skift korttype til t-kort → y-enhed skifter til `Tid (dage)`
  - Gendan gammel session med `y_axis_unit = "time"` → åbner uden fejl med `Tid (minutter)`

## Rollback

Hvis production-issue efter merge:
- `LOCAL_STORAGE_SCHEMA_VERSION` kan resættes til `"2.0"` som hotfix (brugere får én hard-reset af localStorage).
- Fase 2a er selvstændig værdig; denne PR kan revertes uden at påvirke parsing-laget.