### PR TITLE
fix(tests): #239-kluster export/validation tests

### DIFF
--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -67,8 +67,8 @@ test_that("mod_export_ui generates valid Shiny UI", {
   # Create UI
   ui <- mod_export_ui("test")
 
-  # Basic structure checks
-  expect_s3_class(ui, "shiny.tag")
+  # Basic structure checks — mod_export_ui returnerer tagList (shiny.tag.list)
+  expect_s3_class(ui, "shiny.tag.list")
   expect_true(!is.null(ui))
 
   # Convert to HTML for content inspection
@@ -90,9 +90,10 @@ test_that("mod_export_ui contains format-specific conditional panels", {
   expect_true(grepl("test-pdf_description", html))
   expect_true(grepl("test-pdf_improvement", html))
 
-  # PNG-specific fields
-  expect_true(grepl("test-png_size_preset", html))
-  expect_true(grepl("test-png_dpi", html))
+  # PNG-specific fields — ID er png_preset (ingen separat DPI-felt i UI)
+  expect_true(grepl("test-png_preset", html))
+  # PNG-størrelse styres via png_width + png_height (ikke separat DPI)
+  expect_true(grepl("test-png_width", html))
 
   # Check conditional panel conditions exist (simplified regex)
   expect_true(grepl("test-export_format", html) && grepl("pdf", html))

--- a/tests/testthat/test-utils_export_validation.R
+++ b/tests/testthat/test-utils_export_validation.R
@@ -28,7 +28,8 @@ if (!exists("EXPORT_DESCRIPTION_MAX_LENGTH")) {
   EXPORT_DESCRIPTION_MAX_LENGTH <- 2000
 }
 if (!exists("EXPORT_DEPARTMENT_MAX_LENGTH")) {
-  EXPORT_DEPARTMENT_MAX_LENGTH <- 100
+  # Faktisk værdi: 250 (se config_system_config.R)
+  EXPORT_DEPARTMENT_MAX_LENGTH <- 250
 }
 if (!exists("EXPORT_ASPECT_RATIO_MIN")) {
   EXPORT_ASPECT_RATIO_MIN <- 0.5
@@ -117,9 +118,9 @@ test_that("sanitize_user_input trims whitespace", {
 
 test_that("validate_aspect_ratio accepts normal ratios", {
   # Normal aspect ratios (0.5 - 2.0)
-  expect_true(validate_aspect_ratio(1200, 900))  # 1.33
+  expect_true(validate_aspect_ratio(1200, 900)) # 1.33
   expect_true(validate_aspect_ratio(1920, 1080)) # 1.78
-  expect_true(validate_aspect_ratio(800, 800))   # 1.0
+  expect_true(validate_aspect_ratio(800, 800)) # 1.0
 })
 
 test_that("validate_aspect_ratio warns on extreme ratios", {
@@ -190,7 +191,8 @@ test_that("validate_export_inputs rejects overly long description", {
 })
 
 test_that("validate_export_inputs rejects overly long department", {
-  long_dept <- paste(rep("A", 101), collapse = "")
+  # EXPORT_DEPARTMENT_MAX_LENGTH = 250, så vi bruger 251 tegn
+  long_dept <- paste(rep("A", 251), collapse = "")
 
   expect_error(
     validate_export_inputs(format = "pdf", department = long_dept),
@@ -267,8 +269,9 @@ test_that("validate_export_inputs handles empty strings", {
 })
 
 test_that("validate_export_inputs combines multiple errors", {
+  # EXPORT_TITLE_MAX_LENGTH = 200, EXPORT_DEPARTMENT_MAX_LENGTH = 250
   long_title <- paste(rep("A", 201), collapse = "")
-  long_dept <- paste(rep("B", 101), collapse = "")
+  long_dept <- paste(rep("B", 251), collapse = "")
 
   expect_error(
     validate_export_inputs(
@@ -286,7 +289,7 @@ test_that("validate_export_inputs does not validate dimensions for PDF", {
     validate_export_inputs(
       format = "pdf",
       title = "Valid",
-      width = 100,  # Would be invalid for PNG
+      width = 100, # Would be invalid for PNG
       height = 10000
     )
   )
@@ -327,14 +330,14 @@ test_that("sanitize_user_input handles numeric input", {
 test_that("validate_export_inputs handles case-insensitive format", {
   expect_true(
     validate_export_inputs(
-      format = "PDF",  # Uppercase
+      format = "PDF", # Uppercase
       title = "Valid"
     )
   )
 
   expect_true(
     validate_export_inputs(
-      format = "PnG",  # Mixed case
+      format = "PnG", # Mixed case
       width = 800,
       height = 600
     )


### PR DESCRIPTION
## Del af #239-paraply

Fikser 3 FAIL i `test-mod_export.R` og 1 FAIL + 1 ERR i `test-utils_export_validation.R`.

## Ændringer

**test-mod_export.R (3 FAILs fikset):**
- `expect_s3_class(ui, "shiny.tag")` → `"shiny.tag.list"` — `tagList()` returnerer ikke `shiny.tag`
- `grepl("test-png_size_preset", html)` → `"test-png_preset"` — faktisk input-ID
- `grepl("test-png_dpi", html)` → `"test-png_width"` — DPI-felt eksisterer ikke i UI; størrelse styres via width/height

**test-utils_export_validation.R (1 FAIL + 1 ERR fikset):**
- `long_dept` ændret fra 101 → 251 tegn — `EXPORT_DEPARTMENT_MAX_LENGTH` er 250 (ikke 100 som mock-konstant antog)
- Tilsvarende fix i "combines multiple errors"-test
- Mock-konstant opdateret til faktisk værdi (250)

## Status

- `[ FAIL 0 | WARN 1 | SKIP 9 | PASS 52 ]` — test-mod_export.R
- `[ FAIL 0 | WARN 0 | SKIP 0 | PASS 50 ]` — test-utils_export_validation.R
- 9 eksisterende SKIPs bevaret uændret