### PR TITLE
fix(tests): #239-kluster security/session tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # biSPCharts 0.2.0-dev (development)
 
+## Security
+
+* **Session token-tests opdateret til SHA256** (#239): To test-filer testede
+  den tidligere SHA1-implementering. Implementeringen var allerede opgraderet
+  til SHA256 (stærkere hashing), men testene forventede stadig SHA1-output.
+  `test-security-session-tokens.R` opdateret til at verificere SHA256-adfærd.
+  `test-session-token-sanitization.R` opdateret: `sanitize_session_token()`
+  returnerer `"NO_SESSION"` for ikke-character input (eksplicit type-validering
+  — ingen skjult koercering). Del af #239-paraply.
+
 ## Bug fixes
 
 * **test-bfh-error-handling: opdatér forventninger efter #240 validering**

--- a/tests/testthat/test-security-session-tokens.R
+++ b/tests/testthat/test-security-session-tokens.R
@@ -92,22 +92,22 @@ test_that("hashed tokens are not reversible", {
   expect_lt(nchar(hashed), nchar(original_token))
 })
 
-test_that("session token hashing uses SHA1 algorithm", {
+test_that("session token hashing uses SHA256 algorithm", {
   skip_if_not(exists("hash_session_token", mode = "function"))
 
-  # Verify that our implementation matches expected SHA1 behavior
+  # Bekræft at implementeringen bruger SHA256 (opgraderet fra SHA1 af sikkerhedsmæssige årsager)
   test_token <- "test_token_for_verification"
 
   if (requireNamespace("digest", quietly = TRUE)) {
-    # Calculate expected hash using digest directly
-    expected_full_hash <- digest::sha1(test_token)
+    # Beregn forventet hash via digest direkte med SHA256
+    expected_full_hash <- digest::digest(test_token, algo = "sha256")
     expected_short_hash <- substr(expected_full_hash, 1, 8)
 
-    # Our function should produce the same result
+    # Vores funktion skal producere samme SHA256-resultat
     actual_hash <- hash_session_token(test_token)
     expect_equal(actual_hash, expected_short_hash)
   } else {
-    skip("digest package not available for SHA1 verification")
+    skip("digest-pakken ikke tilgængelig for SHA256-verifikation")
   }
 })
 
@@ -238,7 +238,7 @@ test_that("session token hashing meets security best practices", {
 
   # Verify that implementation follows security best practices:
 
-  # 1. Uses cryptographically secure hash function (SHA1)
+  # 1. Uses cryptographically secure hash function (SHA256)
   test_token <- "security_test_token"
   hash_result <- hash_session_token(test_token)
 

--- a/tests/testthat/test-session-token-sanitization.R
+++ b/tests/testthat/test-session-token-sanitization.R
@@ -41,8 +41,9 @@ test_that("sanitize_session_token handles empty tokens", {
 })
 
 test_that("sanitize_session_token handles non-character input", {
-  # Should handle conversion gracefully
-  expect_equal(nchar(sanitize_session_token(12345)), 8)
+  # Ikke-character input behandles som ugyldigt token og returnerer "NO_SESSION"
+  # (funktionen validerer typen eksplicit for at undgå skjult type-koercering)
+  expect_equal(sanitize_session_token(12345), "NO_SESSION")
 })
 
 test_that("Different tokens produce different hashes", {


### PR DESCRIPTION
## Ændringer

Del af #239-paraply (Fase 1, security/session kluster).

Implementeringen var allerede korrekt opgraderet til SHA256, men to testfiler testede stadig den gamle SHA1-adfærd.

### test-security-session-tokens.R
- **Decision: Test-fix** — Algoritmen er bevidst opgraderet til SHA256. Testen forventede `digest::sha1()`, nu opdateret til `digest::digest(..., algo = "sha256")`.
- Opdateret kommentar i "security best practices"-test (SHA1 → SHA256).

### test-session-token-sanitization.R
- **Decision: Test-fix** — `sanitize_session_token()` returnerer `"NO_SESSION"` for ikke-character input (eksplicit type-validering uden koercering). Testen forventede fejlagtigt 8 hex-tegn.

## Test plan

- [x] `test-security-session-tokens.R`: 0 FAIL (var 1 FAIL)
- [x] `test-session-token-sanitization.R`: 0 FAIL (var 1 FAIL)
- [x] Lintr: 0 errors (1 pre-existing style-warning på linje 1, ikke blokkerende)
- [x] NEWS.md opdateret under `## Security`

## Supply-chain checklist (jf. #258)

- [ ] `.Rprofile` ændret? Nej
- [ ] `.Renviron` ændret? Nej
- [ ] `dev/git-hooks/*` ændret? Nej
- [ ] `.github/workflows/*` ændret? Nej
- [ ] `DESCRIPTION` ændret? Nej
- [ ] `renv.lock` ændret? Nej

Udelukkende test- og NEWS-ændringer. Ingen kodeændringer.