### PR TITLE
test(issue-203): fjernede logging+cache-helpers (kategori A batch 1)

### DIFF
--- a/tests/testthat/test-bfh-error-handling.R
+++ b/tests/testthat/test-bfh-error-handling.R
@@ -63,6 +63,7 @@ test_that("classify_error_source handles unknown errors gracefully", {
 
 # Test: Structured logging utilities
 test_that("sanitize_log_details removes sensitive data", {
+  skip("sanitize_log_details blev fjernet i logging-refactor. Ansvaret er flyttet til log_info/log_warn/log_error som strukturerer details internt.")
   details <- list(
     data = data.frame(x = 1:100, y = rnorm(100)),
     session_token = "abc123def456ghi789",
@@ -99,6 +100,7 @@ test_that("sanitize_log_details removes sensitive data", {
 })
 
 test_that("sanitize_log_details handles edge cases", {
+  skip("sanitize_log_details blev fjernet i logging-refactor.")
   # NULL details
   expect_equal(length(sanitize_log_details(NULL)), 0)
 
@@ -110,6 +112,7 @@ test_that("sanitize_log_details handles edge cases", {
 })
 
 test_that("log_with_throttle prevents log spam", {
+  skip("log_with_throttle blev fjernet. Throttling håndteres nu af logger-backend via options(spc.log.level) og .context-filtrering.")
   # Track calls to log function
   log_calls <- 0
   mock_log_fn <- function(...) {
@@ -136,6 +139,7 @@ test_that("log_with_throttle prevents log spam", {
 })
 
 test_that("log_with_throttle validates parameters", {
+  skip("log_with_throttle blev fjernet i logging-refactor.")
   # Invalid log_fn
   expect_error(
     log_with_throttle("key", 60, "not a function", "message"),
@@ -249,6 +253,7 @@ test_that("Errors are logged with correct component tags", {
 
 # Test: Production safeguards
 test_that("No PII is leaked in error logs", {
+  skip("sanitize_log_details blev fjernet i logging-refactor — PII-filtrering sker nu implicit i log_*-kald og tests for dette ligger i test-logging-*.R.")
   # Create data with potentially sensitive info
   sensitive_data <- data.frame(
     patient_id = c("123-45-6789", "987-65-4321"),

--- a/tests/testthat/test-cache-invalidation-sprint3.R
+++ b/tests/testthat/test-cache-invalidation-sprint3.R
@@ -123,6 +123,7 @@ test_that("session_reset event triggers cache invalidation", {
 })
 
 test_that("cache stats are accurate after operations", {
+  skip("get_cache_stats() blev fjernet. Intern .performance_cache er ikke længere eksponeret via public API — se manage_cache_size() og get_cached_result() for alternativer.")
   # Clear to start fresh
   clear_performance_cache()
 

--- a/tests/testthat/test-spc-cache-integration.R
+++ b/tests/testthat/test-spc-cache-integration.R
@@ -251,7 +251,7 @@ test_that("clear_spc_cache removes all entries", {
   }
 
   # Verify entries exist
-  stats_before <- get_spc_cache_stats(qic_cache)
+  stats_before <- get_qic_cache_stats(qic_cache)
   expect_equal(stats_before$size, 5)
 
   # Clear cache
@@ -259,7 +259,7 @@ test_that("clear_spc_cache removes all entries", {
   expect_true(success)
 
   # Verify cache is empty
-  stats_after <- get_spc_cache_stats(qic_cache)
+  stats_after <- get_qic_cache_stats(qic_cache)
   expect_equal(stats_after$size, 0)
 })
 
@@ -268,13 +268,13 @@ test_that("clear_spc_cache removes all entries", {
 # Test Suite 3: Cache Statistics
 # ====================================================================
 
-test_that("get_spc_cache_stats returns correct metrics", {
+test_that("get_qic_cache_stats returns correct metrics", {
   skip_if_not_installed("digest")
 
   qic_cache <- create_qic_cache(max_size = 10)
 
   # Initial stats
-  stats <- get_spc_cache_stats(qic_cache)
+  stats <- get_qic_cache_stats(qic_cache)
   expect_equal(stats$size, 0)
   expect_equal(stats$hits, 0)
   expect_equal(stats$misses, 0)
@@ -291,7 +291,7 @@ test_that("get_spc_cache_stats returns correct metrics", {
   # Cache miss
   get_cached_spc_result("nonexistent_key", qic_cache)
 
-  stats <- get_spc_cache_stats(qic_cache)
+  stats <- get_qic_cache_stats(qic_cache)
   expect_equal(stats$size, 1)
   expect_equal(stats$hits, 1)
   expect_equal(stats$misses, 1)
@@ -338,7 +338,7 @@ test_that("cache achieves >80% hit rate in typical workflow", {
   }
 
   # Check hit rate
-  stats <- get_spc_cache_stats(qic_cache)
+  stats <- get_qic_cache_stats(qic_cache)
 
   # Should achieve >80% hit rate
   expect_gte(stats$hit_rate_percent, 80)


### PR DESCRIPTION
## Del 3 af #203 — kategori A (batch 1)

Tests refererer til funktioner der blev fjernet/omdøbt i tidligere
refactor-runder. Fejlede med `could not find function "X"`.

Se [docs/test-suite-inventory-203.md](docs/test-suite-inventory-203.md).

## Fjernede funktioner (skip'et)

| Funktion | Status | Erstatning |
|---|---|---|
| `sanitize_log_details` | Fjernet i logging-refactor | `log_*`-kald håndterer strukturering implicit |
| `log_with_throttle` | Fjernet | `options(spc.log.level)` + `.context` filtrering i logger-backend |
| `get_cache_stats` | Fjernet fra utils_performance_caching.R | `manage_cache_size()`, `get_cached_result()` |

## Omdøbte funktioner (opdateret)

| Før | Efter | Note |
|---|---|---|
| `get_spc_cache_stats(cache)` | `get_qic_cache_stats(cache)` | Samme signatur, bare navneændring efter qic-cache konsolidering |

## Effekt

Filtered test-run af berørte filer:
- Master: 10 FAIL, 126 PASS
- Denne branch: 2 FAIL, 136 PASS (+6 skip'ede med rationale)
- **+10 PASS, -8 FAIL**

Alle skip'ede blokke har dansk kommentar der forklarer hvorfor testen
er deaktiveret — NEWS-entry bevares så historikken står tydelig.

Resterende 2 fejl i disse filer hører til andre kategorier (reactive
context scope).