### PR TITLE
test(issue-203): fix testthat 3.x info-arg breaking change (kategori C)

### DIFF
--- a/tests/testthat/test-cache-data-signature-bugs.R
+++ b/tests/testthat/test-cache-data-signature-bugs.R
@@ -259,11 +259,11 @@ test_that("create_full_data_signature performs reasonably on large data", {
     sig <- create_data_signature(large_data)
   })
 
-  expect_lt(timing["elapsed"], 0.1,
-            info = "Signature generation should be fast even for large data")
+  expect_true(timing["elapsed"] < 0.1,
+              info = "Signature generation should be fast even for large data")
 
   expect_type(sig, "character")
-  expect_gt(nchar(sig), 10, info = "Signature should be non-trivial hash")
+  expect_true(nchar(sig) > 10, info = "Signature should be non-trivial hash")
 })
 
 # Integration test with actual cache collision scenario ----

--- a/tests/testthat/test-critical-fixes-integration.R
+++ b/tests/testthat/test-critical-fixes-integration.R
@@ -75,14 +75,14 @@ test_that("Event system priorities fungerer i integration", {
 
     # Verify STATE_MANAGEMENT executes before AUTO_DETECT
     if (!is.na(state_pos) && !is.na(autodetect_pos)) {
-      expect_lt(state_pos, autodetect_pos,
-                info = "STATE_MANAGEMENT should execute before AUTO_DETECT")
+      expect_true(state_pos < autodetect_pos,
+                  info = "STATE_MANAGEMENT should execute before AUTO_DETECT")
     }
 
     # Verify AUTO_DETECT executes before UI_SYNC
     if (!is.na(autodetect_pos) && !is.na(ui_pos)) {
-      expect_lt(autodetect_pos, ui_pos,
-                info = "AUTO_DETECT should execute before UI_SYNC")
+      expect_true(autodetect_pos < ui_pos,
+                  info = "AUTO_DETECT should execute before UI_SYNC")
     }
   })
 })
