### PR TITLE
fix(time-axis): skalér target og centerline til kanoniske minutter

### DIFF
--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -435,6 +435,36 @@ compute_spc_results_bfh <- function(
       centerline_value <- extra_params$centerline_value
       y_axis_unit <- extra_params$y_axis_unit %||% "count"
 
+      # Skalér target/centerline til kanoniske minutter hvis y-enheden er
+      # en tids-enhed. Brugeren indtaster target i den valgte enhed (fx 90
+      # med time_days = 90 dage), men y-data er allerede i minutter efter
+      # step 4b. Uden denne skalering ville target = 90 blive plottet som
+      # 90 minutter i stedet for 90 dage (= 129600 min).
+      if (is_time_unit(y_axis_unit)) {
+        if (!is.null(target_value) && length(target_value) > 0) {
+          scaled_target <- parse_time_to_minutes(target_value, input_unit = y_axis_unit)
+          log_debug(
+            paste0(
+              "Skalerer target_value ", target_value, " (", y_axis_unit,
+              ") -> ", scaled_target, " min"
+            ),
+            .context = "BFH_SERVICE"
+          )
+          target_value <- scaled_target
+        }
+        if (!is.null(centerline_value) && length(centerline_value) > 0) {
+          scaled_cl <- parse_time_to_minutes(centerline_value, input_unit = y_axis_unit)
+          log_debug(
+            paste0(
+              "Skalerer centerline_value ", centerline_value, " (", y_axis_unit,
+              ") -> ", scaled_cl, " min"
+            ),
+            .context = "BFH_SERVICE"
+          )
+          centerline_value <- scaled_cl
+        }
+      }
+
       # BFHcharts 0.8.0's y_axis_unit accepterer kun "count", "percent",
       # "rate", "time". Map de nye biSPCharts-enheder (time_minutes/hours/days)
       # til den kanoniske "time" — data er allerede parsed til minutter (se 4b).

--- a/tests/testthat/test-facade-time-parsing.R
+++ b/tests/testthat/test-facade-time-parsing.R
@@ -36,3 +36,18 @@ test_that("is_time_unit identificerer korrekt for BFHcharts-mapping", {
   expect_true(is_time_unit("time"))  # legacy
   expect_false(is_time_unit("count"))
 })
+
+test_that("parse_time_to_minutes skalerer target og centerline-vaerdier", {
+  # Bruger saetter target = 90 med y-enhed "time_days": target skal tolkes
+  # som 90 dage (= 129600 min), ikke 90 minutter.
+  expect_equal(parse_time_to_minutes(90, input_unit = "time_days"), 129600)
+
+  # Target = 5 timer skal tolkes som 300 min
+  expect_equal(parse_time_to_minutes(5, input_unit = "time_hours"), 300)
+
+  # Target = 60 minutter er 60 min
+  expect_equal(parse_time_to_minutes(60, input_unit = "time_minutes"), 60)
+
+  # NULL target returnerer numeric(0) — caller skal haandtere
+  expect_equal(parse_time_to_minutes(numeric(0), "time_days"), numeric(0))
+})


### PR DESCRIPTION
## Bug

Når brugeren vælger fx `Tid (dage)` som y-enhed og sætter target = 90, bliver
target plottet ved 90 **minutter** i stedet for 90 **dage** (= 129600 min).

Samme problem for centerline. Årsag: Fase 2b parsede kun y-data til kanoniske
minutter — target/centerline blev sendt uskaleret til BFHcharts.

## Fix

I `fct_spc_bfh_facade.R` step 7a: kald `parse_time_to_minutes()` på
`target_value` og `centerline_value` **før** `y_axis_unit` mappes til
`"time"`. Data og target er nu konsistent i kanoniske minutter.

## Test

- Nye unit tests i `test-facade-time-parsing.R` verificerer skaleringen:
  - `target=90` med `time_days` → 129600 min
  - `target=5` med `time_hours` → 300 min
- Fuld suite: 441 pre-existing fails (uændret), +2 nye PASS

## Manual verifikation

Upload `tests/manual-test-data/time_days.csv`, vælg `Tid (dage)`,
sæt target = 90. Target-linjen skal nu vises ved 90d-tick, ikke ved 1t 30m.