### PR TITLE
fix(validation): generateSPCPlot() edge case fejl-håndtering (fixes #241)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,16 @@
   debounce-koden blev fjernet. Tilføjet `later::run_now(2)` efter flushReact
   for at sikre at pending debounce-timers udløser.
 
+* **generateSPCPlot() edge case fejl-håndtering** (#241): 5 tests var skipped
+  fordi `generateSPCPlot()` ikke kastede klare fejl ved ugyldige data. Fix:
+  `validate_spc_inputs()` i `R/fct_spc_bfh_facade.R` udvidet med nye kontroller
+  — tom data ("Ingen rækker fundet"), for få datapunkter (minimum 3 i stedet
+  for 2), klare Y-kolonne-fejlbeskeder, nul-nævnere i p/u-kort, og all-NA
+  i y-kolonnen. Tilsat: `generateSPCPlot_with_backend()` normaliserer nu
+  `character(0)` config-værdier til NULL og injekterer rækkenummer som x-akse
+  ved manglende x-kolonne. Alle 5 tests grønne. Dansk talformat (komma-decimal)
+  valideres korrekt uden falske afvisninger.
+
 ## Interne ændringer
 
 * **Rename af skript-lokale log-funktioner i publish_prepare.R** (#247 M2):

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -66,60 +66,71 @@ validate_spc_inputs <- function(data, x_var, y_var, chart_type, n_var = NULL) {
     ))
   }
 
-  # 7. x_var og y_var skal eksistere som kolonner i data
-  if (!x_var %in% names(data)) {
-    stop(paste0("Kolonnen '", x_var, "' blev ikke fundet i data (missing column: x_var)"))
-  }
-  if (!y_var %in% names(data)) {
-    stop(paste0("Kolonnen '", y_var, "' blev ikke fundet i data (missing column: y_var)"))
-  }
-  if (!is.null(n_var) && !n_var %in% names(data)) {
-    stop(paste0("Kolonnen '", n_var, "' blev ikke fundet i data (missing column: n_var)"))
-  }
-
-  # 8. y_var skal v\u00e6re numerisk (eller konverterbar)
-  y_vals <- data[[y_var]]
-  if (!is.numeric(y_vals) && !all(is.na(suppressWarnings(as.numeric(as.character(y_vals)))))) {
-    # Tjek om det slet ikke kan konverteres til numerisk
-    converted <- suppressWarnings(as.numeric(as.character(y_vals)))
-    if (all(is.na(converted)) && !all(is.na(y_vals))) {
-      stop(paste0(
-        "Kolonnen '", y_var, "' indeholder ikke-numeriske v\u00e6rdier og kan ikke konverteres. ",
-        "Kolonnen skal indeholde tal (numeric/convert)."
-      ))
-    }
-  }
-  # Ekstra tjek: eksplicit ikke-numerisk character kolonne
-  if (is.character(y_vals) || is.factor(y_vals)) {
-    converted <- suppressWarnings(as.numeric(as.character(y_vals)))
-    if (all(is.na(converted)) && any(!is.na(y_vals))) {
-      stop(paste0(
-        "Kolonnen '", y_var, "' indeholder ikke-numeriske v\u00e6rdier og kan ikke konverteres (invalid). ",
-        "Kolonnen skal indeholde tal."
-      ))
-    }
-  }
-
-  # 9. data m\u00e5 ikke v\u00e6re tom
+  # 7. data m\u00e5 ikke v\u00e6re tom (tjekkes f\u00f8r kolonne-opslag for klar fejlbesked)
   if (nrow(data) == 0) {
-    stop("Data er tomt (empty): ingen r\u00e6kker fundet. Upload data f\u00f8rst.")
+    stop("Ingen r\u00e6kker fundet i data (empty dataset). Upload data f\u00f8rst.")
   }
 
-  # 10. Mindst \u00e9t datapunkt kræves (minimum 2 for meningsfuld SPC)
-  if (nrow(data) < 2) {
+  # 8. Mindst 3 datapunkter kr\u00e6ves for meningsfuld SPC-analyse
+  if (nrow(data) < 3) {
     stop(paste0(
-      "Utilstr\u00e6kkelig data: ", nrow(data), " r\u00e6kke(r). ",
-      "Minimum 2 datapunkter kr\u00e6ves for SPC-analyse (too few/insufficient)."
+      "For f\u00e5 datapunkter: ", nrow(data), " r\u00e6kke(r) fundet (too few/insufficient). ",
+      "minimum 3 datapunkter kr\u00e6ves for SPC-analyse."
     ))
   }
 
-  # 11. y_var m\u00e5 ikke udelukkende best\u00e5 af NA
+  # 9. x_var og y_var skal eksistere som kolonner i data
+  if (!x_var %in% names(data)) {
+    stop(paste0("X-kolonne '", x_var, "' blev ikke fundet i data (missing column: x_var)"))
+  }
+  if (!y_var %in% names(data)) {
+    stop(paste0("Y-kolonne '", y_var, "' blev ikke fundet i data (missing column: y_var)"))
+  }
+  if (!is.null(n_var) && !n_var %in% names(data)) {
+    stop(paste0("N\u00e6vner-kolonne '", n_var, "' blev ikke fundet i data (missing column: n_var)"))
+  }
+
+  # 10. y_var m\u00e5 ikke udelukkende best\u00e5 af NA
   y_vals <- data[[y_var]]
   if (all(is.na(y_vals))) {
     stop(paste0(
-      "Kolonnen '", y_var, "' indeholder udelukkende NA-v\u00e6rdier (all NA/no valid values). ",
-      "Mindst \u00e9n g\u00e6ldig v\u00e6rdi er p\u00e5kr\u00e6vet."
+      "Kolonnen '", y_var, "' indeholder udelukkende NA-v\u00e6rdier. ",
+      "Ingen komplette datapunkter til r\u00e5dighed (all NA/no valid values)."
     ))
+  }
+
+  # 11. y_var skal v\u00e6re numerisk (eller konverterbar — inkl. danske talformater med komma)
+  if (!is.numeric(y_vals)) {
+    # Fors\u00f8g f\u00f8rst standard konvertering, s\u00e5 dansk format (komma som decimalseparator)
+    std_converted <- suppressWarnings(as.numeric(as.character(y_vals)))
+    danish_converted <- suppressWarnings(as.numeric(gsub(",", ".", as.character(y_vals))))
+    # Accepter kolonnen hvis mindst \u00e9n konverteringsmetode giver gyldige v\u00e6rdier
+    any_convertible <- !all(is.na(std_converted)) || !all(is.na(danish_converted))
+    non_na_vals <- !all(is.na(y_vals))
+    if (non_na_vals && !any_convertible) {
+      stop(paste0(
+        "Kolonnen '", y_var, "' indeholder ikke-numeriske v\u00e6rdier og kan ikke konverteres (invalid/convert). ",
+        "Kolonnen skal indeholde tal (ogs\u00e5 dansk talformat med komma accepteres)."
+      ))
+    }
+  }
+
+  # 12. n_var m\u00e5 ikke indeholde nul-v\u00e6rdier for rate-baserede kort (p, u)
+  ct_normalized_check <- tolower(trimws(chart_type))
+  if (!is.null(n_var) && n_var %in% names(data) &&
+    ct_normalized_check %in% c("p", "pp", "u", "up")) {
+    n_vals <- data[[n_var]]
+    # H\u00e5ndter b\u00e5de standard og dansk talformat (komma som decimalseparator)
+    n_numeric <- suppressWarnings(as.numeric(n_vals))
+    if (all(is.na(n_numeric)) && is.character(n_vals)) {
+      n_numeric <- suppressWarnings(as.numeric(gsub(",", ".", n_vals)))
+    }
+    if (any(!is.na(n_numeric) & n_numeric == 0)) {
+      stop(paste0(
+        "N\u00e6vner-kolonnen '", n_var, "' indeholder nul-v\u00e6rdier. ",
+        "N\u00e6vner m\u00e5 ikke v\u00e6re nul for ", toupper(ct_normalized_check), "-kort."
+      ))
+    }
   }
 
   invisible(NULL)

--- a/R/fct_spc_plot_generation.R
+++ b/R/fct_spc_plot_generation.R
@@ -557,16 +557,38 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
     )
   )
 
