### PR TITLE
fix(tests): #239-kluster package/infrastructure tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,19 @@
 
 ## Bug fixes
 
+* **Package/infrastructure tests: opdatér forventninger til nuværende API**
+  (#239 — package/infra): 3 test-filer med 6 FAIL + 1 ERR opdateret:
+  (1) `test-package-initialization.R`: branding-globals er migreret fra
+  `.GlobalEnv` til `claudespc_env` (pakke-environment) — tests bruger nu
+  getter-funktioner (`get_hospital_name()`, `get_bootstrap_theme()`,
+  `get_hospital_logo_path()`). (2) `test-package-namespace-validation.R`:
+  `read.dcf()` returnerer navngivet matrix — `as.character()` tilføjet;
+  `initialize_app()` er `@keywords internal` og eksporteres ikke i NAMESPACE
+  — fjernet fra key_exports-liste. (3) `test-yaml-config-adherence.R`:
+  fallback-test forsøgte at fjerne `get_golem_config` fra `.GlobalEnv` men
+  funktionen lever i pakke-namespacet; test opdateret til at verificere
+  faktiske YAML-værdier (production: `"ERROR"`, development: `"DEBUG"`).
+
 * **test-bfh-error-handling: opdatér forventninger efter #240 validering**
   (#239): 6 tests forventede `NULL`-return fra `compute_spc_results_bfh()`
   ved ugyldige input — den adfærd var korrekt FØR #240 indførte eksplicit

--- a/tests/testthat/test-package-initialization.R
+++ b/tests/testthat/test-package-initialization.R
@@ -2,7 +2,6 @@
 # Tests for package-based initialization without filesystem dependencies
 
 test_that("initialize_app() works with package loading", {
-
   # Test that initialize_app can run without requiring source() calls
   result <- initialize_app()
 
@@ -15,7 +14,6 @@ test_that("initialize_app() works with package loading", {
 })
 
 test_that("Package functions are available", {
-
   # Test that essential functions are loaded via package
   essential_functions <- c(
     "create_app_state",
@@ -28,30 +26,32 @@ test_that("Package functions are available", {
 
   for (func_name in essential_functions) {
     expect_true(exists(func_name, mode = "function"),
-                info = paste("Function", func_name, "should be available"))
+      info = paste("Function", func_name, "should be available")
+    )
   }
 })
 
 test_that("Branding configuration is available", {
+  # NOTE (#239 — package/infra): Branding-globals er migreret fra .GlobalEnv
+  # til `claudespc_env` (pakke-environment) for at undgå namespace-forurening.
+  # Tests bruger nu getter-funktioner i stedet for direkte exists()-tjek.
+  # Se R/config_branding_getters.R og R/zzz.R::initialize_package_globals().
 
-  # Test that branding globals are set by package .onLoad
-  expect_true(exists("HOSPITAL_NAME"))
-  expect_true(exists("my_theme"))
-  expect_true(exists("HOSPITAL_LOGO_PATH"))
+  # Test branding via getter-funktioner (nuværende API)
+  hospital_name <- get_hospital_name()
+  expect_type(hospital_name, "character")
+  expect_length(hospital_name, 1)
+  expect_true(nzchar(hospital_name))
 
-  # Test branding values
-  expect_type(HOSPITAL_NAME, "character")
-  expect_length(HOSPITAL_NAME, 1)
-  expect_true(nzchar(HOSPITAL_NAME))
+  hospital_theme <- get_bootstrap_theme()
+  expect_s3_class(hospital_theme, "bs_theme")
 
-  expect_s3_class(my_theme, "bs_theme")
-
-  expect_type(HOSPITAL_LOGO_PATH, "character")
-  expect_length(HOSPITAL_LOGO_PATH, 1)
+  logo_path <- get_hospital_logo_path()
+  expect_type(logo_path, "character")
+  expect_length(logo_path, 1)
 })
 
 test_that("initialize_app() returns valid configuration", {
-
   result <- initialize_app()
 
   # Test config structure
@@ -74,7 +74,6 @@ test_that("initialize_app() returns valid configuration", {
 })
 
 test_that("Initialization verification works correctly", {
-
   result <- initialize_app()
   verification <- result$verification
 
@@ -106,7 +105,6 @@ test_that("Initialization verification works correctly", {
 })
 
 test_that("get_initialization_status_report() works", {
-
   result <- initialize_app()
   status_report <- get_initialization_status_report(result)
 
@@ -124,7 +122,6 @@ test_that("get_initialization_status_report() works", {
 })
 
 test_that("No filesystem dependencies in initialization", {
-
   # Test that initialization doesn't try to source files
   # This is a regression test for the old source() chain
 
@@ -135,7 +132,7 @@ test_that("No filesystem dependencies in initialization", {
   unlockBinding("file.exists", baseenv())
   assign("file.exists", function(path) {
     if (any(grepl("^R/", path) | grepl("/R/", path))) {
-      return(FALSE)  # Simulate missing source files
+      return(FALSE) # Simulate missing source files
     }
     old_file_exists(path)
   }, envir = baseenv())
@@ -152,7 +149,6 @@ test_that("No filesystem dependencies in initialization", {
 })
 
 test_that("Package-based loading is robust", {
-
   # Test with missing config override
   result1 <- initialize_app(config_override = NULL)
   expect_type(result1, "list")
@@ -169,7 +165,6 @@ test_that("Package-based loading is robust", {
 })
 
 test_that("Performance optimizations work without file dependencies", {
-
   config <- list(
     testing = list(auto_load_enabled = TRUE),
     development = list(auto_restore_enabled = FALSE)

--- a/tests/testthat/test-package-namespace-validation.R
+++ b/tests/testthat/test-package-namespace-validation.R
@@ -36,7 +36,9 @@ test_that("Package DESCRIPTION and NAMESPACE are consistent", {
   desc <- read.dcf(desc_path)
 
   # TEST: Package name er korrekt
-  expect_equal(desc[1, "Package"], "biSPCharts")
+  # NOTE (#239 — package/infra): read.dcf returnerer en navngivet character-matrix;
+  # as.character() fjerner names-attributten så expect_equal sammenligner værdier korrekt.
+  expect_equal(as.character(desc[1, "Package"]), "biSPCharts")
 
   # TEST: Version følger semantic versioning
   version <- desc[1, "Version"]
@@ -53,7 +55,10 @@ test_that("Package DESCRIPTION and NAMESPACE are consistent", {
   expect_true(length(exports) > 0, info = "NAMESPACE should contain export statements")
 
   # TEST: Key exports er til stede
-  key_exports <- c("run_app", "initialize_app")
+  # NOTE (#239 — package/infra): initialize_app() er @keywords internal og
+  # eksporteres IKKE i NAMESPACE — den er en intern hjælpefunktion.
+  # Kun run_app() er den offentlige API til at starte appen.
+  key_exports <- c("run_app")
   for (export in key_exports) {
     pattern <- paste0("^export\\(", export, "\\)")
     expect_true(

--- a/tests/testthat/test-yaml-config-adherence.R
+++ b/tests/testthat/test-yaml-config-adherence.R
@@ -9,13 +9,16 @@ test_that("YAML configuration is loaded correctly per environment", {
 
   for (env in environments_to_test) {
     original_config <- Sys.getenv("GOLEM_CONFIG_ACTIVE", "")
-    on.exit({
-      if (original_config == "") {
-        Sys.unsetenv("GOLEM_CONFIG_ACTIVE")
-      } else {
-        Sys.setenv(GOLEM_CONFIG_ACTIVE = original_config)
-      }
-    }, add = TRUE)
+    on.exit(
+      {
+        if (original_config == "") {
+          Sys.unsetenv("GOLEM_CONFIG_ACTIVE")
+        } else {
+          Sys.setenv(GOLEM_CONFIG_ACTIVE = original_config)
+        }
+      },
+      add = TRUE
+    )
 
     # Set environment and test config loading
     Sys.setenv(GOLEM_CONFIG_ACTIVE = env)
@@ -34,7 +37,8 @@ test_that("YAML configuration is loaded correctly per environment", {
 
     # Should either load successfully or return NULL (both acceptable)
     expect_true(is.null(config_result) || is.list(config_result),
-                info = paste("YAML config should load or be NULL for environment:", env))
+      info = paste("YAML config should load or be NULL for environment:", env)
+    )
   }
 })
 
@@ -87,6 +91,16 @@ test_that("Logging configuration respects YAML settings when available", {
 })
 
 test_that("Fallback behavior works when YAML config is unavailable", {
+  # NOTE (#239 — package/infra): get_golem_config() lever i pakke-namespacet og
+  # kan ikke fjernes fra .GlobalEnv for at simulere "YAML unavailable".
+  # Fallback-kodevejen (hardcoded "DEBUG"/"WARN") kan derfor ikke nås i
+  # en normal pakke-load. Tests verificerer i stedet det faktiske YAML-indhold
+  # som er grunden til at koden opfører sig korrekt i produktion.
+  #
+  # Faktiske YAML-værdier (inst/golem-config.yml):
+  #   development: logging.level = "DEBUG"
+  #   production:  logging.level = "ERROR"
+
   original_config <- Sys.getenv("GOLEM_CONFIG_ACTIVE", "")
   original_log_level <- Sys.getenv("SPC_LOG_LEVEL", "")
 
@@ -103,32 +117,23 @@ test_that("Fallback behavior works when YAML config is unavailable", {
     }
   })
 
-  # Test fallback when get_golem_config doesn't exist
-  if (exists("get_golem_config", mode = "function")) {
-    # Temporarily remove function to test fallback
-    temp_get_golem_config <- get_golem_config
-    rm(get_golem_config, envir = .GlobalEnv)
-
-    on.exit({
-      assign("get_golem_config", temp_get_golem_config, envir = .GlobalEnv)
-    }, add = TRUE)
-  }
-
-  # Test development fallback
+  # Test development: YAML sætter "DEBUG"
   Sys.setenv(GOLEM_CONFIG_ACTIVE = "development")
   Sys.unsetenv("SPC_LOG_LEVEL")
 
   configure_logging_from_yaml()
   expect_equal(Sys.getenv("SPC_LOG_LEVEL"), "DEBUG",
-               "Development should fallback to DEBUG when YAML unavailable")
+    info = "Development should use DEBUG fra YAML config"
+  )
 
-  # Test production fallback
+  # Test production: YAML sætter "ERROR" (ikke "WARN" — se inst/golem-config.yml)
   Sys.setenv(GOLEM_CONFIG_ACTIVE = "production")
   Sys.unsetenv("SPC_LOG_LEVEL")
 
   configure_logging_from_yaml()
-  expect_equal(Sys.getenv("SPC_LOG_LEVEL"), "WARN",
-               "Production should fallback to WARN when YAML unavailable")
+  expect_equal(Sys.getenv("SPC_LOG_LEVEL"), "ERROR",
+    info = "Production skal bruge ERROR fra YAML config (golem-config.yml production.logging.level)"
+  )
 })
 
 test_that("Configuration precedence order is respected", {
@@ -151,20 +156,24 @@ test_that("Configuration precedence order is respected", {
   # Test precedence: Explicit > YAML > Environment Default
 
   # 1. Explicit parameter should override everything
-  Sys.setenv(GOLEM_CONFIG_ACTIVE = "production")  # Would default to WARN
+  Sys.setenv(GOLEM_CONFIG_ACTIVE = "production") # Would default to WARN
   Sys.unsetenv("SPC_LOG_LEVEL")
 
   configure_logging_from_yaml(log_level = "ERROR")
-  expect_equal(Sys.getenv("SPC_LOG_LEVEL"), "ERROR",
-               "Explicit log level should have highest precedence")
+  expect_equal(
+    Sys.getenv("SPC_LOG_LEVEL"), "ERROR",
+    "Explicit log level should have highest precedence"
+  )
 
   # 2. When no explicit parameter, should use YAML or fallback
   Sys.unsetenv("SPC_LOG_LEVEL")
-  configure_logging_from_yaml()  # No explicit parameter
+  configure_logging_from_yaml() # No explicit parameter
 
   final_log_level <- Sys.getenv("SPC_LOG_LEVEL", "")
-  expect_true(final_log_level %in% c("DEBUG", "INFO", "WARN", "ERROR"),
-              "Should set valid log level from YAML or fallback")
+  expect_true(
+    final_log_level %in% c("DEBUG", "INFO", "WARN", "ERROR"),
+    "Should set valid log level from YAML or fallback"
+  )
 })
 
 test_that("Environment-specific test mode configuration works", {


### PR DESCRIPTION
## Formål

Del af #239-paraply (Fase 1 saneringsarbejde). Fikser 3 test-filer relateret til package/infrastructure: 6 FAIL + 1 ERR → 0 FAIL.

## Ændringer per fil

### `test-package-initialization.R` — 3 FAIL + 1 ERR → 0

**Triage: Forældet test-forventning.**

Branding-globals (`HOSPITAL_NAME`, `my_theme`, `HOSPITAL_LOGO_PATH`) er migreret fra `.GlobalEnv` til `claudespc_env` (pakke-environment) for at undgå namespace-forurening. Ændringen skete i `R/zzz.R::initialize_package_globals()`.

Fix: `exists("HOSPITAL_NAME")` mv. erstattet med getter-kald:
- `get_hospital_name()`
- `get_bootstrap_theme()`
- `get_hospital_logo_path()`

### `test-package-namespace-validation.R` — 2 FAIL → 0

**Triage: Forældet test-forventning (2 problemer).**

1. `read.dcf()` returnerer en navngivet character-matrix — `expect_equal(desc[1, "Package"], "biSPCharts")` fejler fordi `names(actual)` er `"Package"` men `names(expected)` er fraværende. Fix: wrappet i `as.character()`.

2. `initialize_app()` er `@keywords internal` og eksporteres IKKE i NAMESPACE — den er en intern hjælpefunktion. `run_app()` er den offentlige API. Fix: fjernet fra `key_exports`-listen.

### `test-yaml-config-adherence.R` — 1 FAIL → 0

**Triage: Forældet test-forventning.**

Fallback-test forsøgte at fjerne `get_golem_config` fra `.GlobalEnv` for at simulere "YAML unavailable", men funktionen lever i pakke-namespacet og kan ikke fjernes på den måde. Fallback-kodevejen (hardcoded `"WARN"`) er aldrig tilgængelig i en normal pakke-load.

Derudover: production YAML har `logging.level = "ERROR"`, ikke `"WARN"` (se `inst/golem-config.yml`).

Fix: Test verificerer nu faktiske YAML-værdier (development: `"DEBUG"`, production: `"ERROR"`).

## Test plan

- [x] `test-package-initialization.R`: 47 PASS, 0 FAIL
- [x] `test-package-namespace-validation.R`: 11 PASS, 0 FAIL
- [x] `test-yaml-config-adherence.R`: 8 PASS, 0 FAIL, 2 SKIP (pre-existing), 1 WARN (pre-existing)
- [x] Ingen ægte R-bugs fundet — alle failures var forældte test-forventninger