### PR TITLE
fix(tests): opdatér chart-type labels til use-case-baserede (#235)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # biSPCharts 0.2.0-dev (development)
 
+## Bug fixes
+
+* **Chart type mapping tests** (#235): opdaterede forældede chart-type
+  labels i `test-app-initialization.R`, `test-data-validation.R` og
+  `test-visualization-server.R` til de use-case-baserede labels fra
+  `c268f3a` (#147) og `8db3946`. 4 tests grønne, ingen kode-ændringer.
+
 ## Interne ændringer (Fase 1 saneringsarbejde, #228/#229)
 
 * **Test-artefakter flyttet ud af aktiv suite** (jf. `harden-test-suite-

--- a/tests/testthat/test-app-initialization.R
+++ b/tests/testthat/test-app-initialization.R
@@ -4,10 +4,12 @@
 test_that("App initialization og global configuration fungerer", {
   # Test at core funktioner er loaded (ikke package-baseret)
   # Projektet bruger source-baseret loading, ikke package struktur
-  skip_if_not(exists("get_qic_chart_type", mode = "function"),
-              "get_qic_chart_type not available - check global.R loading")
+  skip_if_not(
+    exists("get_qic_chart_type", mode = "function"),
+    "get_qic_chart_type not available - check global.R loading"
+  )
 
-  expect_equal(get_qic_chart_type("P-kort (Andele)"), "p")
+  expect_equal(get_qic_chart_type("P-kort \u2014 andele/procenter (fx infektionsrate)"), "p")
   expect_equal(get_qic_chart_type(""), "run")
 
   # Test hospital konfiguration hvis tilgængelig
@@ -54,8 +56,10 @@ test_that("Unified state system kan initialiseres", {
   expect_true(exists("create_app_state"))
 
   # Strong assertion - this is critical functionality
-  expect_true(exists("create_app_state", mode = "function"),
-              "create_app_state must be available for unified state system")
+  expect_true(
+    exists("create_app_state", mode = "function"),
+    "create_app_state must be available for unified state system"
+  )
 
   app_state <- create_app_state()
   expect_true(is.environment(app_state))

--- a/tests/testthat/test-data-validation.R
+++ b/tests/testthat/test-data-validation.R
@@ -75,7 +75,7 @@ test_that("safe_date_parse fungerer robust", {
     # If atomic vector, check that parsing worked
     expect_true(length(result) > 0)
   }
-  
+
   # Test invalid datoer
   invalid_datoer <- c("ikke-en-dato", "abc", "32-13-2024")
   result_invalid <- safe_date_parse(invalid_datoer)
@@ -92,14 +92,14 @@ test_that("safe_date_parse fungerer robust", {
 
 test_that("chart type mapping fungerer", {
   # Test danske navne til engelske koder
-  expect_equal(get_qic_chart_type("Seriediagram med SPC (Run Chart)"), "run")
-  expect_equal(get_qic_chart_type("P-kort (Andele)"), "p")
-  expect_equal(get_qic_chart_type("I-kort (Individuelle værdier)"), "i")
-  
+  expect_equal(get_qic_chart_type("Seriediagram (Run) \u2014 data over tid"), "run")
+  expect_equal(get_qic_chart_type("P-kort \u2014 andele/procenter (fx infektionsrate)"), "p")
+  expect_equal(get_qic_chart_type("I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)"), "i")
+
   # Test allerede engelske koder
   expect_equal(get_qic_chart_type("run"), "run")
   expect_equal(get_qic_chart_type("p"), "p")
-  
+
   # Test fallback
   expect_equal(get_qic_chart_type("ukendt_type"), "run")
   expect_equal(get_qic_chart_type(""), "run")

--- a/tests/testthat/test-visualization-server.R
+++ b/tests/testthat/test-visualization-server.R
@@ -12,7 +12,7 @@ test_that("setup_visualization initializes correctly", {
     "setup_visualization function not available - check test setup"
   )
 
-  mock_input <- list(chart_type = "P-kort (Andele)")
+  mock_input <- list(chart_type = "P-kort \u2014 andele/procenter (fx infektionsrate)")
   mock_output <- list()
   mock_session <- list(token = "test_session")
 
@@ -75,10 +75,10 @@ test_that("Chart type conversion works in visualization context", {
     "get_qic_chart_type not available - check test setup"
   )
 
-  expect_equal(get_qic_chart_type("P-kort (Andele)"), "p")
-  expect_equal(get_qic_chart_type("U-kort (Rater)"), "u")
-  expect_equal(get_qic_chart_type("I-kort (Individuelle værdier)"), "i")
-  expect_equal(get_qic_chart_type("Seriediagram (Run Chart)"), "run")
+  expect_equal(get_qic_chart_type("P-kort \u2014 andele/procenter (fx infektionsrate)"), "p")
+  expect_equal(get_qic_chart_type("U-kort \u2014 rater (fx komplikationer pr. 1000)"), "u")
+  expect_equal(get_qic_chart_type("I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)"), "i")
+  expect_equal(get_qic_chart_type("Seriediagram (Run) \u2014 data over tid"), "run")
 
   expect_equal(get_qic_chart_type(""), "run")
   expect_equal(get_qic_chart_type(NULL), "run")


### PR DESCRIPTION
## Summary

Opdaterer 3 testfiler hvor forældede chart-type labels gav silent fallback til `"run"` i stedet for de rigtige koder (`"p"`, `"i"`, osv.).

Labels blev ændret i to omgange:
- **#147 (c268f3a):** migrerede til kliniske use-case-baserede labels (fx `"P-kort — andele/procenter (fx infektionsrate)"`)
- **8db3946:** `"Run"` → `"Seriediagram (Run) — data over tid"`

Testfilerne (`test-app-initialization.R`, `test-data-validation.R`, `test-visualization-server.R`) brugte stadig de gamle labels og ramte `get_qic_chart_type()`'s catch-all fallback.

## Changes

- **test-app-initialization.R:** 1 assertion opdateret
- **test-data-validation.R:** 3 assertions opdateret
- **test-visualization-server.R:** 4 assertions + 1 mock_input opdateret

Unicode-escape (`\u2014`) brugt konsekvent (matcher `test-config_chart_types.R`).

## Test plan

- [x] `testthat::test_file("tests/testthat/test-app-initialization.R")` → 12/12 pass (3 pre-existing skips)
- [x] `testthat::test_file("tests/testthat/test-data-validation.R")` → 14/14 pass (2 pre-existing skips)
- [x] `testthat::test_file("tests/testthat/test-visualization-server.R")` → 14/14 pass

## Relations

- Closes #235
- Part of paraply #239