### PR TITLE
fix(label-formatting): brug formatC round-half-up for 1-decimal rounding (#236)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@
   labels i `test-app-initialization.R`, `test-data-validation.R` og
   `test-visualization-server.R` til de use-case-baserede labels fra
   `c268f3a` (#147) og `8db3946`. 4 tests grønne, ingen kode-ændringer.
+* **format_y_value() afrunding for rate/count/default** (#236): `format()`
+  med `nsmall = 1` sikrer kun minimum decimaler, ikke maksimum — derfor
+  returnerede `format_y_value(123.456, "rate")` "123,456" i stedet for
+  forventet "123,5". Fix: byttet til `formatC(val, digits = 1, format = "f",
+  decimal.mark = ",")` i rate/default/count-branches. `formatC` bruger
+  round-half-up (123.45 → 123,5) som matcher klinisk læsevaner, modsat R's
+  base `round()` som bruger banker's rounding (123.45 → 123,4). 2 tests
+  grønne (linje 41 og 87 i `test-label-formatting.R`).
 
 ## Interne ændringer (Fase 1 saneringsarbejde, #228/#229)
 

--- a/R/utils_label_formatting.R
+++ b/R/utils_label_formatting.R
@@ -54,44 +54,48 @@ format_y_value <- function(val, y_unit, y_range = NULL) {
   }
 
   # Count formatting med K/M/mia notation
+  # Bruger formatC med format="f" for round-half-up (jf. rate-branch).
   if (y_unit == "count") {
     if (abs(val) >= 1e9) {
       scaled <- val / 1e9
       if (scaled == round(scaled)) {
         return(paste0(round(scaled), " mia."))
       } else {
-        return(paste0(format(scaled, decimal.mark = ",", nsmall = 1), " mia."))
+        return(paste0(formatC(scaled, digits = 1, format = "f", decimal.mark = ","), " mia."))
       }
     } else if (abs(val) >= 1e6) {
       scaled <- val / 1e6
       if (scaled == round(scaled)) {
         return(paste0(round(scaled), "M"))
       } else {
-        return(paste0(format(scaled, decimal.mark = ",", nsmall = 1), "M"))
+        return(paste0(formatC(scaled, digits = 1, format = "f", decimal.mark = ","), "M"))
       }
     } else if (abs(val) >= 1e3) {
       scaled <- val / 1e3
       if (scaled == round(scaled)) {
         return(paste0(round(scaled), "K"))
       } else {
-        return(paste0(format(scaled, decimal.mark = ",", nsmall = 1), "K"))
+        return(paste0(formatC(scaled, digits = 1, format = "f", decimal.mark = ","), "K"))
       }
     } else {
       # For values < 1000: show decimals only if present
       if (val == round(val)) {
         return(format(round(val), decimal.mark = ",", big.mark = "."))
       } else {
-        return(format(val, decimal.mark = ",", big.mark = ".", nsmall = 1))
+        return(formatC(val, digits = 1, format = "f", decimal.mark = ",", big.mark = "."))
       }
     }
   }
 
   # Rate formatting - kun decimaler hvis tilstede
+  # Bemærk: formatC med format="f" giver round-half-up (123.45 → 123,5) som
+  # matcher klinisk læsevaner. R's base round() bruger banker's rounding
+  # (123.45 → 123.4) som opfattes forvirrende for slut-brugere.
   if (y_unit == "rate") {
     if (val == round(val)) {
       return(format(round(val), decimal.mark = ","))
     } else {
-      return(format(val, decimal.mark = ",", nsmall = 1))
+      return(formatC(val, digits = 1, format = "f", decimal.mark = ","))
     }
   }
 
@@ -104,10 +108,10 @@ format_y_value <- function(val, y_unit, y_range = NULL) {
     return(format_time_composite(val))
   }
 
-  # Default formatting - dansk notation
+  # Default formatting - dansk notation med round-half-up (se rate-branch)
   if (val == round(val)) {
     return(format(round(val), decimal.mark = ","))
   } else {
-    return(format(val, decimal.mark = ",", nsmall = 1))
+    return(formatC(val, digits = 1, format = "f", decimal.mark = ","))
   }
 }


### PR DESCRIPTION
## Summary

Fixer bug i `format_y_value()` hvor `format(val, nsmall = 1)` returnerede fuld precision i stedet for afrundet 1-decimal output. Symptom: `format_y_value(123.456, "rate")` returnerede `"123,456"` i stedet for forventet `"123,5"`.

**Rod-årsag:** `nsmall` sikrer kun *minimum* decimaler, ikke maksimum. Koden manglede eksplicit rounding før formatering.

**Fix:** Byttet til `formatC(val, digits = 1, format = "f", decimal.mark = ",")` i rate/default/count-branches. `formatC` med `format="f"` giver round-half-up (123.45 → 123,5) som matcher klinisk læsevaner, modsat R's base `round()` der bruger banker's rounding (123.45 → 123,4).

## Scope

- **Rate-branch** (line 94): Primary fix for #236
- **Default/unknown-branch** (line 111): Primary fix for #236
- **Count-branch K/M/mia + <1000** (lines 63, 70, 77, 84): Preventivt — samme bug-mønster (fx `1555` → `"1,555K"` i stedet for `"1,6K"`). Ingen testfailures, men fikset for konsistens.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-label-formatting.R")` → 41/41 pass (tidligere 2 failures)
- [x] `testthat::test_dir(filter="label|y-axis")` → ingen regressioner
- [x] Manual check: `formatC(123.45, digits=1, format="f", decimal.mark=",")` → `"123,5"` ✓

## Relations

- Closes #236
- Part of paraply #239