### PR TITLE
chore(todos): opdatér L5/L9 TODO-refs til sub-issues #261/#262

### DIFF
--- a/tests/testthat/test-mod-spc-chart-comprehensive.R
+++ b/tests/testthat/test-mod-spc-chart-comprehensive.R
@@ -402,7 +402,7 @@ describe("Error Handling", {
     })
   })
 
-  # TODO(#247-L9): Refaktorér til at verificere modulets write-path —
+  # TODO(#262): Refaktorér til at verificere modulets write-path —
   # test skal trigge modulet til at skrive plot_warnings via reactive,
   # ikke pre-populere app_state direkte og verificere samme strenge.
   it("sets appropriate warnings on validation failure", {

--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -169,7 +169,7 @@ test_that("mod_export_server requires app_state parameter", {
 # §2.3.2 (plot-available reactive): reagerer på app_state plot-data
 # Leveret i §2.3.2 (#230)
 #
-# TODO(#247-L5): Refaktorér til at verificere output$plot_available-binding
+# TODO(#261): Refaktorér til at verificere output$plot_available-binding
 # direkte via testServer i stedet for at evaluere logikken via shiny::isolate().
 # Kræver at output-id'et eksponeres og at testServer understøtter det korrekt.
 test_that("mod_export_server plot_available reflects app_state (§2.3.2)", {


### PR DESCRIPTION
Små TODO-opdateringer efter #247-lukning. De 2 deferred findings er splittet til separate issues — kommentarerne peger nu på korrekte targets. No-op for runtime.