### PR TITLE
chore(review): adressér LOW findings L1-L14 fra PR #246 review (#247 delvis)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,30 @@
 # biSPCharts 0.2.0-dev (development)
 
+## Interne ændringer
+
+* **Test-hygiene L1-L14 (#247):** Addresserer LOW findings fra automatisk review
+  af PR #246. Ingen adfærdsændringer i produktionskode.
+  - L1: `rnorm(10)` i helper erstattet med `withr::with_seed(42, rnorm(10))` for
+    deterministisk adfærd
+  - L2: `%||%`-definition i `run_e2e.R` flyttet til toppen (before-use)
+  - L3: `sapply()` → `vapply(..., logical(1), ...)` i `helper-bootstrap.R`
+  - L4: `@export` erstattet med `@noRd` i `dev/lintr_seed_rng.R`
+  - L5: TODO tilføjet — output$plot_available-binding-test deferret til separat issue
+  - L6: Parametriserede security-tests tilføjet for SQL injection, path traversal
+    og formula injection (#244)
+  - L7: `skip_if_not(exists(...))` → `expect_true(exists(...))` i
+    `test-event-context-handlers.R`
+  - L8: Kommentar om `local_mocked_bindings`-begrænsning tilføjet i
+    `helper-bootstrap.R`
+  - L9: TODO tilføjet — warnings write-path test deferret til separat issue
+  - L10: `autoSaveAppState`-kald wrappet i `shiny::isolate()` i test
+  - L11: Symmetritests for `handle_data_change_context` og
+    `handle_session_restore_context` med `has_data=FALSE` tilføjet
+  - L12: `Filter(function(x) ...)` → `purrr::keep(lints, ~ ...)` i
+    `dev/publish_prepare.R`
+  - L13: `library()` wrappet i `suppressPackageStartupMessages()` i e2e/setup.R
+  - L14: No-op — allerede fixet i `bda2a0a`
+
 ## Security
 
 * **Path traversal test-dækning** (#244): To skipped tests i

--- a/dev/lintr_seed_rng.R
+++ b/dev/lintr_seed_rng.R
@@ -25,7 +25,7 @@
 #' Linter: detekter rng-kald uden set.seed i test_that-blokke
 #'
 #' @return En `lintr::Linter`-funktion.
-#' @export
+#' @noRd
 seed_rng_linter <- function() {
   # Random-funktioner der kræver seeding
   rng_functions <- c(

--- a/dev/publish_prepare.R
+++ b/dev/publish_prepare.R
@@ -315,11 +315,11 @@ phase_manifest <- function() {
     lint_res <- tryCatch(
       {
         lints <- lintr::lint_package()
-        errors <- Filter(function(x) x$type == "error", lints)
+        errors <- purrr::keep(lints, ~ .x$type == "error")
         if (length(errors) > 0) {
           stop(sprintf("%d lintr ERROR(s) fundet", length(errors)))
         }
-        warnings_ct <- length(Filter(function(x) x$type == "warning", lints))
+        warnings_ct <- length(purrr::keep(lints, ~ .x$type == "warning"))
         list(ok = TRUE, warnings = warnings_ct)
       },
       error = function(e) e

--- a/tests/e2e/run_e2e.R
+++ b/tests/e2e/run_e2e.R
@@ -21,6 +21,8 @@
 #   1 = E2E-fejl efter retries
 # ==============================================================================
 
+`%||%` <- function(x, y) if (is.null(x)) y else x
+
 run_e2e <- function(retry_count = NULL) {
   retry_count <- retry_count %||% as.integer(Sys.getenv("E2E_RETRY", "2"))
   if (is.na(retry_count) || retry_count < 0) retry_count <- 2L
@@ -121,8 +123,6 @@ run_e2e <- function(retry_count = NULL) {
     Sys.sleep(5)
   }
 }
-
-`%||%` <- function(x, y) if (is.null(x)) y else x
 
 if (!interactive()) {
   run_e2e()

--- a/tests/e2e/setup.R
+++ b/tests/e2e/setup.R
@@ -8,8 +8,8 @@
 # §4.1 af harden-test-suite-regression-gate.
 # ==============================================================================
 
-library(testthat)
-library(shiny)
+suppressPackageStartupMessages(library(testthat))
+suppressPackageStartupMessages(library(shiny))
 
 # ------------------------------------------------------------------------------
 # Chrome-availability gate

--- a/tests/testthat/helper-bootstrap.R
+++ b/tests/testthat/helper-bootstrap.R
@@ -20,6 +20,13 @@ library(testthat)
 # Shiny aliases
 # ------------------------------------------------------------------------------
 # Gør core Shiny-funktioner tilgængelige uden library(shiny) i hver testfil.
+#
+# ADVARSEL: Disse aliaser assigneres direkte i globalenv via `<-`.
+# `testthat::local_mocked_bindings()` kan IKKE intercepte funktioner der er
+# bundet på denne måde — den patcher pakke-namespace, ikke globalenv-bindinger.
+# Brug `testthat::local_mocked_bindings(.package = "shiny", ...)` for at mocke
+# den originale shiny-funktion, eller omskriv kald til `shiny::isolate()` etc.
+# i den kode der skal mockes.
 
 isolate <- shiny::isolate
 reactive <- shiny::reactive
@@ -77,7 +84,7 @@ if (!package_already_loaded()) {
 # Conditional source af ekstra helpers hvis pkgload ikke eksporterede dem
 conditionally_source_helpers <- function() {
   helper_functions <- c("observer_manager", "create_empty_session_data")
-  functions_missing <- !sapply(helper_functions, exists, mode = "function")
+  functions_missing <- !vapply(helper_functions, exists, logical(1), mode = "function")
 
   if (any(functions_missing)) {
     additional_helper_files <- c(

--- a/tests/testthat/test-event-context-handlers.R
+++ b/tests/testthat/test-event-context-handlers.R
@@ -55,7 +55,7 @@ create_handler_app_state <- function(has_data = TRUE) {
   state <- new.env(parent = emptyenv())
   state$data <- new.env(parent = emptyenv())
   state$data$current_data <- if (has_data) {
-    data.frame(x = 1:10, y = rnorm(10))
+    data.frame(x = 1:10, y = withr::with_seed(42, rnorm(10)))
   } else {
     NULL
   }
@@ -67,7 +67,7 @@ create_handler_app_state <- function(has_data = TRUE) {
 # ============================================================================
 
 test_that("classify_update_context returnerer 'general' ved NULL input (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   expect_equal(classify_update_context(NULL), "general")
   expect_equal(classify_update_context(list()), "general")
@@ -75,7 +75,7 @@ test_that("classify_update_context returnerer 'general' ved NULL input (§2.2.3)
 })
 
 test_that("classify_update_context identificerer 'load' ved upload-kontekster (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   expect_equal(classify_update_context(list(context = "file_upload")), "load")
   expect_equal(classify_update_context(list(context = "data_loaded")), "load")
@@ -84,7 +84,7 @@ test_that("classify_update_context identificerer 'load' ved upload-kontekster (�
 })
 
 test_that("classify_update_context identificerer 'table_edit' exakt (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   # Kun exact match — skal ikke matche andre "edit"-varianter
   expect_equal(
@@ -99,7 +99,7 @@ test_that("classify_update_context identificerer 'table_edit' exakt (§2.2.3)", 
 })
 
 test_that("classify_update_context identificerer 'session_restore' exakt (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   expect_equal(
     classify_update_context(list(context = "session_restore")),
@@ -113,7 +113,7 @@ test_that("classify_update_context identificerer 'session_restore' exakt (§2.2.
 })
 
 test_that("classify_update_context identificerer 'data_change' ved edit/modify (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   expect_equal(
     classify_update_context(list(context = "data_change")),
@@ -130,7 +130,7 @@ test_that("classify_update_context identificerer 'data_change' ved edit/modify (
 })
 
 test_that("classify_update_context falder tilbage til 'general' for ukendte (§2.2.3)", {
-  skip_if_not(exists("classify_update_context", mode = "function"))
+  expect_true(exists("classify_update_context", mode = "function"))
 
   expect_equal(
     classify_update_context(list(context = "something_random")),
@@ -144,7 +144,7 @@ test_that("classify_update_context falder tilbage til 'general' for ukendte (§2
 # ============================================================================
 
 test_that("handle_load_context triggerer auto-detection når data findes (§2.2.3)", {
-  skip_if_not(exists("handle_load_context", mode = "function"))
+  expect_true(exists("handle_load_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -159,7 +159,7 @@ test_that("handle_load_context triggerer auto-detection når data findes (§2.2.
 })
 
 test_that("handle_load_context springer auto-detection over uden data (§2.2.3)", {
-  skip_if_not(exists("handle_load_context", mode = "function"))
+  expect_true(exists("handle_load_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = FALSE)
@@ -176,7 +176,7 @@ test_that("handle_load_context springer auto-detection over uden data (§2.2.3)"
 # ============================================================================
 
 test_that("handle_table_edit_context triggerer navigation+viz (§2.2.3)", {
-  skip_if_not(exists("handle_table_edit_context", mode = "function"))
+  expect_true(exists("handle_table_edit_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -198,7 +198,7 @@ test_that("handle_table_edit_context triggerer navigation+viz (§2.2.3)", {
 # ============================================================================
 
 test_that("handle_data_change_context triggerer choices+navigation+viz (§2.2.3)", {
-  skip_if_not(exists("handle_data_change_context", mode = "function"))
+  expect_true(exists("handle_data_change_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -234,12 +234,35 @@ test_that("handle_data_change_context triggerer choices+navigation+viz (§2.2.3)
   )
 })
 
+test_that("handle_data_change_context kører uden fejl ved has_data=FALSE (§2.2.3)", {
+  expect_true(exists("handle_data_change_context", mode = "function"))
+
+  spy <- create_spy_emit()
+  app_state <- create_handler_app_state(has_data = FALSE)
+
+  testthat::local_mocked_bindings(
+    update_column_choices_unified = function(...) invisible(NULL)
+  )
+
+  expect_no_error(
+    handle_data_change_context(
+      app_state = app_state,
+      emit = spy$emit,
+      input = list(),
+      output = list(),
+      session = NULL,
+      ui_service = NULL,
+      context = "column_change"
+    )
+  )
+})
+
 # ============================================================================
 # handle_general_context
 # ============================================================================
 
 test_that("handle_general_context triggerer kun choices (ingen navigation/viz) (§2.2.3)", {
-  skip_if_not(exists("handle_general_context", mode = "function"))
+  expect_true(exists("handle_general_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -276,7 +299,7 @@ test_that("handle_general_context triggerer kun choices (ingen navigation/viz) (
 # ============================================================================
 
 test_that("handle_session_restore_context triggerer choices+navigation+viz (§2.2.3)", {
-  skip_if_not(exists("handle_session_restore_context", mode = "function"))
+  expect_true(exists("handle_session_restore_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -311,12 +334,34 @@ test_that("handle_session_restore_context triggerer choices+navigation+viz (§2.
   )
 })
 
+test_that("handle_session_restore_context kører uden fejl ved has_data=FALSE (§2.2.3)", {
+  expect_true(exists("handle_session_restore_context", mode = "function"))
+
+  spy <- create_spy_emit()
+  app_state <- create_handler_app_state(has_data = FALSE)
+
+  testthat::local_mocked_bindings(
+    update_column_choices_unified = function(...) invisible(NULL)
+  )
+
+  expect_no_error(
+    handle_session_restore_context(
+      app_state = app_state,
+      emit = spy$emit,
+      input = list(),
+      output = list(),
+      session = NULL,
+      ui_service = NULL
+    )
+  )
+})
+
 # ============================================================================
 # handle_data_update_by_context (dispatcher)
 # ============================================================================
 
 test_that("handle_data_update_by_context dispatcher ruter 'load' korrekt (§2.2.3)", {
-  skip_if_not(exists("handle_data_update_by_context", mode = "function"))
+  expect_true(exists("handle_data_update_by_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -341,7 +386,7 @@ test_that("handle_data_update_by_context dispatcher ruter 'load' korrekt (§2.2.
 })
 
 test_that("handle_data_update_by_context dispatcher ruter 'table_edit' korrekt (§2.2.3)", {
-  skip_if_not(exists("handle_data_update_by_context", mode = "function"))
+  expect_true(exists("handle_data_update_by_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -365,7 +410,7 @@ test_that("handle_data_update_by_context dispatcher ruter 'table_edit' korrekt (
 })
 
 test_that("handle_data_update_by_context dispatcher ruter 'session_restore' korrekt (§2.2.3)", {
-  skip_if_not(exists("handle_data_update_by_context", mode = "function"))
+  expect_true(exists("handle_data_update_by_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -394,7 +439,7 @@ test_that("handle_data_update_by_context dispatcher ruter 'session_restore' korr
 })
 
 test_that("handle_data_update_by_context dispatcher fallback til 'general' (§2.2.3)", {
-  skip_if_not(exists("handle_data_update_by_context", mode = "function"))
+  expect_true(exists("handle_data_update_by_context", mode = "function"))
 
   spy <- create_spy_emit()
   app_state <- create_handler_app_state(has_data = TRUE)
@@ -434,7 +479,7 @@ test_that("handle_data_update_by_context dispatcher fallback til 'general' (§2.
 # ============================================================================
 
 test_that("handle_load_context håndterer manglende data-felt defensivt (§2.2.3)", {
-  skip_if_not(exists("handle_load_context", mode = "function"))
+  expect_true(exists("handle_load_context", mode = "function"))
 
   spy <- create_spy_emit()
   # app_state uden data-felt

--- a/tests/testthat/test-mod-spc-chart-comprehensive.R
+++ b/tests/testthat/test-mod-spc-chart-comprehensive.R
@@ -402,6 +402,9 @@ describe("Error Handling", {
     })
   })
 
+  # TODO(#247-L9): Refaktorér til at verificere modulets write-path —
+  # test skal trigge modulet til at skrive plot_warnings via reactive,
+  # ikke pre-populere app_state direkte og verificere samme strenge.
   it("sets appropriate warnings on validation failure", {
     app_state <- create_mock_app_state()
 

--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -168,6 +168,10 @@ test_that("mod_export_server requires app_state parameter", {
 
 # §2.3.2 (plot-available reactive): reagerer på app_state plot-data
 # Leveret i §2.3.2 (#230)
+#
+# TODO(#247-L5): Refaktorér til at verificere output$plot_available-binding
+# direkte via testServer i stedet for at evaluere logikken via shiny::isolate().
+# Kræver at output-id'et eksponeres og at testServer understøtter det korrekt.
 test_that("mod_export_server plot_available reflects app_state (§2.3.2)", {
   # TEST: output$plot_available er TRUE når data + y_column er sat.
   # Verificérer reactive-kontrakten: output opdateres når app_state ændrer sig.

--- a/tests/testthat/test-negative-assertions-phase2-5.R
+++ b/tests/testthat/test-negative-assertions-phase2-5.R
@@ -153,10 +153,10 @@ test_that("autoSaveAppState deaktiverer auto_save ved quota-exceeded (§2.5.3)",
   test_data <- data.frame(x = 1:5, y = 6:10)
   metadata <- list(x_column = "x", y_column = "y", chart_type = "run")
 
-  autoSaveAppState(
+  shiny::isolate(autoSaveAppState(
     failing_session, test_data, metadata,
     app_state = app_state
-  )
+  ))
 
   # Efter quota-fejl skal auto_save_enabled være FALSE
   expect_false(
@@ -473,4 +473,75 @@ test_that("compute_spc_results_bfh kaster fejl ved ugyldig chart_type (§2.5.3)"
   expect_true(error_caught || is.null(result),
     label = "Ugyldig chart_type skal give error eller NULL"
   )
+})
+
+# ------------------------------------------------------------------------------
+# 7. Security: SQL injection, path traversal, formula injection (#244)
+# ------------------------------------------------------------------------------
+
+test_that("sanitize_column_name saniterer SQL injection-strings (§2.5.3, #244)", {
+  skip_if_not(exists("sanitize_column_name", mode = "function"))
+
+  # sanitize_column_name fjerner ikke-tilladte tegn (allowed: A-Za-z0-9_æøåÆØÅ .-)
+  # og HTML-escaper quotes. Kontrakten er at output er ændret og ikke identisk
+  # med farlige injection-strings.
+  sql_inputs <- c(
+    "'; DROP TABLE users; --",
+    "1 OR 1=1",
+    "admin'--"
+  )
+
+  for (input in sql_inputs) {
+    result <- sanitize_column_name(input)
+    # Output skal IKKE være identisk med input (sanitering er sket)
+    expect_false(
+      identical(result, input),
+      label = paste0("SQL injection-string ikke saniteret (output == input): ", input)
+    )
+    # Output må ikke indeholde rå enkeltcitater (de HTML-escapes til &#39;)
+    expect_false(
+      grepl("'", result, fixed = TRUE),
+      label = paste0("Rå enkeltcitat overlevede sanitering: ", input)
+    )
+  }
+})
+
+test_that("validate_file_extension afviser path traversal-forsøg (§2.5.3, #244)", {
+  skip_if_not(exists("validate_file_extension", mode = "function"))
+
+  traversal_inputs <- c(
+    "../../../etc/passwd",
+    "..%2F..%2Fetc",
+    "./../secret.R",
+    "csv/../../../root"
+  )
+
+  for (input in traversal_inputs) {
+    result <- validate_file_extension(input)
+    expect_false(result,
+      label = paste0("Path traversal-input ikke afvist: ", input)
+    )
+  }
+})
+
+test_that("sanitize_csv_output blokerer formula injection-strings (§2.5.3, #244)", {
+  skip_if_not(exists("sanitize_csv_output", mode = "function"))
+
+  formula_inputs <- c("=CMD()", "+HYPERLINK()", "-2+3+cmd|", "@SUM(A1:A100)")
+
+  df <- data.frame(
+    label = formula_inputs,
+    value = seq_along(formula_inputs),
+    stringsAsFactors = FALSE
+  )
+
+  result <- sanitize_csv_output(df)
+
+  for (i in seq_along(formula_inputs)) {
+    # Saniteret output skal starte med ' (tvungen tekstmode) hvis formel
+    expect_true(
+      startsWith(result$label[i], "'"),
+      label = paste0("Formula injection ikke saniteret: ", formula_inputs[i])
+    )
+  }
 })


### PR DESCRIPTION
## Baggrund

Adresserer LOW severity findings (L1-L14) fra automatisk review (4 agents) af PR #246. HIGH findings fixet i `bda2a0a`. MEDIUM findings (M1-M5) håndteres i **separat PR** — ikke scope her.

## Status per finding

- [x] **L1** — `withr::with_seed(42, rnorm(10))` i `create_handler_app_state` helper
- [x] **L2** — `%||%`-definition flyttet til toppen af `run_e2e.R`
- [x] **L3** — `sapply()` → `vapply(..., logical(1), ...)` i `helper-bootstrap.R`
- [x] **L4** — `@export` → `@noRd` i `dev/lintr_seed_rng.R`
- [-] **L5** — Deferret: output$plot_available-binding-test kræver arkitektur-beslutning om testServer-migration (TODO-kommentar tilføjet)
- [x] **L6** — Parametriserede security-tests tilføjet: SQL injection, path traversal, formula injection (#244)
- [x] **L7** — `skip_if_not(exists(...))` → `expect_true(exists(...))` (17 guards i event-context-handlers)
- [x] **L8** — Kommentar om `local_mocked_bindings`-begrænsning tilføjet i `helper-bootstrap.R`
- [-] **L9** — Deferret: warnings write-path test kræver dybere modul-refactor (TODO-kommentar tilføjet)
- [x] **L10** — `autoSaveAppState`-kald wrappet i `shiny::isolate()` i test
- [x] **L11** — Symmetritests for `handle_data_change_context` og `handle_session_restore_context` med `has_data=FALSE` tilføjet
- [x] **L12** — `Filter(function(x) ...)` → `purrr::keep(lints, ~ ...)` i `dev/publish_prepare.R`
- [x] **L13** — `library()` wrappet i `suppressPackageStartupMessages()` i `e2e/setup.R`
- [=] **L14** — No-op: allerede fixet i `bda2a0a` (exit 2 → exit 0 ved manglende Rscript)

## MEDIUM findings

M1-M5 håndteres i separat PR (ikke scope for denne).

## Test plan

- [x] `testthat::test_dir('tests/testthat', filter='event-context|bootstrap|negative-assertions')` — 0 fails, 126 pass
- [x] Pre-existing 3 failures i `test-mod_export.R` bekræftet som pre-existing (eksisterede før denne branch)
- [x] Ingen produktionskode ændret

Lukker delvist #247.