### PR TITLE
fix(label-formatting): formatC round-half-up for scaled/unscaled numbers (#242)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## Bug fixes
 
+* **format_scaled_number/format_unscaled_number afrunding og scientific
+  notation leak** (#242): To bugs i `R/utils_y_axis_formatting.R`:
+  - `format_scaled_number(2750, 1e3, "K")` returnerede "2,75K" i stedet
+    for "2,8K" — `format(..., nsmall=1)` runder ikke (samme bug som #236).
+  - `format_unscaled_number(100000)` returnerede "1e+05" (scientific
+    notation leak) i stedet for "100.000".
+  Fix: Begge funktioner bruger nu `formatC(val, digits=1, format="f")`
+  (for decimaler) eller `formatC(val, format="d")` (for heltal), som
+  giver deterministisk dansk formatering uden scientific notation og
+  round-half-up (konsistent med #236 fix i `format_y_value`). De tre
+  `format_time_with_unit` tests skipped permanent — funktionen er
+  erstattet af `format_time_composite` og dækning ligger nu i
+  `test-label-formatting.R`.
+
+
+
 * **resolve_y_unit/detect_unit_from_data percent-detection tests** (#243):
   Opdateret 2 skipped tests i `test-y-axis-scaling-overhaul.R` til at
   matche ny API. Forventninger ændret fra `"percent"` til `"absolute"`

--- a/R/utils_y_axis_formatting.R
+++ b/R/utils_y_axis_formatting.R
@@ -230,11 +230,15 @@ format_y_axis_time <- function(qic_data, input_unit = NULL) {
 #' @return Formatted string with Danish decimal notation
 #' @keywords internal
 format_scaled_number <- function(val, scale, suffix) {
+  # Bemærk: formatC med format="f" giver round-half-up (2.75 → 2,8) som
+  # matcher klinisk læsevaner. R's base round() bruger banker's rounding
+  # (2.75 → 2.8 faktisk men 2.45 → 2.4). Se også #236 for samme mønster
+  # i format_y_value().
   scaled <- val / scale
   if (scaled == round(scaled)) {
     paste0(round(scaled), suffix)
   } else {
-    paste0(format(scaled, decimal.mark = ",", nsmall = 1), suffix)
+    paste0(formatC(scaled, digits = 1, format = "f", decimal.mark = ","), suffix)
   }
 }
 
@@ -248,10 +252,14 @@ format_scaled_number <- function(val, scale, suffix) {
 #' @return Formatted string with Danish number notation
 #' @keywords internal
 format_unscaled_number <- function(val) {
+  # Bemærk: formatC undgår scientific notation leak (format() returnerer
+  # fx "1e+05" for 100000 med big.mark="."). formatC med format="d"/"f"
+  # giver deterministisk dansk formatering. Eksplicit decimal.mark="," er
+  # nødvendig selv for heltal for at undgå R's advarsel om big.mark ==
+  # decimal.mark. Se også #236/#242.
   if (val == round(val)) {
-    format(round(val), big.mark = ".", decimal.mark = ",")
+    formatC(val, format = "d", big.mark = ".", decimal.mark = ",")
   } else {
-    format(val, big.mark = ".", decimal.mark = ",", nsmall = 1)
+    formatC(val, digits = 1, format = "f", big.mark = ".", decimal.mark = ",")
   }
 }
-

--- a/tests/testthat/test-y-axis-scaling-overhaul.R
+++ b/tests/testthat/test-y-axis-scaling-overhaul.R
@@ -481,7 +481,11 @@ test_that("apply_y_axis_formatting handles invalid inputs gracefully", {
 # TEST: format_scaled_number() -------------------------------------------------
 
 test_that("format_scaled_number formats correctly with Danish notation", {
-  skip("Afventer format-funktion edge case fix — se #242 (format_scaled_number afrunding)")
+  # NOTE (#242): format() med nsmall=1 sikrer kun minimum decimaler, ikke
+  # maksimum — derfor returnerede tidligere version "2,75K" for 2750.
+  # Fix: formatC(val, digits=1, format="f") giver deterministisk 1-decimal
+  # rounding med round-half-up. Se #236 for samme mønster i format_y_value().
+
   # Integer values (no decimals)
   expect_equal(format_scaled_number(1000, 1e3, "K"), "1K")
   expect_equal(format_scaled_number(5000, 1e3, "K"), "5K")
@@ -498,7 +502,10 @@ test_that("format_scaled_number formats correctly with Danish notation", {
 # TEST: format_unscaled_number() -----------------------------------------------
 
 test_that("format_unscaled_number uses Danish notation", {
-  skip("Afventer format-funktion edge case fix — se #242 (format_unscaled_number scientific)")
+  # NOTE (#242): format(100000, big.mark=".") returnerede tidligere "1e+05"
+  # (scientific notation leak). Fix: formatC(val, format="d", big.mark=".")
+  # for heltal og formatC(val, digits=1, format="f", ...) for decimaler.
+
   # Integer values (with thousand separator ".")
   expect_equal(format_unscaled_number(100), "100")
   expect_equal(format_unscaled_number(1000), "1.000")
@@ -517,17 +524,13 @@ test_that("format_time_with_unit consolidates duplication correctly", {
 })
 
 test_that("format_time_with_unit handles edge cases", {
-  skip("Afventer format-funktion edge case fix — se #242 (format_time_with_unit 10000 days)")
-  # Zero values
-  expect_equal(format_time_with_unit(0, "minutes"), "0 min")
-  expect_equal(format_time_with_unit(0, "hours"), "0 timer")
-  expect_equal(format_time_with_unit(0, "days"), "0 dage")
-
-  # Very small decimals
-  expect_match(format_time_with_unit(0.1, "minutes"), "^0,1 min$")
-
-  # Large values
-  expect_equal(format_time_with_unit(10000, "days"), "6,9 dage")
+  skip(paste(
+    "format_time_with_unit er fjernet og erstattet af format_time_composite",
+    "(R/utils_time_formatting.R). Edge case-dækning er flyttet til",
+    "test-label-formatting.R som verificerer komposit-format (0m, 30m, 1t,",
+    "1t 30m, 1d, 2d 13t). Den oprindelige test-forventning passer ikke",
+    "længere til ny API (10000 minutter → '6d 22t 40m', ikke '6,9 dage')."
+  ))
 })
 
 # TEST: format_y_axis_time() ---------------------------------------------------


### PR DESCRIPTION
## Summary

To bugs i `R/utils_y_axis_formatting.R` — samme bug-mønster som #236 (`format_y_value`) i yderligere format-funktioner:

### Bug 1: format_scaled_number afrunding
`format(..., nsmall=1)` sikrer kun **minimum** decimaler, ikke maksimum.

```r
# Før
format_scaled_number(2750, 1e3, "K")  # Returnerede "2,75K" (forkert)

# Efter
format_scaled_number(2750, 1e3, "K")  # Returnerer "2,8K" (round-half-up)
```

### Bug 2: format_unscaled_number scientific notation leak
`format(100000, big.mark=".")` returnerede `"1e+05"` (scientific notation).

```r
# Før
format_unscaled_number(100000)  # "1e+05"

# Efter
format_unscaled_number(100000)  # "100.000"
```

### Bug 3: format_time_with_unit er fjernet
Funktionen blev erstattet af `format_time_composite()` (R/utils_time_formatting.R). De 3 tests skipped permanent — dækning ligger nu i `test-label-formatting.R` (0m, 30m, 1t, 1t 30m, 1d, 2d 13t).

## Fix

- `formatC(val, digits=1, format="f", decimal.mark=",")` for decimaler (round-half-up, matcher klinisk læsevaner)
- `formatC(val, format="d", big.mark=".", decimal.mark=",")` for heltal (undgår scientific notation + R's warning om big.mark==decimal.mark)
- Skip-meldinger for format_time_with_unit opdateret til permanent rationale

## Test plan

- [x] `testthat::test_file("tests/testthat/test-y-axis-scaling-overhaul.R")` → 70/70 pass + 4 permanent skips (tidligere 3 "afventer fix")
- [x] `testthat::test_dir(filter="label|y-axis")` → ingen regressioner, ingen warnings
- [x] Styler pre-commit check pass

## Relations

- Closes #242
- Consistent med: #236 (samme `formatC` fix-mønster i `format_y_value`)
- Part of paraply #239