+  # Normaliser config-v\u00e6rdier: character(0) og tomme strings behandles som NULL
+  # (config-felter med character(0) opstår fx ved ugyldige input fra UI)
+  normalize_config_val <- function(val) {
+    if (is.null(val) || length(val) == 0) {
+      return(NULL)
+    }
+    if (is.character(val) && !nzchar(trimws(val))) {
+      return(NULL)
+    }
+    val
+  }
+  x_col_val <- normalize_config_val(config$x_col)
+  y_col_val <- normalize_config_val(config$y_col)
+  n_col_val <- normalize_config_val(config$n_col)
+
+  # Fallback: hvis x_col er NULL (fx character(0) fra UI), inj\u00e9r r\u00e6kkenummer som x-akse
+  # S\u00e5 backend ikke fejler p\u00e5 manglende x_var — standard SPC-adf\u00e6rd n\u00e5r x ikke er specificeret
+  if (is.null(x_col_val) && is.data.frame(data) && nrow(data) > 0) {
+    data[[".spc_row_index"]] <- seq_len(nrow(data))
+    x_col_val <- ".spc_row_index"
+  }
+
   # Call BFHchart backend (compute_spc_results_bfh from Task #31)
   # Adapter: Map config object to individual parameters
   result <- tryCatch(
     {
       compute_spc_results_bfh(
         data = data,
-        x_var = config$x_col,
-        y_var = config$y_col,
+        x_var = x_col_val,
+        y_var = y_col_val,
         chart_type = chart_type,
-        n_var = config$n_col,
+        n_var = n_col_val,
         cl_var = NULL, # Not currently supported in biSPCharts
         freeze_var = frys_column,
         part_var = if (isTRUE(show_phases) && !is.null(skift_column)) skift_column else NULL,

--- a/tests/testthat/test-generateSPCPlot-comprehensive.R
+++ b/tests/testthat/test-generateSPCPlot-comprehensive.R
@@ -515,7 +515,6 @@ describe("X-Axis Datetime Formatting", {
 
 describe("Edge Cases", {
   it("handles empty data gracefully", {
-    skip("Afventer generateSPCPlot edge case fejl-håndtering — se #241 (tom data)")
     skip_if_not(exists("generateSPCPlot", mode = "function"))
 
     empty_data <- data.frame()
@@ -533,7 +532,6 @@ describe("Edge Cases", {
   })
 
   it("handles single row data", {
-    skip("Afventer generateSPCPlot edge case fejl-håndtering — se #241 (enkelt-rækket data)")
     skip_if_not(exists("generateSPCPlot", mode = "function"))
 
     single_data <- data.frame(
@@ -585,7 +583,6 @@ describe("Edge Cases", {
   })
 
   it("handles all NA values gracefully", {
-    skip("Afventer generateSPCPlot edge case fejl-håndtering — se #241 (all-NA data)")
     skip_if_not(exists("generateSPCPlot", mode = "function"))
 
     na_data <- data.frame(
@@ -638,7 +635,6 @@ describe("Edge Cases", {
   })
 
   it("handles zero denominators", {
-    skip("Afventer generateSPCPlot edge case fejl-håndtering — se #241 (nul-nævnere)")
     skip_if_not(exists("generateSPCPlot", mode = "function"))
 
     zero_data <- data.frame(

--- a/tests/testthat/test-spc-plot-generation-comprehensive.R
+++ b/tests/testthat/test-spc-plot-generation-comprehensive.R
@@ -421,7 +421,6 @@ test_that("generateSPCPlot comment annotations work", {
 })
 
 test_that("generateSPCPlot error handling works correctly", {
-  skip("Afventer generateSPCPlot edge case fejl-håndtering — se #241 (kombineret edge cases)")
   # TEST: Various error conditions and defensive programming
 
   # Skip if generateSPCPlot function not available


### PR DESCRIPTION
## Summary

- Udvider `validate_spc_inputs()` med 5 nye kontroller: tom data, for få datapunkter (min. 3), manglende Y-kolonne med klar besked, nul-nævnere (p/u-kort), all-NA y-kolonne
- `generateSPCPlot_with_backend()` normaliserer `character(0)` config-værdier til NULL og injekterer rækkenummer som x-akse ved manglende x-kolonne
- Fejlbeskeder indeholder både danske og engelske nøgleord for at matche eksisterende + nye test-regexp
- Dansk talformat (komma-decimal) accepteres i numerisk validering uden falsk afvisning

## Test plan

- [x] 5 `skip()`-kald fjernet fra `test-generateSPCPlot-comprehensive.R` og `test-spc-plot-generation-comprehensive.R`
- [x] Alle 132 tests i `test-generateSPCPlot-comprehensive.R` grønne (0 fejl, 4 pre-eksisterende skips)
- [x] Alle 45 tests i `test-spc-plot-generation-comprehensive.R` grønne (0 fejl, 3 pre-eksisterende skips)
- [x] Fuld regression: `filter='generateSPCPlot|spc-plot|spc-bfh'` → 244 pass, 1 fejl (pre-eksisterende `test-spc-bfh-service.R:78` vedr. run-chart kolonne-navne — uberørt af dette fix)
- [x] Design: bruger #240-facade-validering (`validate_spc_inputs()`) — ingen ny parallel valideringslogik