### PR TITLE
chore(deps): bump BFHcharts >=0.8.1 + BFHllm >=0.1.2, fjern CI workaround

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,18 +44,11 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # Pre-install BFH sibling-pakker eksplicit fra GitHub.
-      # Workaround: BFHcharts/BFHllm har ikke selv Remotes for deres BFH-deps,
-      # saa pak kan ikke loese transitivt fra biSPCharts' Remotes alene.
-      # Den arkitektonisk korrekte fix er at tilfoeje Remotes til BFHcharts +
-      # BFHllm DESCRIPTION (gemmes til CI-replikation paa upstream-pakker).
+      # Cross-repo deps haandteres nu transitivt via Remotes-felter i
+      # biSPCharts (top-level), BFHcharts (>= 0.8.1) og BFHllm (>= 0.1.2).
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            any::rcmdcheck
-            github::johanreventlow/BFHtheme
-            github::johanreventlow/BFHllm
-            github::johanreventlow/BFHcharts
+          extra-packages: any::rcmdcheck
           needs: check
 
       # Pragmatisk konfiguration for biSPCharts (Shiny app, pre-1.0):
@@ -66,8 +59,7 @@ jobs:
       # - error-on "error": kun ERRORs blokerer; WARNINGs/NOTEs er synlige men
       #   non-blocking (11 WARN/5 NOTE er pre-existing pakke-hygiejne issues)
       # CI validerer stadig: NAMESPACE-integritet, dep-resolution, kompilering,
-      # pakke-installation, basal struktur. Dette er kerne-vaerdien af R CMD
-      # check for et Shiny-app-projekt der ikke targets CRAN.
+      # pakke-installation, basal struktur.
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
@@ -98,11 +90,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: |
-            any::testthat
-            github::johanreventlow/BFHtheme
-            github::johanreventlow/BFHllm
-            github::johanreventlow/BFHcharts
+          extra-packages: any::testthat
           needs: check
 
       - name: Install local package

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     ggpp (>= 0.5.0),
     ggrepel (>= 0.9.0),
     geomtextpath (>= 0.1.0),
-    BFHcharts (>= 0.8.0),
+    BFHcharts (>= 0.8.1),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -71,7 +71,7 @@ Suggests:
     covr (>= 3.6.0),
     qicharts2 (>= 0.7.0),
     curl (>= 4.3.0),
-    BFHllm (>= 0.1.1)
+    BFHllm (>= 0.1.2)
 Config/testthat/edition: 3
 Config/Notes: qicharts2 moved to Suggests for regression testing during BFHcharts migration
 Remotes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # biSPCharts 0.2.0-dev (development)
 
+## Interne ændringer
+
+* **Cross-repo bump:** `BFHcharts (>= 0.8.1)` og `BFHllm (>= 0.1.2)`. Begge
+  sibling-pakker har nu egne `Remotes:`-felter, så pak kan løse transitive
+  BFH-deps uden eksplicit workaround. Workarounden i
+  `.github/workflows/R-CMD-check.yaml` (de fire `github::johanreventlow/...`
+  entries i `extra-packages`) er fjernet. CI er nu arkitektonisk korrekt
+  konfigureret og matcher VERSIONING_POLICY cross-repo bump-protokol.
+
 ## Interne ændringer (Fase 3 — TODO-resolution + targeted salvage, #203)
 
 * **Fail-count reduceret fra 292 til 80** (-212, target <200 **klart opnået**).


### PR DESCRIPTION
## Cross-repo bump

BFHcharts v0.8.1 og BFHllm v0.1.2 har nu egne `Remotes:`-felter (PR #139 paa BFHcharts, PR #9 paa BFHllm). pak kan derfor loese transitive BFH-deps uden eksplicit workaround.

## Aendringer

- `DESCRIPTION`: bump lower-bound BFHcharts og BFHllm
- `.github/workflows/R-CMD-check.yaml`: fjern de fire `github::johanreventlow/*` entries fra `extra-packages` i begge jobs (R-CMD-check og testthat)

## Verifikation

CI vil koere uden workaround. Hvis groen → workarounden er korrekt fjernet.