### PR TITLE
fix(time-axis): target_text vises som komposit-tid ved tids-enheder

### DIFF
--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -483,6 +483,34 @@ compute_spc_results_bfh <- function(
       )
       target_text <- extra_params$target_text
 
+      # Formatér target_text som komposit-tid hvis y-enheden er en tids-enhed.
+      # target_text er brugerens rå input (fx "90" eller "<90"). Vi bevarer
+      # evt. operator-prefix og erstatter den numeriske del med komposit-format
+      # baseret på target_value (skaleret til minutter ovenfor).
+      # Eksempel: bruger skriver target=90 med "Tid (dage)" → label viser "90d";
+      # 90 timer → label viser "3d 18t".
+      original_y_unit <- extra_params$y_axis_unit %||% "count"
+      if (is_time_unit(original_y_unit) &&
+          !is.null(target_text) &&
+          !is.null(target_value) &&
+          length(target_value) > 0) {
+        operator_match <- regmatches(
+          target_text,
+          regexpr("^[<>=]+", target_text)
+        )
+        operator_prefix <- if (length(operator_match) > 0) operator_match else ""
+        formatted_value <- format_time_composite(target_value)
+        new_target_text <- paste0(operator_prefix, formatted_value)
+        log_debug(
+          paste0(
+            "Formaterer target_text '", target_text, "' -> '",
+            new_target_text, "' (y_axis_unit=", original_y_unit, ")"
+          ),
+          .context = "BFH_SERVICE"
+        )
+        target_text <- new_target_text
+      }
+
       # Guard: Fjern nævner for chart types der ikke bruger den.
       # Forhindrer at BFHcharts dividerer y med n (giver alle værdier = 1).
       if (!is.null(n_var) && !chart_type_requires_denominator(validated_chart_type)) {

--- a/tests/testthat/test-facade-time-parsing.R
+++ b/tests/testthat/test-facade-time-parsing.R
@@ -51,3 +51,29 @@ test_that("parse_time_to_minutes skalerer target og centerline-vaerdier", {
   # NULL target returnerer numeric(0) — caller skal haandtere
   expect_equal(parse_time_to_minutes(numeric(0), "time_days"), numeric(0))
 })
+
+test_that("format_time_composite formaterer target-labels korrekt", {
+  # Direkte tests af labelformat som target_text-skaleringen producerer.
+  # target=90 (days) = 129600 min -> "90d"
+  expect_equal(format_time_composite(129600), "90d")
+  # target=90 (hours) = 5400 min -> "3d 18t"
+  expect_equal(format_time_composite(5400), "3d 18t")
+  # target=30 (minutes) = 30 min -> "30m"
+  expect_equal(format_time_composite(30), "30m")
+  # target=1.5 (hours) = 90 min -> "1t 30m"
+  expect_equal(format_time_composite(90), "1t 30m")
+})
+
+test_that("target_text formatering bevarer operator-prefix", {
+  # Uddrag af operator-logikken fra facade. Verificerer at regex matcher
+  # korrekt paa fx "<90", ">=30", "=60".
+  extract_op <- function(x) {
+    m <- regmatches(x, regexpr("^[<>=]+", x))
+    if (length(m) > 0) m else ""
+  }
+  expect_equal(extract_op("<90"), "<")
+  expect_equal(extract_op(">=30"), ">=")
+  expect_equal(extract_op("=60"), "=")
+  expect_equal(extract_op("90"), "")
+  expect_equal(paste0(extract_op("<90"), format_time_composite(129600)), "<90d")
+})


### PR DESCRIPTION
## Bug

Når brugeren indtaster target = 90 med y-enhed 'Tid (dage)', viser
target-linjens **label** tallet '90' (brugerens rå input), mens
centerline og akse-ticks korrekt viser '90d' (komposit-format).

Samme problem for andre tids-enheder: target = 90 med 'Tid (timer)'
→ label viser '90' i stedet for '3d 18t'.

## Fix

Facaden formaterer nu target_text via format_time_composite() baseret
på den kanoniske target_value (i minutter efter PR #208). Operator-
prefix bevares intakt.

| Bruger indtaster | Enhed | Target-label før | Target-label efter |
|---|---|---|---|
| 90 | dage | 90 | 90d |
| <90 | timer | <90 | <3d 18t |
| =30 | minutter | =30 | =30m |

## Test

- 8 nye unit tests i test-facade-time-parsing.R
- Alle existing tests passerer uden regression

## Afhænger af

**PR #208** (target/centerline-skalering). Denne PR er baseret på #208's
branch — skal merges efter #208.