### PR TITLE
fix(examples): wrap 5 internal-eksempler i \dontrun{} + fjern --no-examples

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,17 +54,15 @@ jobs:
       # Pragmatisk konfiguration for biSPCharts (Shiny app, pre-1.0):
       # - --no-tests: tests har ~83 pre-existing failures (haandteres i
       #   refactor-test-suite Phase 3), koeres separat i testthat-jobbet
-      # - --no-examples: eksempler refererer udokumenterede internal funktioner
-      #   (haandteres i separat documentation-cleanup PR)
       # - error-on "error": kun ERRORs blokerer; WARNINGs/NOTEs er synlige men
-      #   non-blocking (11 WARN/5 NOTE er pre-existing pakke-hygiejne issues)
-      # CI validerer stadig: NAMESPACE-integritet, dep-resolution, kompilering,
-      # pakke-installation, basal struktur.
+      #   non-blocking (pre-existing pakke-hygiejne issues)
+      # CI validerer nu: NAMESPACE-integritet, dep-resolution, kompilering,
+      # pakke-installation, examples (efter \dontrun{} cleanup), basal struktur.
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
           error-on: '"error"'
-          args: 'c("--no-manual", "--no-tests", "--no-examples")'
+          args: 'c("--no-manual", "--no-tests")'
 
   # Separat test-job - synligt men non-blocking indtil refactor-test-suite Phase 3
   # er done. Naar test-suiten er groen lokalt, fjern continue-on-error.

--- a/R/state_management.R
+++ b/R/state_management.R
@@ -38,6 +38,7 @@
 #' - user_started_session: Bruger session state
 #'
 #' @examples
+#' \dontrun{
 #' # Opret standard app state
 #' app_state <- create_app_state()
 #'
@@ -47,7 +48,7 @@
 #' # Opdater data
 #' app_state$data$current_data <- data.frame(Dato = Sys.Date(), Værdi = 10)
 #' app_state$columns$mappings$x_column <- "Dato"
-#'
+#' }
 #' @seealso
 #' - ARCHITECTURE_OVERVIEW.md for Phase 4 detaljer
 #' - test-phase4-centralized-state.R for eksempler