@@ -304,6 +304,7 @@ test_that("OBSERVER_PRIORITIES helper functions integration", {
   if (exists("reactiveVal")) {
     test_val <- reactiveVal(0)
 
+    # expect_no_error accepterer ikke info= i testthat 3.x
     expect_no_error({
       observeEvent(test_val(), priority = priority_high(), {
         # High priority handler
@@ -316,7 +317,7 @@ test_that("OBSERVER_PRIORITIES helper functions integration", {
       observeEvent(test_val(), priority = priority_cleanup(), {
         # Cleanup handler
       })
-    }, info = "Helper functions should work in observer registration")
+    })
   }
 })
 
@@ -364,10 +365,10 @@ test_that("Memory management under sustained load", {
   memory_growth <- final_memory - initial_memory
 
   # Memory growth should be reasonable (< 20MB for 50 cycles)
-  expect_lt(memory_growth, 20,
-            info = paste("Memory growth should be bounded. Growth:", memory_growth, "MB"))
+  expect_true(memory_growth < 20,
+              info = paste("Memory growth should be bounded. Growth:", memory_growth, "MB"))
 
   # No major memory leaks should be detected
-  expect_lt(memory_growth / 50, 0.5,
-            info = "Per-cycle memory growth should be minimal (< 0.5MB/cycle)")
+  expect_true(memory_growth / 50 < 0.5,
+              info = "Per-cycle memory growth should be minimal (< 0.5MB/cycle)")
 })

--- a/tests/testthat/test-input-debouncing-comprehensive.R
+++ b/tests/testthat/test-input-debouncing-comprehensive.R
@@ -38,7 +38,7 @@ test_that("Debouncing reducerer redundante chart renders ved hurtige input ændr
 
   # Verificer timing
   time_window <- max(input_times) - min(input_times)
-  expect_lt(time_window, 0.6,
+  expect_true(time_window < 0.6,
     info = "Input ændringer skal være inden for 500ms vindue")
 
   # I production med debouncing skulle kun sidste værdi renderes
@@ -64,9 +64,9 @@ test_that("Debounce delays er korrekt konfigureret i DEBOUNCE_DELAYS", {
   if (exists("DEBOUNCE_DELAYS")) {
     for (delay_name in names(DEBOUNCE_DELAYS)) {
       delay_value <- DEBOUNCE_DELAYS[[delay_name]]
-      expect_gte(delay_value, 100,
+      expect_true(delay_value >= 100,
         info = paste(delay_name, "skal være mindst 100ms"))
-      expect_lte(delay_value, 3000,
+      expect_true(delay_value <= 3000,
         info = paste(delay_name, "skal være max 3000ms"))
     }
   }
@@ -102,7 +102,7 @@ test_that("Chart update debouncing forhindrer excessive plot regeneration", {
   elapsed_time <- as.numeric(Sys.time() - start_time, units = "secs")
 
   # Verificer at ændringer sker hurtigt nok til at debouncing er relevant
-  expect_lt(elapsed_time, 1.0,
+  expect_true(elapsed_time < 1.0,
     info = "Parameter changes skal ske hurtigt nok til debouncing benefit")
 
   # Med debouncing skulle kun 1 plot generation ske efter delay
@@ -167,7 +167,7 @@ test_that("File selection debouncing håndterer Windows file dialogs", {
   total_time <- max(selection_times) - min(selection_times)
 
   # Verificer at selections sker hurtigt nok til debouncing benefit
-  expect_lt(total_time, 0.5,
+  expect_true(total_time < 0.5,
     info = "File selections inden for debounce window")
 
   # Med 500ms debounce skulle kun sidste fil processeres
@@ -228,7 +228,7 @@ test_that("Debouncing performance målinger viser 60-80% improvement", {
 
     # FORVENTET: 60-80% improvement
     # Dette er en simplified test - actual improvement afhænger af render complexity
-    expect_gt(improvement_pct, 0,
+    expect_true(improvement_pct > 0,
       info = "Debouncing skal give performance improvement")
   }
 })
@@ -278,14 +278,14 @@ test_that("Debouncing dokumentation er tilstede i konfiguration", {
     # Tjek for dokumentation af debounce delays
     debounce_section <- grep("DEBOUNCE_DELAYS", config_content, value = TRUE)
 
-    expect_gt(length(debounce_section), 0,
+    expect_true(length(debounce_section) > 0,
       info = "DEBOUNCE_DELAYS skal være defineret i config")
 
     # Tjek for kommentarer der forklarer delays
     comment_lines <- grep("#.*debounce|#.*delay", config_content,
                          ignore.case = TRUE, value = TRUE)
 
-    expect_gt(length(comment_lines), 0,
+    expect_true(length(comment_lines) > 0,
       info = "Debounce delays skal være dokumenteret med kommentarer")
   }
 })

--- a/tests/testthat/test-package-namespace-validation.R
+++ b/tests/testthat/test-package-namespace-validation.R
@@ -50,7 +50,7 @@ test_that("Package DESCRIPTION and NAMESPACE are consistent", {
 
   # TEST: NAMESPACE indeholder export statements
   exports <- grep("^export\\(", namespace_lines, value = TRUE)
-  expect_gt(length(exports), 0, info = "NAMESPACE should contain export statements")
+  expect_true(length(exports) > 0, info = "NAMESPACE should contain export statements")
 
   # TEST: Key exports er til stede
   key_exports <- c("run_app", "initialize_app")


### PR DESCRIPTION
## Del 1 af #203 — kategori C

testthat 3.x fjernede \`info\`-parameteren fra \`expect_gt/gte/lt/lte/no_error\`.
Tests fejlede med \`unused argument (info = ...)\`.

Se [docs/test-suite-inventory-203.md](docs/test-suite-inventory-203.md) for komplet
kategorisering.

## Fix-strategi

| Før | Efter |
|---|---|
| \`expect_lt(x, y, info = \"msg\")\` | \`expect_true(x < y, info = \"msg\")\` |
| \`expect_gt(x, y, info = \"msg\")\` | \`expect_true(x > y, info = \"msg\")\` |
| \`expect_gte(x, y, info = \"msg\")\` | \`expect_true(x >= y, info = \"msg\")\` |
| \`expect_no_error(expr, info = \"msg\")\` | Info-arg droppet (kommentar bevaret) |

## Effekt

Filtered test-run af berørte filer:
- Master: 13 FAIL, 74 PASS
- Denne branch: 9 FAIL, 90 PASS
- **+4 fixet fejl, +16 nye PASS**

## Ændrede filer

- \`test-cache-data-signature-bugs.R\` (2 assertions)
- \`test-critical-fixes-integration.R\` (4 assertions)
- \`test-input-debouncing-comprehensive.R\` (8 assertions)
- \`test-package-namespace-validation.R\` (1 assertion)

Resterende 9 fejl i disse filer hører til andre kategorier (missing
functions, reactive context) og fixes i separate PR'er.