### PR TITLE
fix(validation): tilføj validate_spc_inputs helper til facaden (#240)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,17 @@
 
 ## Bug fixes
 
+* **compute_spc_results_bfh() input-validering** (#240): Facaden i
+  `R/fct_spc_bfh_facade.R` manglede eksplicit input-validering med danske
+  fejlbeskeder — 12 tests var skipped fordi funktionen ikke kastede fejl
+  ved ugyldige parametre. Fix: ny `validate_spc_inputs()`-helper med 11
+  kontroller kørt FØR `safe_operation()` (så fejl propagerer til caller
+  i stedet for at blive opslugt). Dækker: `data`/`x_var`/`y_var`/
+  `chart_type` obligatorisk, `chart_type` i `SUPPORTED_CHART_TYPES_BFH`,
+  `n_var` påkrævet for p/u/pp/up-kort, kolonner eksisterer i `data`,
+  `y_var` numerisk eller konverterbar, ikke-tom data, min. 2 rækker,
+  `y_var` ikke udelukkende NA. Alle 12 tests grønne.
+
 * **`log_error`-kald med ugyldige argumenter (#245):** `fct_spc_plot_generation.R`
   kaldte `log_error()` med `session = NULL` og `show_user = TRUE` som ikke
   eksisterer i logging-API'et — medførte at alle `generateSPCPlot()`-tests

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -11,6 +11,121 @@
 # 4. Output standardization (via fct_spc_bfh_output)
 # 5. Anhøj metadata beregning (via fct_spc_bfh_signals)
 
+#' Valider input til compute_spc_results_bfh()
+#'
+#' Intern hjælpefunktion der tjekker alle obligatoriske parametre og
+#' data-egenskaber FØR safe_operation() kaldes. Fejl propagerer direkte
+#' til caller med danske brugervenlige beskeder.
+#'
+#' @param data data.frame eller NULL
+#' @param x_var character eller NULL
+#' @param y_var character eller NULL
+#' @param chart_type character eller NULL
+#' @param n_var character eller NULL
+#' @return Usynlig NULL (kaster fejl ved ugyldig input)
+#' @keywords internal
+validate_spc_inputs <- function(data, x_var, y_var, chart_type, n_var = NULL) {
+  # 1. data er påkrævet og skal være data.frame
+  if (is.null(data)) {
+    stop("data parameter er p\u00e5kr\u00e6vet (data required): m\u00e5 ikke v\u00e6re NULL")
+  }
+  if (!is.data.frame(data)) {
+    stop("data skal v\u00e6re en data.frame")
+  }
+
+  # 2. x_var er påkrævet
+  if (is.null(x_var) || !nzchar(trimws(x_var))) {
+    stop("x_var parameter er p\u00e5kr\u00e6vet (x_var required): angiv kolonnenavn for x-aksen")
+  }
+
+  # 3. y_var er påkrævet
+  if (is.null(y_var) || !nzchar(trimws(y_var))) {
+    stop("y_var parameter er p\u00e5kr\u00e6vet (y_var required): angiv kolonnenavn for m\u00e5lekolonnen")
+  }
+
+  # 4. chart_type er påkrævet
+  if (is.null(chart_type) || !nzchar(trimws(chart_type))) {
+    stop("chart_type parameter er p\u00e5kr\u00e6vet (chart_type required)")
+  }
+
+  # 5. chart_type skal v\u00e6re en understøttet type
+  ct_normalized <- tolower(trimws(chart_type))
+  if (!ct_normalized %in% SUPPORTED_CHART_TYPES_BFH) {
+    stop(paste0(
+      "chart_type '", chart_type, "' er invalid (ugyldig diagramtype). ",
+      "Must be one of: ",
+      paste(SUPPORTED_CHART_TYPES_BFH, collapse = ", ")
+    ))
+  }
+
+  # 6. n_var er påkrævet for P-, U-kort (og pp, up)
+  if (ct_normalized %in% c("p", "pp", "u", "up") && is.null(n_var)) {
+    stop(paste0(
+      "n_var (denominator) required for ", ct_normalized, "-kort. ",
+      "Angiv kolonnenavnet for n\u00e6vneren."
+    ))
+  }
+
+  # 7. x_var og y_var skal eksistere som kolonner i data
+  if (!x_var %in% names(data)) {
+    stop(paste0("Kolonnen '", x_var, "' blev ikke fundet i data (missing column: x_var)"))
+  }
+  if (!y_var %in% names(data)) {
+    stop(paste0("Kolonnen '", y_var, "' blev ikke fundet i data (missing column: y_var)"))
+  }
+  if (!is.null(n_var) && !n_var %in% names(data)) {
+    stop(paste0("Kolonnen '", n_var, "' blev ikke fundet i data (missing column: n_var)"))
+  }
+
+  # 8. y_var skal v\u00e6re numerisk (eller konverterbar)
+  y_vals <- data[[y_var]]
+  if (!is.numeric(y_vals) && !all(is.na(suppressWarnings(as.numeric(as.character(y_vals)))))) {
+    # Tjek om det slet ikke kan konverteres til numerisk
+    converted <- suppressWarnings(as.numeric(as.character(y_vals)))
+    if (all(is.na(converted)) && !all(is.na(y_vals))) {
+      stop(paste0(
+        "Kolonnen '", y_var, "' indeholder ikke-numeriske v\u00e6rdier og kan ikke konverteres. ",
+        "Kolonnen skal indeholde tal (numeric/convert)."
+      ))
+    }
+  }
+  # Ekstra tjek: eksplicit ikke-numerisk character kolonne
+  if (is.character(y_vals) || is.factor(y_vals)) {
+    converted <- suppressWarnings(as.numeric(as.character(y_vals)))
+    if (all(is.na(converted)) && any(!is.na(y_vals))) {
+      stop(paste0(
+        "Kolonnen '", y_var, "' indeholder ikke-numeriske v\u00e6rdier og kan ikke konverteres (invalid). ",
+        "Kolonnen skal indeholde tal."
+      ))
+    }
+  }
+
+  # 9. data m\u00e5 ikke v\u00e6re tom
+  if (nrow(data) == 0) {
+    stop("Data er tomt (empty): ingen r\u00e6kker fundet. Upload data f\u00f8rst.")
+  }
+
+  # 10. Mindst \u00e9t datapunkt kræves (minimum 2 for meningsfuld SPC)
+  if (nrow(data) < 2) {
+    stop(paste0(
+      "Utilstr\u00e6kkelig data: ", nrow(data), " r\u00e6kke(r). ",
+      "Minimum 2 datapunkter kr\u00e6ves for SPC-analyse (too few/insufficient)."
+    ))
+  }
+
+  # 11. y_var m\u00e5 ikke udelukkende best\u00e5 af NA
+  y_vals <- data[[y_var]]
+  if (all(is.na(y_vals))) {
+    stop(paste0(
+      "Kolonnen '", y_var, "' indeholder udelukkende NA-v\u00e6rdier (all NA/no valid values). ",
+      "Mindst \u00e9n g\u00e6ldig v\u00e6rdi er p\u00e5kr\u00e6vet."
+    ))
+  }
+
+  invisible(NULL)
+}
+
+
 #' Compute SPC Results Using BFHchart Backend
 #'
 #' Primary facade function that wraps BFHchart functionality with biSPCharts conventions.
@@ -155,23 +270,19 @@ compute_spc_results_bfh <- function(
   app_state = NULL,
   ...
 ) {
+  # Validering UDEN safe_operation — fejl skal propagere til caller (fx testthat)
+  validate_spc_inputs(
+    data = if (missing(data)) NULL else data,
+    x_var = if (missing(x_var)) NULL else x_var,
+    y_var = if (missing(y_var)) NULL else y_var,
+    chart_type = if (missing(chart_type)) NULL else chart_type,
+    n_var = n_var
+  )
+
   safe_operation(
     operation_name = "BFHchart SPC computation",
     code = {
-      # 1. Validate required parameters
-      if (missing(data) || is.null(data)) {
-        stop("data parameter is required")
-      }
-      if (missing(x_var) || is.null(x_var)) {
-        stop("x_var parameter is required")
-      }
-      if (missing(y_var) || is.null(y_var)) {
-        stop("y_var parameter is required")
-      }
-      if (missing(chart_type) || is.null(chart_type)) {
-        stop("chart_type parameter is required")
-      }
-
+      # 1. (Validering sker i validate_spc_inputs() FØR safe_operation)
       # 1b. Cache key generation (before expensive validation)
       # Extract parameters for cache key
       extra_params <- list(...)
@@ -491,9 +602,9 @@ compute_spc_results_bfh <- function(
       # 90 timer → label viser "3d 18t".
       original_y_unit <- extra_params$y_axis_unit %||% "count"
       if (is_time_unit(original_y_unit) &&
-          !is.null(target_text) &&
-          !is.null(target_value) &&
-          length(target_value) > 0) {
+        !is.null(target_text) &&
+        !is.null(target_value) &&
+        length(target_value) > 0) {
         operator_match <- regmatches(
           target_text,
           regexpr("^[<>=]+", target_text)

--- a/tests/testthat/test-spc-bfh-service.R
+++ b/tests/testthat/test-spc-bfh-service.R
@@ -188,7 +188,6 @@ test_that("compute_spc_results_bfh() handles S charts (standard deviation)", {
 # Parameter Validation Tests --------------------------------------------------
 
 test_that("compute_spc_results_bfh() requires data parameter", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende data)")
   expect_error(
     compute_spc_results_bfh(
       x_var = "month",
@@ -201,7 +200,6 @@ test_that("compute_spc_results_bfh() requires data parameter", {
 })
 
 test_that("compute_spc_results_bfh() requires x_var parameter", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende x_var)")
   data <- create_test_data(n_rows = 10)
 
   expect_error(
@@ -216,7 +214,6 @@ test_that("compute_spc_results_bfh() requires x_var parameter", {
 })
 
 test_that("compute_spc_results_bfh() requires y_var parameter", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende y_var)")
   data <- create_test_data(n_rows = 10)
 
   expect_error(
@@ -231,7 +228,6 @@ test_that("compute_spc_results_bfh() requires y_var parameter", {
 })
 
 test_that("compute_spc_results_bfh() requires chart_type parameter", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende chart_type)")
   data <- create_test_data(n_rows = 10)
 
   expect_error(
@@ -246,7 +242,6 @@ test_that("compute_spc_results_bfh() requires chart_type parameter", {
 })
 
 test_that("compute_spc_results_bfh() validates chart_type values", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (ugyldigt chart_type)")
   data <- create_test_data(n_rows = 10)
 
   expect_error(
@@ -262,7 +257,6 @@ test_that("compute_spc_results_bfh() validates chart_type values", {
 })
 
 test_that("compute_spc_results_bfh() requires n_var for P charts", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende n_var for P-chart)")
   data <- create_test_data(n_rows = 20, chart_type = "p")
 
   # P charts need denominator
@@ -280,7 +274,6 @@ test_that("compute_spc_results_bfh() requires n_var for P charts", {
 })
 
 test_that("compute_spc_results_bfh() requires n_var for U charts", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende n_var for U-chart)")
   data <- create_test_data(n_rows = 20, chart_type = "u")
 
   expect_error(
@@ -381,7 +374,6 @@ test_that("compute_spc_results_bfh() integrates with parse_and_validate_spc_data
 })
 
 test_that("compute_spc_results_bfh() handles validation errors gracefully", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (ikke-numerisk y)")
   # Create invalid data (non-numeric values)
   data <- tibble::tibble(
     month = 1:10,
@@ -450,7 +442,6 @@ test_that("compute_spc_results_bfh() qic_data has correct column types", {
 # "Error Handling Tests")
 
 test_that("compute_spc_results_bfh() handles empty data", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (tom data)")
   empty_data <- tibble::tibble(
     month = as.Date(character(0)),
     value = numeric(0)
@@ -469,7 +460,6 @@ test_that("compute_spc_results_bfh() handles empty data", {
 })
 
 test_that("compute_spc_results_bfh() handles single data point", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (enkelt datapunkt)")
   single_point <- tibble::tibble(
     month = as.Date("2024-01-01"),
     value = 50
@@ -488,7 +478,6 @@ test_that("compute_spc_results_bfh() handles single data point", {
 })
 
 test_that("compute_spc_results_bfh() handles all NA values", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (all-NA data)")
   all_na <- tibble::tibble(
     month = seq.Date(from = as.Date("2024-01-01"), by = "month", length.out = 20),
     value = rep(NA_real_, 20)
@@ -507,7 +496,6 @@ test_that("compute_spc_results_bfh() handles all NA values", {
 })
 
 test_that("compute_spc_results_bfh() handles missing columns", {
-  skip("Afventer compute_spc_results_bfh input-validering — se #240 (manglende kolonner)")
   data <- create_test_data(n_rows = 20)
 
   expect_error(


### PR DESCRIPTION
## Summary

`compute_spc_results_bfh()` i `R/fct_spc_bfh_facade.R` manglede eksplicit input-validering med danske fejlbeskeder. 12 tests i `test-spc-bfh-service.R` var skipped fordi funktionen ikke kastede fejl ved ugyldige parametre — fejl blev opslugt af `safe_operation()`-wrapperen.

## Løsning

Ny intern `validate_spc_inputs()`-helper med **11 kontroller**, placeret **FØR** `safe_operation()` så fejl propagerer direkte til caller (vigtig for testthat's `expect_error()`).

## Kontroller

| # | Check | Fejlbesked |
|---|-------|------------|
| 1 | `data` ikke NULL | "data parameter er påkrævet" |
| 2 | `data` er data.frame | "data skal være en data.frame" |
| 3 | `x_var` non-empty | "x_var parameter er påkrævet" |
| 4 | `y_var` non-empty | "y_var parameter er påkrævet" |
| 5 | `chart_type` non-empty | "chart_type parameter er påkrævet" |
| 6 | `chart_type` i `SUPPORTED_CHART_TYPES_BFH` | "chart_type 'X' er invalid" |
| 7 | `n_var` påkrævet for p/u/pp/up-kort | "n_var (denominator) required for X-kort" |
| 8 | `x_var`/`y_var`/`n_var` eksisterer i `data` | "Kolonnen 'X' blev ikke fundet" |
| 9 | `y_var` numerisk eller konverterbar | "Kolonnen 'X' indeholder ikke-numeriske værdier" |
| 10 | `nrow(data) >= 2` | "Utilstrækkelig data: X række(r). Minimum 2" |
| 11 | `y_var` ikke udelukkende NA | "Kolonnen 'X' indeholder udelukkende NA-værdier" |

Alle fejlbeskeder på dansk med engelsk kontekst i parentes for klarhed.

## Test plan

- [x] 12/12 #240-tests grønne (tidligere alle skipped)
- [x] `test-spc-bfh-service.R` PAS: 67, FAIL: 1, SKIP: 2
- [x] Den ene FAIL (`"handles run charts"`) er **pre-existing** og relateret til BFHcharts 0.8.0 run-chart behavior (ucl/lcl returneres uventet — se #245 cross-repo findings). Ikke introduceret af denne PR.
- [x] Styler + lintr pre-commit pass

## Design-beslutning

**Facade-niveau validering** (fremfor BFHcharts-delegation) fordi:
1. Danske fejlbeskeder til brugervendt fejlhåndtering
2. Fejl fanges tidligt før expensive cache-lookup eller BFHcharts-backend-kald
3. Testbare kontrakter — testene kan nu verificere specifikke input-scenarier

## Relations

- Closes #240
- Part of paraply #239
- Relateret: #245 (pre-existing run-chart fail — cross-repo BFHcharts)

## Note om implementering

PR arbejde blev udført af Sonnet-subagent, blev afbrudt af rate limit før commit. Jeg (Opus) genoprettede arbejdet fra git stash, verificerede kvaliteten, kørte tests, og laver PR.