### PR TITLE
test(issue-203): claudespc -> biSPCharts rename (kategori F)

### DIFF
--- a/tests/testthat/test-branding-globals.R
+++ b/tests/testthat/test-branding-globals.R
@@ -8,7 +8,7 @@ if (dir.exists(local_lib)) {
   .libPaths(c(local_lib, .libPaths()))
 }
 
-# NOTE: Cannot load claudespc package in its own tests due to circular dependency
+# NOTE: Cannot load biSPCharts package in its own tests due to circular dependency
 # Load components directly from source instead
 if (file.exists(file.path(project_root, "R/branding_globals.R"))) {
   source(file.path(project_root, "R/branding_globals.R"), local = FALSE)

--- a/tests/testthat/test-input-sanitization.R
+++ b/tests/testthat/test-input-sanitization.R
@@ -3,42 +3,42 @@
 
 test_that("sanitize_selection handles edge case inputs correctly", {
   skip_if(
-    !exists("sanitize_selection", where = asNamespace("claudespc"), mode = "function"),
+    !exists("sanitize_selection", where = asNamespace("biSPCharts"), mode = "function"),
     "sanitize_selection function not available in package namespace"
   )
 
   # Test character(0)
-  expect_null(claudespc:::sanitize_selection(character(0)))
+  expect_null(biSPCharts:::sanitize_selection(character(0)))
 
   # Test NULL
-  expect_null(claudespc:::sanitize_selection(NULL))
+  expect_null(biSPCharts:::sanitize_selection(NULL))
 
   # Test empty string
-  expect_null(claudespc:::sanitize_selection(""))
+  expect_null(biSPCharts:::sanitize_selection(""))
 
   # Test whitespace only
-  expect_null(claudespc:::sanitize_selection("   "))
+  expect_null(biSPCharts:::sanitize_selection("   "))
 
   # Test NA variants
-  expect_null(claudespc:::sanitize_selection(NA_character_))
-  expect_null(claudespc:::sanitize_selection(NA))
+  expect_null(biSPCharts:::sanitize_selection(NA_character_))
+  expect_null(biSPCharts:::sanitize_selection(NA))
 
   # Test vector with all NAs
-  expect_null(claudespc:::sanitize_selection(c(NA_character_, NA_character_)))
+  expect_null(biSPCharts:::sanitize_selection(c(NA_character_, NA_character_)))
 
   # Test valid inputs
-  expect_equal(claudespc:::sanitize_selection("valid"), "valid")
-  expect_equal(claudespc:::sanitize_selection(c("valid", "second")), "valid")
+  expect_equal(biSPCharts:::sanitize_selection("valid"), "valid")
+  expect_equal(biSPCharts:::sanitize_selection(c("valid", "second")), "valid")
 
   # Test mixed vectors
-  expect_null(claudespc:::sanitize_selection(c(NA_character_, "valid")))
-  expect_equal(claudespc:::sanitize_selection(c("valid", NA_character_)), "valid")
+  expect_null(biSPCharts:::sanitize_selection(c(NA_character_, "valid")))
+  expect_equal(biSPCharts:::sanitize_selection(c("valid", NA_character_)), "valid")
 })
 
 test_that("Reactive expressions handle character(0) inputs without crashing", {
   skip_if_not_installed("shiny")
   skip_if(
-    !exists("sanitize_selection", where = asNamespace("claudespc"), mode = "function"),
+    !exists("sanitize_selection", where = asNamespace("biSPCharts"), mode = "function"),
     "sanitize_selection function not available"
   )
 
@@ -61,7 +61,7 @@ test_that("Reactive expressions handle character(0) inputs without crashing", {
 
       # Reactive that should handle edge cases safely
       safe_x_column <- shiny::reactive({
-        claudespc:::sanitize_selection(values$x_column)
+        biSPCharts:::sanitize_selection(values$x_column)
       })
 
       output$test_result <- shiny::renderText({
@@ -107,10 +107,10 @@ test_that("Performance ikke påvirkes af character(0) handling", {
 
   # Benchmark character(0) handling
   benchmark_result <- microbenchmark::microbenchmark(
-    char_zero = claudespc:::sanitize_selection(character(0)),
-    null_input = claudespc:::sanitize_selection(NULL),
-    empty_string = claudespc:::sanitize_selection(""),
-    valid_input = claudespc:::sanitize_selection("valid"),
+    char_zero = biSPCharts:::sanitize_selection(character(0)),
+    null_input = biSPCharts:::sanitize_selection(NULL),
+    empty_string = biSPCharts:::sanitize_selection(""),
+    valid_input = biSPCharts:::sanitize_selection("valid"),
     times = 100
   )
 

--- a/tests/testthat/test-no-file-dependencies.R
+++ b/tests/testthat/test-no-file-dependencies.R
@@ -46,5 +46,5 @@ test_that("no system.file() calls in app_server", {
 
 test_that("main_app_server is properly exported", {
   # Verify main_app_server is in package namespace
-  expect_true("main_app_server" %in% getNamespaceExports("claudespc"))
+  expect_true("main_app_server" %in% getNamespaceExports("biSPCharts"))
 })

--- a/tests/testthat/test-package-namespace-validation.R
+++ b/tests/testthat/test-package-namespace-validation.R
@@ -10,7 +10,7 @@ test_that("Core functions can be loaded via pkgload", {
   # Pakken er allerede loaded via helper.R — verificer blot at namespace er aktiv.
   # VIGTIGT: Kald ALDRIG load_all() uden helpers=FALSE i testfiler,
   # da det trigger helper.R rekursivt og kan hænge.
-  expect_true("biSPCharts" %in% loadedNamespaces() || "claudespc" %in% loadedNamespaces())
+  expect_true("biSPCharts" %in% loadedNamespaces())
 
   # TEST: Kritiske funktioner er tilgængelige via namespace
   core_functions <- c(
@@ -36,7 +36,7 @@ test_that("Package DESCRIPTION and NAMESPACE are consistent", {
   desc <- read.dcf(desc_path)
 
   # TEST: Package name er korrekt
-  expect_equal(desc[1, "Package"], "claudespc")
+  expect_equal(desc[1, "Package"], "biSPCharts")
 
   # TEST: Version følger semantic versioning
   version <- desc[1, "Version"]


### PR DESCRIPTION
## Del 2 af #203 — kategori F

Pakken blev omdøbt fra `claudespc` til `biSPCharts` for noget tid siden,
men enkelte tests refererede stadig til det gamle navn. Fejlede med:
`there is no package called 'claudespc'`.

Se [docs/test-suite-inventory-203.md](docs/test-suite-inventory-203.md).

## Ændringer

| Fil | Forekomster | Type |
|---|---|---|
| `test-input-sanitization.R` | 18 | Namespace refs (`claudespc:::sanitize_selection`) |
| `test-no-file-dependencies.R` | 1 | `getNamespaceExports` |
| `test-package-namespace-validation.R` | 2 | loadedNamespaces + DESCRIPTION-check |
| `test-branding-globals.R` | 1 | Kommentar |

## Effekt

Filtered test-run af berørte filer:
- Master: 8 FAIL, 22 PASS
- Denne branch: 4 FAIL, 36 PASS
- **+4 fixet fejl, +14 nye PASS**

Resterende 4 fails i disse filer hører til andre kategorier
(missing initialize_app, AppDriver/Chrome).