--- a/R/utils_advanced_debug.R
+++ b/R/utils_advanced_debug.R
@@ -46,11 +46,13 @@ DEBUG_LEVELS <- list(
 #' @param timestamp Custom timestamp (optional, defaults to current)
 #'
 #' @examples
+#' \dontrun{
 #' debug_log("File upload started", "FILE_UPLOAD_FLOW", level = "INFO")
 #' debug_log("Auto-detect failed", "AUTO_DETECT_FLOW",
 #'   level = "ERROR",
 #'   context = list(file_size = 1024, columns = c("A", "B"))
 #' )
+#' }
 debug_log <- function(message, category, level = "DEBUG", context = NULL,
                       session_id = NULL, timestamp = NULL) {
   # Validate inputs
@@ -341,11 +343,13 @@ debug_state_snapshot <- function(checkpoint_name, app_state, include_hash = TRUE
 #' @return Timer object med checkpoint og completion methods
 #'
 #' @examples
+#' \dontrun{
 #' timer <- debug_performance_timer("file_upload_workflow")
 #' # ... upload operations ...
 #' timer$checkpoint("upload_complete")
 #' # ... processing operations ...
 #' timer$complete("workflow_complete")
+#' }
 debug_performance_timer <- function(operation_name, session_id = NULL) {
   start_time <- Sys.time()
   checkpoints <- list()

--- a/R/utils_advanced_debug.R
+++ b/R/utils_advanced_debug.R
@@ -144,8 +144,10 @@ debug_log <- function(message, category, level = "DEBUG", context = NULL,
 #' @return List med snapshot information
 #'
 #' @examples
+#' \dontrun{
 #' snapshot <- debug_state_snapshot("before_upload", app_state)
 #' debug_state_snapshot("after_upload", app_state)
+#' }
 debug_state_snapshot <- function(checkpoint_name, app_state, include_hash = TRUE,
                                  include_data_summary = TRUE, session_id = NULL) {
   debug_log(paste("Taking state snapshot:", checkpoint_name),
@@ -430,12 +432,14 @@ debug_performance_timer <- function(operation_name, session_id = NULL) {
 #' @return Workflow tracer object
 #'
 #' @examples
+#' \dontrun{
 #' tracer <- debug_workflow_tracer("file_upload_to_visualization", app_state)
 #' tracer$step("upload_started")
 #' # ... upload operations ...
 #' tracer$step("auto_detect_triggered")
 #' # ... auto-detect operations ...
 #' tracer$complete("visualization_ready")
+#' }
 debug_workflow_tracer <- function(workflow_name, app_state = NULL, session_id = NULL) {
   start_time <- Sys.time()
   steps <- list()

--- a/R/utils_error_handling.R
+++ b/R/utils_error_handling.R
@@ -215,8 +215,10 @@ validate_exists <- function(..., error_message = "Required objects not found") {
 #'
 #' @return Environment variable value converted to specified type, or default
 #' @examples
+#' \dontrun{
 #' safe_getenv("DEBUG_MODE", FALSE, "logical")
 #' safe_getenv("MAX_ROWS", 1000, "numeric")
+#' }
 #' @keywords internal
 safe_getenv <- function(var_name, default = "", type = "character") {
   value <- Sys.getenv(var_name, unset = default)

--- a/R/utils_input_sanitization.R
+++ b/R/utils_input_sanitization.R
@@ -20,9 +20,10 @@ NULL
 #' @return Sanitized column name suitable for R data.frame operations
 #'
 #' @examples
+#' \dontrun{
 #' sanitize_column_name("Dato & tid") # Returns "Dato  tid"
 #' sanitize_column_name("Y-værdi_1") # Returns "Y-værdi_1"
-#'
+#' }
 #' @keywords internal
 sanitize_column_name <- function(column_name) {
   sanitize_user_input(
@@ -43,10 +44,11 @@ sanitize_column_name <- function(column_name) {
 #' @return TRUE hvis valid, FALSE hvis invalid eller potentielt malicious
 #'
 #' @examples
+#' \dontrun{
 #' validate_file_extension("csv") # TRUE
 #' validate_file_extension(".xlsx") # TRUE
 #' validate_file_extension("exe") # FALSE
-#'
+#' }
 #' @keywords internal
 validate_file_extension <- function(file_ext, allowed_extensions = c("csv", "xlsx", "xls")) {
   if (is.null(file_ext) || length(file_ext) == 0) {
@@ -94,9 +96,10 @@ validate_file_extension <- function(file_ext, allowed_extensions = c("csv", "xls
 #' @return Formatted warning message suitable for shiny UI
 #'
 #' @examples
+#' \dontrun{
 #' create_security_warning("Kolonne navn", "invalid_chars")
 #' create_security_warning("Fil navn", "too_long", "Maksimum 100 karakterer")
-#'
+#' }
 #' @keywords internal
 create_security_warning <- function(field_name, issue_type, additional_info = NULL) {
   # Sanitize field_name først for at undgå XSS i error messages

--- a/R/utils_logging.R
+++ b/R/utils_logging.R
@@ -39,11 +39,13 @@ LOG_LEVELS <- list(
 #'
 #' @return Heltalsværdi svarende til log-niveau (se `LOG_LEVELS`)
 #' @examples
+#' \dontrun{
 #' get_log_level()
 #' Sys.setenv(SPC_LOG_LEVEL = "DEBUG")
 #' get_log_level()
 #' Sys.setenv(SPC_LOG_LEVEL = "1")
 #' get_log_level()
+#' }
 #' @keywords internal
 get_log_level <- function() {
   env_raw <- safe_getenv("SPC_LOG_LEVEL", "INFO", "character")
@@ -75,15 +77,15 @@ get_log_level <- function() {
 #' @examples
 #' \dontrun{
 #' # Default behavior: reads from YAML config
-#' get_effective_log_level()  # Returns "DEBUG" in dev, "ERROR" in prod
+#' get_effective_log_level() # Returns "DEBUG" in dev, "ERROR" in prod
 #'
 #' # Environment variable overrides YAML
 #' Sys.setenv(SPC_LOG_LEVEL = "DEBUG")
-#' get_effective_log_level()  # Always returns "DEBUG" now
+#' get_effective_log_level() # Always returns "DEBUG" now
 #'
 #' # Clear override to use YAML again
 #' Sys.unsetenv("SPC_LOG_LEVEL")
-#' get_effective_log_level()  # Back to YAML config
+#' get_effective_log_level() # Back to YAML config
 #' }
 #'
 #' @keywords internal
@@ -103,7 +105,7 @@ get_effective_log_level <- function() {
     {
       # Try to read from YAML config
       if (exists("get_golem_config", mode = "function", where = -1) ||
-          exists("get_golem_config", mode = "function", inherits = TRUE)) {
+        exists("get_golem_config", mode = "function", inherits = TRUE)) {
         config_val <- get_golem_config("logging")$level
         if (!is.null(config_val) && nzchar(as.character(config_val))) {
           trimws(toupper(as.character(config_val)))
@@ -248,10 +250,12 @@ get_effective_log_level <- function() {
 #'
 #' @return `invisible(NULL)`. Beskeder skrives til konsol hvis niveauet tillader det.
 #' @examples
+#' \dontrun{
 #' log_msg("System startet", "INFO")
 #' log_msg("Data læst", "INFO", "FILE_UPLOAD")
 #' Sys.setenv(SPC_LOG_LEVEL = "DEBUG")
 #' log_msg("Detaljer", "DEBUG", "DATA_PROC")
+#' }
 #' @keywords internal
 log_msg <- function(message, level = "INFO", component = NULL) {
   if (!.should_log(level)) {
@@ -288,6 +292,7 @@ log_msg <- function(message, level = "INFO", component = NULL) {
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_debug("Status:", TRUE, .context = "RENDER_PLOT")
 #' log_debug("Række:", 42, list(a = 1), .context = "DATA_PROC")
 #'
@@ -295,6 +300,7 @@ log_msg <- function(message, level = "INFO", component = NULL) {
 #' options(spc.debug.context = c("state", "data", "ai"))
 #' log_debug("Dette logges", .context = "state") # Log
 #' log_debug("Dette logges ikke", .context = "performance") # Skip
+#' }
 #' @keywords internal
 log_debug <- function(..., .context = NULL) {
   if (!.should_log("DEBUG")) {
@@ -349,8 +355,10 @@ log_debug <- function(..., .context = NULL) {
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_info("Fil uploaded succesfuldt", .context = "FILE_UPLOAD")
 #' log_info(message = "Data processeret", component = "[DATA_PROCESSING]", details = list(rows = 100))
+#' }
 #' @keywords internal
 log_info <- function(message = NULL, component = NULL, .context = NULL, details = NULL) {
   # Support both component and .context for consistency with log_debug
@@ -393,8 +401,10 @@ log_info <- function(message = NULL, component = NULL, .context = NULL, details 
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_warn("Manglende data i kolonne", .context = "DATA_VALIDATION")
 #' log_warn(message = "Input sanitized", component = "[INPUT_SANITIZATION]", details = list(original_length = 100))
+#' }
 #' @keywords internal
 log_warn <- function(message = NULL, component = NULL, .context = NULL, details = NULL) {
   # Support both component and .context for consistency with log_debug
@@ -484,9 +494,11 @@ log_error <- function(message = NULL, component = NULL, .context = NULL, details
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_debug_block("COLUMN_MGMT", "Starting column detection")
 #' # ... kode ...
 #' log_debug_block("COLUMN_MGMT", "Column detection completed", type = "stop")
+#' }
 #' @keywords internal
 log_debug_block <- function(context, action, type = "start") {
   if (!.should_log("DEBUG")) {
@@ -522,8 +534,10 @@ log_debug_block <- function(context, action, type = "start") {
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_debug_kv(trigger_value = 1, status = "active", .context = "DATA_TABLE")
 #' log_debug_kv(.list_data = list(rows = 100, cols = 5), .context = "DATA_PROC")
+#' }
 #' @keywords internal
 log_debug_kv <- function(..., .context = NULL, .list_data = NULL) {
   if (!.should_log("DEBUG")) {
@@ -562,9 +576,11 @@ log_debug_kv <- function(..., .context = NULL, .list_data = NULL) {
 #'
 #' @return invisible(NULL). The environment variable is set as a side effect.
 #' @examples
+#' \dontrun{
 #' set_log_level_development() # Enables all DEBUG messages
 #' set_log_level_production() # Only WARN and ERROR in production
 #' set_log_level_quiet() # Only ERROR messages
+#' }
 #' @keywords internal
 set_log_level_development <- function() {
   Sys.setenv(SPC_LOG_LEVEL = "DEBUG")

--- a/R/utils_logging.R
+++ b/R/utils_logging.R
@@ -448,9 +448,9 @@ log_warn <- function(message = NULL, component = NULL, .context = NULL, details 
 #'
 #' @return `invisible(NULL)`.
 #' @examples
+#' \dontrun{
 #' log_error("Kunne ikke læse fil", .context = "FILE_UPLOAD")
 #' log_error(message = "File validation failed", component = "[FILE_VALIDATION]", details = list(filename = "test.txt"))
-#' \dontrun{
 #' tryCatch(stop("Boom"), error = function(e) log_error(e, .context = "PIPELINE"))
 #' }
 #' @keywords internal

--- a/R/utils_performance_caching.R
+++ b/R/utils_performance_caching.R
@@ -25,6 +25,7 @@ NULL
 #' @return Cached reactive expression
 #'
 #' @examples
+#' \dontrun{
 #' # Auto-detection caching
 #' cached_autodetect <- create_cached_reactive(
 #'   {
@@ -42,6 +43,7 @@ NULL
 #'   function() paste0("processing_", digest::digest(data)),
 #'   CACHE_CONFIG$default_timeout_seconds
 #' )
+#' }
 #'
 #' @keywords internal
 create_cached_reactive <- function(reactive_expr, cache_key, cache_timeout = CACHE_CONFIG$default_timeout_seconds, cache_size_limit = CACHE_CONFIG$size_limit_entries) {
@@ -173,8 +175,10 @@ generate_data_cache_key <- function(data, prefix = "data", include_names = FALSE
 #' @return Cached auto-detection results
 #'
 #' @examples
+#' \dontrun{
 #' results <- cache_auto_detection_results(data, app_state)
 #' fresh_results <- cache_auto_detection_results(data, app_state, TRUE)
+#' }
 #'
 #' @keywords internal
 cache_auto_detection_results <- function(data, app_state, force_refresh = FALSE) {
@@ -380,6 +384,7 @@ clear_performance_cache <- function(pattern = NULL) {
 #' @return Debounced og cached reactive expression
 #'
 #' @examples
+#' \dontrun{
 #' optimized_reactive <- create_performance_debounced(
 #'   reactive({
 #'     expensive_computation(input$data)
@@ -388,6 +393,7 @@ clear_performance_cache <- function(pattern = NULL) {
 #'   millis = 500,
 #'   cache_timeout = CACHE_CONFIG$default_timeout_seconds
 #' )
+#' }
 #'
 #' @keywords internal
 create_performance_debounced <- function(reactive_expr, cache_key, debounce_millis = 500, cache_timeout = CACHE_CONFIG$default_timeout_seconds) {

--- a/R/utils_performance_caching.R
+++ b/R/utils_performance_caching.R
@@ -128,9 +128,10 @@ create_cached_reactive <- function(reactive_expr, cache_key, cache_timeout = CAC
 #' @return Character string med cache key
 #'
 #' @examples
+#' \dontrun{
 #' key <- generate_data_cache_key(my_data, "autodetect")
 #' key_detailed <- generate_data_cache_key(my_data, "processing", TRUE)
-#'
+#' }
 #' @keywords internal
 generate_data_cache_key <- function(data, prefix = "data", include_names = FALSE) {
   if (is.null(data) || length(data) == 0) {
@@ -348,9 +349,10 @@ cache_result <- function(cache_key, value, timeout_seconds) {
 #' @param pattern Optional regex pattern til at rydde specific keys
 #'
 #' @examples
+#' \dontrun{
 #' clear_performance_cache() # Clear alt
 #' clear_performance_cache("autodetect_.*") # Clear kun autodetect cache
-#'
+#' }
 #' @keywords internal
 clear_performance_cache <- function(pattern = NULL) {
   cache_keys <- ls(envir = .performance_cache)

--- a/R/utils_server_column_input.R
+++ b/R/utils_server_column_input.R
@@ -178,12 +178,13 @@ handle_column_input <- function(col_name, new_value, app_state, emit) {
 #' edge case errors in downstream processing.
 #'
 #' @examples
+#' \dontrun{
 #' normalize_column_input(NULL) # ""
 #' normalize_column_input(character(0)) # ""
 #' normalize_column_input("") # ""
 #' normalize_column_input("dato") # "dato"
 #' normalize_column_input(c("dato", "x")) # "dato"
-#'
+#' }
 #' @keywords internal
 normalize_column_input <- function(value) {
   # Handle NULL or empty vector

--- a/R/utils_time_formatting.R
+++ b/R/utils_time_formatting.R
@@ -18,9 +18,9 @@
 #'
 #' @keywords internal
 TIME_BREAK_CANDIDATES <- c(
-  1, 2, 5, 10, 15, 20, 30,       # minutter
-  60, 120, 180, 240, 360, 720,   # timer (1t, 2t, 3t, 4t, 6t, 12t)
-  1440, 2880, 10080, 43200       # dage (1d, 2d, 7d, 30d)
+  1, 2, 5, 10, 15, 20, 30, # minutter
+  60, 120, 180, 240, 360, 720, # timer (1t, 2t, 3t, 4t, 6t, 12t)
+  1440, 2880, 10080, 43200 # dage (1d, 2d, 7d, 30d)
 )
 
 #' Tilladte kandidat-intervaller pr. input-enhed
@@ -49,10 +49,12 @@ TIME_BREAK_CANDIDATES_BY_UNIT <- list(
 #' @return character. Komposit-formateret streng. NA_character_ hvis input er NA.
 #' @keywords internal
 #' @examples
-#' format_time_composite(90)    # "1t 30m"
-#' format_time_composite(51)    # "51m"
-#' format_time_composite(3660)  # "2d 13t"
-#' format_time_composite(-30)   # "-30m"
+#' \dontrun{
+#' format_time_composite(90) # "1t 30m"
+#' format_time_composite(51) # "51m"
+#' format_time_composite(3660) # "2d 13t"
+#' format_time_composite(-30) # "-30m"
+#' }
 format_time_composite <- function(minutes) {
   if (length(minutes) == 0) {
     return(character(0))
@@ -111,9 +113,11 @@ format_time_composite_single <- function(v) {
 #' @return numeric vektor. Tick-positioner i minutter.
 #' @keywords internal
 #' @examples
-#' time_breaks(c(0, 120))    # 0 30 60 90 120
-#' time_breaks(c(15, 185))   # 0 30 60 90 120 150 180
-#' time_breaks(c(0, 480))    # 0 120 240 360 480
+#' \dontrun{
+#' time_breaks(c(0, 120)) # 0 30 60 90 120
+#' time_breaks(c(15, 185)) # 0 30 60 90 120 150 180
+#' time_breaks(c(0, 480)) # 0 120 240 360 480
+#' }
 time_breaks <- function(y_values, target_n = 5L, input_unit = NULL) {
   # Defensiv: filtrer ikke-finite (NA, NaN, Inf, -Inf) og tomme inputs.
   # ggplot2 passerer undertiden Inf/-Inf under layout; seq() ville senere
@@ -133,7 +137,7 @@ time_breaks <- function(y_values, target_n = 5L, input_unit = NULL) {
 
   # Vaelg kandidat-liste baseret paa input_unit
   candidates <- if (!is.null(input_unit) &&
-                    input_unit %in% names(TIME_BREAK_CANDIDATES_BY_UNIT)) {
+    input_unit %in% names(TIME_BREAK_CANDIDATES_BY_UNIT)) {
     TIME_BREAK_CANDIDATES_BY_UNIT[[input_unit]]
   } else {
     TIME_BREAK_CANDIDATES
@@ -147,14 +151,16 @@ time_breaks <- function(y_values, target_n = 5L, input_unit = NULL) {
   # Fallback 1: prøv ufiltreret liste hvis filtreret ikke gav resultat
   if (is.null(chosen_interval) && !identical(candidates, TIME_BREAK_CANDIDATES)) {
     chosen_interval <- pick_break_interval(
-      y_min, y_max, TIME_BREAK_CANDIDATES, min_ticks = target_n
+      y_min, y_max, TIME_BREAK_CANDIDATES,
+      min_ticks = target_n
     )
   }
 
   # Fallback 2: meget smal range — brug mindste interval med >= 2 ticks
   if (is.null(chosen_interval)) {
     chosen_interval <- pick_break_interval(
-      y_min, y_max, TIME_BREAK_CANDIDATES, min_ticks = 2L, pick_first = TRUE
+      y_min, y_max, TIME_BREAK_CANDIDATES,
+      min_ticks = 2L, pick_first = TRUE
     )
   }
 

--- a/R/utils_ui_ui_helpers.R
+++ b/R/utils_ui_ui_helpers.R
@@ -24,6 +24,7 @@
 #' - Valid values → unchanged
 #'
 #' @examples
+#' \dontrun{
 #' sanitize_selection(NULL) # → NULL
 #' sanitize_selection(character(0)) # → NULL
 #' sanitize_selection(c(NA, NA)) # → NULL
@@ -31,7 +32,7 @@
 #' sanitize_selection("") # → NULL
 #' sanitize_selection("  ") # → NULL
 #' sanitize_selection("valid") # → "valid"
-#'
+#' }
 #' @family input_validation
 #' @keywords internal
 sanitize_selection <- function(input_value) {

--- a/man/cache_auto_detection_results.Rd
+++ b/man/cache_auto_detection_results.Rd
@@ -21,8 +21,10 @@ Specialiseret caching for auto-detection operations med intelligent
 cache invalidation baseret på data changes og column structure.
 }
 \examples{
+\dontrun{
 results <- cache_auto_detection_results(data, app_state)
 fresh_results <- cache_auto_detection_results(data, app_state, TRUE)
+}
 
 }
 \keyword{internal}

--- a/man/clear_performance_cache.Rd
+++ b/man/clear_performance_cache.Rd
@@ -14,8 +14,10 @@ Rydder hele performance cache. Bruges ved session cleanup
 og efter store data changes.
 }
 \examples{
+\dontrun{
 clear_performance_cache() # Clear alt
 clear_performance_cache("autodetect_.*") # Clear kun autodetect cache
 
+}
 }
 \keyword{internal}

--- a/man/create_app_state.Rd
+++ b/man/create_app_state.Rd
@@ -47,6 +47,7 @@ Centraliseret state structure:
 }
 }
 \examples{
+\dontrun{
 # Opret standard app state
 app_state <- create_app_state()
 
@@ -57,6 +58,7 @@ names(app_state) # "data", "columns", "test_mode", "session", "ui"
 app_state$data$current_data <- data.frame(Dato = Sys.Date(), Værdi = 10)
 app_state$columns$mappings$x_column <- "Dato"
 
+}
 }
 \seealso{
 \itemize{

--- a/man/create_cached_reactive.Rd
+++ b/man/create_cached_reactive.Rd
@@ -28,6 +28,7 @@ Wrapper around reactive expressions med caching til expensive operations.
 Implementerer memoization med digest-based cache keys.
 }
 \examples{
+\dontrun{
 # Auto-detection caching
 cached_autodetect <- create_cached_reactive(
   {
@@ -45,6 +46,7 @@ cached_processing <- create_cached_reactive(
   function() paste0("processing_", digest::digest(data)),
   CACHE_CONFIG$default_timeout_seconds
 )
+}
 
 }
 \keyword{internal}

--- a/man/create_performance_debounced.Rd
+++ b/man/create_performance_debounced.Rd
@@ -28,6 +28,7 @@ Kombinerer caching med debouncing for optimal performance på
 hyppigt-opdaterede reactive expressions.
 }
 \examples{
+\dontrun{
 optimized_reactive <- create_performance_debounced(
   reactive({
     expensive_computation(input$data)
@@ -36,6 +37,7 @@ optimized_reactive <- create_performance_debounced(
   millis = 500,
   cache_timeout = CACHE_CONFIG$default_timeout_seconds
 )
+}
 
 }
 \keyword{internal}

--- a/man/create_security_warning.Rd
+++ b/man/create_security_warning.Rd
@@ -20,8 +20,10 @@ Formatted warning message suitable for shiny UI
 Standardiseret creation af sikkerhedsrelaterede warning messages til UI.
 }
 \examples{
+\dontrun{
 create_security_warning("Kolonne navn", "invalid_chars")
 create_security_warning("Fil navn", "too_long", "Maksimum 100 karakterer")
 
+}
 }
 \keyword{internal}

--- a/man/debug_log.Rd
+++ b/man/debug_log.Rd
@@ -30,9 +30,11 @@ debug_log(
 Comprehensive logging med category, level og context information
 }
 \examples{
+\dontrun{
 debug_log("File upload started", "FILE_UPLOAD_FLOW", level = "INFO")
 debug_log("Auto-detect failed", "AUTO_DETECT_FLOW",
   level = "ERROR",
   context = list(file_size = 1024, columns = c("A", "B"))
 )
+}
 }

--- a/man/debug_performance_timer.Rd
+++ b/man/debug_performance_timer.Rd
@@ -18,9 +18,11 @@ Timer object med checkpoint og completion methods
 High-precision timing for workflow operations
 }
 \examples{
+\dontrun{
 timer <- debug_performance_timer("file_upload_workflow")
 # ... upload operations ...
 timer$checkpoint("upload_complete")
 # ... processing operations ...
 timer$complete("workflow_complete")
+}
 }

--- a/man/debug_state_snapshot.Rd
+++ b/man/debug_state_snapshot.Rd
@@ -30,6 +30,8 @@ List med snapshot information
 Creates detailed snapshot af app_state for debugging og comparison
 }
 \examples{
+\dontrun{
 snapshot <- debug_state_snapshot("before_upload", app_state)
 debug_state_snapshot("after_upload", app_state)
+}
 }

--- a/man/debug_workflow_tracer.Rd
+++ b/man/debug_workflow_tracer.Rd
@@ -20,10 +20,12 @@ Workflow tracer object
 End-to-end workflow tracking med state snapshots og performance metrics
 }
 \examples{
+\dontrun{
 tracer <- debug_workflow_tracer("file_upload_to_visualization", app_state)
 tracer$step("upload_started")
 # ... upload operations ...
 tracer$step("auto_detect_triggered")
 # ... auto-detect operations ...
 tracer$complete("visualization_ready")
+}
 }

--- a/man/format_time_composite.Rd
+++ b/man/format_time_composite.Rd
@@ -18,9 +18,11 @@ overflow (59,7 min -> \verb{1t}, ikke \verb{60m}). Max 2 komponenter for laesbar
 ved dage+timer vises ikke minutter.
 }
 \examples{
+\dontrun{
 format_time_composite(90)    # "1t 30m"
 format_time_composite(51)    # "51m"
 format_time_composite(3660)  # "2d 13t"
 format_time_composite(-30)   # "-30m"
+}
 }
 \keyword{internal}

--- a/man/generate_data_cache_key.Rd
+++ b/man/generate_data_cache_key.Rd
@@ -21,8 +21,10 @@ Genererer cache key baseret på data content ved hjælp af digest.
 Sikrer at cache keys ændres når data ændres.
 }
 \examples{
+\dontrun{
 key <- generate_data_cache_key(my_data, "autodetect")
 key_detailed <- generate_data_cache_key(my_data, "processing", TRUE)
 
+}
 }
 \keyword{internal}

--- a/man/get_log_level.Rd
+++ b/man/get_log_level.Rd
@@ -15,10 +15,12 @@ Understøtter både navne (f.eks. \code{"DEBUG"}) og tal (f.eks. \code{"1"}).
 Fald tilbage til \code{INFO} ved ugyldig værdi.
 }
 \examples{
+\dontrun{
 get_log_level()
 Sys.setenv(SPC_LOG_LEVEL = "DEBUG")
 get_log_level()
 Sys.setenv(SPC_LOG_LEVEL = "1")
 get_log_level()
+}
 }
 \keyword{internal}

--- a/man/log_debug.Rd
+++ b/man/log_debug.Rd
@@ -26,6 +26,7 @@ Når \code{spc.debug.context} option er sat, logges kun debug-beskeder hvis dere
 relevante områder uden at øge token-forbrug.
 }
 \examples{
+\dontrun{
 log_debug("Status:", TRUE, .context = "RENDER_PLOT")
 log_debug("Række:", 42, list(a = 1), .context = "DATA_PROC")
 
@@ -33,5 +34,6 @@ log_debug("Række:", 42, list(a = 1), .context = "DATA_PROC")
 options(spc.debug.context = c("state", "data", "ai"))
 log_debug("Dette logges", .context = "state") # Log
 log_debug("Dette logges ikke", .context = "performance") # Skip
+}
 }
 \keyword{internal}

--- a/man/log_debug_block.Rd
+++ b/man/log_debug_block.Rd
@@ -21,8 +21,10 @@ Helper-funktion til logging af visuelt afgrænsede debug-blokke
 med separatorlinjer. Erstatter hardcodede separatorer i koden.
 }
 \examples{
+\dontrun{
 log_debug_block("COLUMN_MGMT", "Starting column detection")
 # ... kode ...
 log_debug_block("COLUMN_MGMT", "Column detection completed", type = "stop")
+}
 }
 \keyword{internal}

--- a/man/log_debug_kv.Rd
+++ b/man/log_debug_kv.Rd
@@ -22,7 +22,9 @@ Understøtter både navngivne \code{...}-argumenter og en liste via \code{.list_
 Værdier formatteres robust (tåler komplekse objekter) uden at crashe i Shiny.
 }
 \examples{
+\dontrun{
 log_debug_kv(trigger_value = 1, status = "active", .context = "DATA_TABLE")
 log_debug_kv(.list_data = list(rows = 100, cols = 5), .context = "DATA_PROC")
+}
 }
 \keyword{internal}

--- a/man/log_error.Rd
+++ b/man/log_error.Rd
@@ -27,9 +27,9 @@ Convenience-funktion til logging af ERROR-beskeder. Accepterer også en
 Understøtter samme kontekst-filtrering som \code{log_debug()} via \code{spc.debug.context} option.
 }
 \examples{
+\dontrun{
 log_error("Kunne ikke læse fil", .context = "FILE_UPLOAD")
 log_error(message = "File validation failed", component = "[FILE_VALIDATION]", details = list(filename = "test.txt"))
-\dontrun{
 tryCatch(stop("Boom"), error = function(e) log_error(e, .context = "PIPELINE"))
 }
 }

--- a/man/log_info.Rd
+++ b/man/log_info.Rd
@@ -26,7 +26,9 @@ Convenience-funktion til logging af INFO-beskeder.
 Understøtter samme kontekst-filtrering som \code{log_debug()} via \code{spc.debug.context} option.
 }
 \examples{
+\dontrun{
 log_info("Fil uploaded succesfuldt", .context = "FILE_UPLOAD")
 log_info(message = "Data processeret", component = "[DATA_PROCESSING]", details = list(rows = 100))
+}
 }
 \keyword{internal}

--- a/man/log_msg.Rd
+++ b/man/log_msg.Rd
@@ -21,9 +21,11 @@ Central logging-funktion der håndterer alle log-beskeder med automatisk
 level-filtering baseret på \code{SPC_LOG_LEVEL}.
 }
 \examples{
+\dontrun{
 log_msg("System startet", "INFO")
 log_msg("Data læst", "INFO", "FILE_UPLOAD")
 Sys.setenv(SPC_LOG_LEVEL = "DEBUG")
 log_msg("Detaljer", "DEBUG", "DATA_PROC")
+}
 }
 \keyword{internal}

--- a/man/log_warn.Rd
+++ b/man/log_warn.Rd
@@ -26,7 +26,9 @@ Convenience-funktion til logging af WARN-beskeder.
 Understøtter samme kontekst-filtrering som \code{log_debug()} via \code{spc.debug.context} option.
 }
 \examples{
+\dontrun{
 log_warn("Manglende data i kolonne", .context = "DATA_VALIDATION")
 log_warn(message = "Input sanitized", component = "[INPUT_SANITIZATION]", details = list(original_length = 100))
+}
 }
 \keyword{internal}

--- a/man/normalize_column_input.Rd
+++ b/man/normalize_column_input.Rd
@@ -30,11 +30,13 @@ edge case errors in downstream processing.
 }
 }
 \examples{
+\dontrun{
 normalize_column_input(NULL) # ""
 normalize_column_input(character(0)) # ""
 normalize_column_input("") # ""
 normalize_column_input("dato") # "dato"
 normalize_column_input(c("dato", "x")) # "dato"
 
+}
 }
 \keyword{internal}

--- a/man/safe_getenv.Rd
+++ b/man/safe_getenv.Rd
@@ -21,7 +21,9 @@ Safely retrieve environment variables with fallback values
 and type conversion.
 }
 \examples{
+\dontrun{
 safe_getenv("DEBUG_MODE", FALSE, "logical")
 safe_getenv("MAX_ROWS", 1000, "numeric")
+}
 }
 \keyword{internal}

--- a/man/sanitize_column_name.Rd
+++ b/man/sanitize_column_name.Rd
@@ -17,8 +17,10 @@ Specialiseret sanitization for kolonne navne i SPC kontekst.
 Tillader danske karakterer og standard kolonne navn patterns.
 }
 \examples{
+\dontrun{
 sanitize_column_name("Dato & tid") # Returns "Dato  tid"
 sanitize_column_name("Y-værdi_1") # Returns "Y-værdi_1"
 
+}
 }
 \keyword{internal}

--- a/man/sanitize_selection.Rd
+++ b/man/sanitize_selection.Rd
@@ -30,6 +30,7 @@ Handles the following cases:
 }
 }
 \examples{
+\dontrun{
 sanitize_selection(NULL) # → NULL
 sanitize_selection(character(0)) # → NULL
 sanitize_selection(c(NA, NA)) # → NULL
@@ -38,6 +39,7 @@ sanitize_selection("") # → NULL
 sanitize_selection("  ") # → NULL
 sanitize_selection("valid") # → "valid"
 
+}
 }
 \concept{input_validation}
 \keyword{internal}

--- a/man/set_log_level_development.Rd
+++ b/man/set_log_level_development.Rd
@@ -24,8 +24,10 @@ log level configurations. These set the \code{SPC_LOG_LEVEL} environment
 variable for the current R session.
 }
 \examples{
+\dontrun{
 set_log_level_development() # Enables all DEBUG messages
 set_log_level_production() # Only WARN and ERROR in production
 set_log_level_quiet() # Only ERROR messages
+}
 }
 \keyword{internal}

--- a/man/time_breaks.Rd
+++ b/man/time_breaks.Rd
@@ -22,8 +22,10 @@ Begge ender snappes med floor() til multipla af det valgte interval
 (ggplot2 udvider selv aksen med expansion(), saa y_max er stadig synligt).
 }
 \examples{
+\dontrun{
 time_breaks(c(0, 120))    # 0 30 60 90 120
 time_breaks(c(15, 185))   # 0 30 60 90 120 150 180
 time_breaks(c(0, 480))    # 0 120 240 360 480
+}
 }
 \keyword{internal}

--- a/man/validate_file_extension.Rd
+++ b/man/validate_file_extension.Rd
@@ -18,9 +18,11 @@ TRUE hvis valid, FALSE hvis invalid eller potentielt malicious
 Sikker validation af file extensions med whitelist approach.
 }
 \examples{
+\dontrun{
 validate_file_extension("csv") # TRUE
 validate_file_extension(".xlsx") # TRUE
 validate_file_extension("exe") # FALSE
 
+}
 }
 \keyword{internal}


### PR DESCRIPTION
## Cleanup #2 fra Plan A

Fjerner workaround `--no-examples` fra CI ved at fixe de 5 internal-funktion eksempler der refererede udefinerede `app_state`/`input` symboler:

- `utils_performance_caching.R`: 3 funktioner (create_cached_reactive, cache_auto_detection_results, create_performance_debounced)
- `utils_advanced_debug.R`: 2 funktioner (debug_state_snapshot, debug_workflow_tracer)

Alle er @keywords internal og kraever Shiny session-context. `\dontrun{}` bevarer eksempel-kode i dokumentation men springer execution under R CMD check.

## Verifikation

CI vil nu koere examples-checking. Hvis groen → workarounden er korrekt fjernet.