### PR TITLE
fix(fonts): gør Mari font-registrering idempotent (#237)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,17 @@
   round-half-up (123.45 → 123,5) som matcher klinisk læsevaner, modsat R's
   base `round()` som bruger banker's rounding (123.45 → 123,4). 2 tests
   grønne (linje 41 og 87 i `test-label-formatting.R`).
+* **Mari font-registrering idempotent** (#237): `register_mari_font()`
+  afviste at registrere Mari hvis den allerede var installeret som
+  system-font (fx MacOS user fonts ~/Library/Fonts/), og genererede
+  ERROR-log "A system font called `Mari` already exists" ved hver
+  test-session-start. Fix: Tjek `systemfonts::system_fonts()` for
+  eksisterende Mari-family før registrering; spring over (idempotent)
+  hvis fonten allerede er tilgængelig. Primær symptom (ERROR-log)
+  elimineret. **Restcase:** "font family 'Mari' not found in PostScript
+  font database"-warnings ved plot-generering i PostScript-device
+  kontekst er separat — ligger i BFHtheme-ansvar og kræver cross-repo
+  eskalering (PostScript font-database er adskilt fra systemfonts).
 
 ## Interne ændringer (Fase 1 saneringsarbejde, #228/#229)
 

--- a/R/utils_font_registration.R
+++ b/R/utils_font_registration.R
@@ -178,6 +178,21 @@ register_mari_font <- function() {
     return(invisible(NULL))
   }
 
+  # Idempotens-guard: Hvis Mari allerede er installeret som system-font
+  # (fx MacOS user fonts), afviser systemfonts::register_font at registrere
+  # over — derfor springer vi over. Undgår spurious "already exists"-fejl
+  # ved gentagne test-sessions på dev-maskiner hvor Mari er systeminstalleret.
+  sys_fonts <- systemfonts::system_fonts()
+  if ("Mari" %in% sys_fonts$family) {
+    log_debug(
+      component = "[FONT_REGISTRATION]",
+      message = "Mari allerede tilgængelig som system-font — registrering sprunget over",
+      details = list(variants = sum(sys_fonts$family == "Mari"))
+    )
+    assign(".mari_registered", TRUE, envir = .GlobalEnv)
+    return(invisible(NULL))
+  }
+
   font_dir <- system.file(
     "templates/typst/bfh-template/fonts",
     package = "biSPCharts"


### PR DESCRIPTION
## Summary

Fixer `register_mari_font()` idempotens-bug der genererede spurious ERROR-log ved hver test-session på dev-maskiner hvor Mari er installeret som system-font (fx MacOS `~/Library/Fonts/`).

**Rod-årsag:** `systemfonts::register_font(name = "Mari", ...)` afviser at registrere over system-fonts og kaster "A system font called `Mari` already exists". Det er en korrekt guard i systemfonts, men vi burde tjekke først i stedet for at fange fejlen efterfølgende.

**Fix:** Check `systemfonts::system_fonts()$family` for eksisterende `"Mari"` før registrering. Hvis fonten allerede er tilgængelig, sæt guard-flag og return (idempotent).

## Effect

- ERROR-log "Registrer Mari fonts fejlede: A system font called `Mari` already exists" ved `devtools::load_all()` er elimineret
- WARN-log "Mari font-registrering fejlede" er elimineret
- BFHtheme finder stadig Mari via `system_fonts()` — fonten er tilgængelig uanset om vi "registrerer" den eller ej

## Restcase (separat)

Warnings "font family 'Mari' not found in PostScript font database" ved plot-generering i PostScript-device kontekst er **ikke** fixet af denne PR. Problemet er at PostScript font-database (`grDevices::postscriptFonts()`) er adskilt fra systemfonts, og BFHtheme skal registrere fonten begge steder. **Kræver cross-repo eskalering til BFHtheme.**

## Test plan

- [x] `devtools::load_all(".")` → ingen "already exists" ERROR i log
- [x] `testthat::test_file("tests/testthat/test-bfh-error-handling.R")` → ERROR-log elimineret; tilbageværende test-failure (line 247) er uafhængig (relateret til #240 compute_spc_results_bfh validation)
- [x] Fresh session: `register_mari_font()` detekterer Mari i `system_fonts()` og returnerer tidligt
- [x] Gentagne kald (2x, 3x) kaster ingen fejl

## Relations

- Closes #237
- Part of paraply #239
- Cross-repo follow-up: PostScript-warnings → BFHtheme