### PR TITLE
fix(tests): #239-kluster data/performance tests (3 filer)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,16 @@
   funktionen lever i pakke-namespacet; test opdateret til at verificere
   faktiske YAML-værdier (production: `"ERROR"`, development: `"DEBUG"`).
 
+* **#239-kluster: data-operations og performance-tests** (#239): Tre testfiler
+  rettet: (1) `test-file-operations-tidyverse.R` — `validate_uploaded_file`
+  returnerede tidligt ved ikke-eksisterende fil (tempfile-sti), og
+  fejlbeskeder er på dansk; brug `file.create()` + regex mod "tom"/"størrelse".
+  (2) `test-plot-generation-performance.R` — qicharts2 >= 0.5.5 returnerer
+  S7-objekt hvor data tilgås via `@data` i stedet for `$data`; adaptivet til
+  at understøtte begge API-versioner. (3) `test-tidyverse-purrr-operations.R`
+  — `system.time()["elapsed"] > 0` fejler på hurtig hardware hvor operationer
+  afsluttes på < 1ms og runder til 0; ændret til `>= 0`. 0 FAIL (tidligere 5).
+
 * **test-bfh-error-handling: opdatér forventninger efter #240 validering**
   (#239): 6 tests forventede `NULL`-return fra `compute_spc_results_bfh()`
   ved ugyldige input — den adfærd var korrekt FØR #240 indførte eksplicit

--- a/tests/testthat/test-file-operations-tidyverse.R
+++ b/tests/testthat/test-file-operations-tidyverse.R
@@ -57,8 +57,8 @@ test_that("preprocess_uploaded_data handles tidyverse operations correctly", {
     }
 
     # Test data integrity - non-empty meaningful data should be preserved
-    expect_true(nrow(processed_data) >= 3)  # At least some valid rows
-    expect_true(ncol(processed_data) >= 3)  # Preserve columns even if empty
+    expect_true(nrow(processed_data) >= 3) # At least some valid rows
+    expect_true(ncol(processed_data) >= 3) # Preserve columns even if empty
   } else {
     skip("preprocess_uploaded_data function not available")
   }
@@ -119,12 +119,15 @@ test_that("Danish CSV processing with tidyverse locale handling", {
     )
 
     # Test CSV upload processing
-    result <- tryCatch({
-      handle_csv_upload(temp_file, app_state, session_id = "test", emit = mock_emit)
-      "success"
-    }, error = function(e) {
-      list(error = e$message)
-    })
+    result <- tryCatch(
+      {
+        handle_csv_upload(temp_file, app_state, session_id = "test", emit = mock_emit)
+        "success"
+      },
+      error = function(e) {
+        list(error = e$message)
+      }
+    )
 
     if (is.character(result) && result == "success") {
       # Verify data was loaded correctly
@@ -168,9 +171,12 @@ test_that("error handling in file operations with tidyverse", {
     expect_false(result$valid)
     expect_true(length(result$errors) > 0)
 
-    # Test with zero-size file
+    # Test med tom fil (size=0) — brug file.create() så eksistens-tjekket passerer
+    empty_path <- tempfile(fileext = ".csv")
+    file.create(empty_path)
+    on.exit(unlink(empty_path), add = TRUE)
     empty_file_info <- list(
-      datapath = tempfile(),
+      datapath = empty_path,
       name = "empty.csv",
       size = 0,
       type = "text/csv"
@@ -178,19 +184,24 @@ test_that("error handling in file operations with tidyverse", {
 
     result_empty <- validate_uploaded_file(empty_file_info, session_id = "test")
     expect_false(result_empty$valid)
-    expect_true(any(grepl("empty", result_empty$errors, ignore.case = TRUE)))
+    # Fejlbesked er på dansk: "Uploaded fil er tom"
+    expect_true(any(grepl("tom", result_empty$errors, ignore.case = TRUE)))
 
-    # Test with oversized file
+    # Test med oversized fil — brug file.create() og angiv størrelse i metadata
+    big_path <- tempfile(fileext = ".csv")
+    file.create(big_path)
+    on.exit(unlink(big_path), add = TRUE)
     big_file_info <- list(
-      datapath = tempfile(),
+      datapath = big_path,
       name = "big.csv",
-      size = 100 * 1024 * 1024,  # 100MB
+      size = 100 * 1024 * 1024, # 100MB i metadata
       type = "text/csv"
     )
 
     result_big <- validate_uploaded_file(big_file_info, session_id = "test")
     expect_false(result_big$valid)
-    expect_true(any(grepl("size", result_big$errors, ignore.case = TRUE)))
+    # Fejlbesked er på dansk: "Filstørrelse overskrider maksimum på X MB"
+    expect_true(any(grepl("st\u00f8rrelse|overskrider|maksimum", result_big$errors, ignore.case = TRUE)))
   } else {
     skip("validate_uploaded_file function not available")
   }
@@ -213,12 +224,15 @@ test_that("Excel file processing with tidyverse patterns", {
     )
 
     # Test with non-existent Excel file (should handle gracefully)
-    result <- tryCatch({
-      handle_excel_upload(excel_path, session = NULL, app_state, mock_emit)
-      "completed"
-    }, error = function(e) {
-      "error_handled"
-    })
+    result <- tryCatch(
+      {
+        handle_excel_upload(excel_path, session = NULL, app_state, mock_emit)
+        "completed"
+      },
+      error = function(e) {
+        "error_handled"
+      }
+    )
 
     # Either should complete or handle error gracefully
     expect_true(result %in% c("completed", "error_handled"))
@@ -226,4 +240,3 @@ test_that("Excel file processing with tidyverse patterns", {
     skip("Excel upload functions not available")
   }
 })
-

--- a/tests/testthat/test-plot-generation-performance.R
+++ b/tests/testthat/test-plot-generation-performance.R
@@ -27,13 +27,18 @@ test_that("Vectorized part processing produces identical output", {
   )
 
   # Verify that the qic object was created successfully
-  expect_s3_class(qic_result, "qic")
-  expect_true("data" %in% names(qic_result))
+  expect_true(inherits(qic_result, "qic"))
 
-  # Verify that anhoej signals are calculated
-  if ("n.crossings" %in% names(qic_result$data)) {
-    expect_true("n.crossings" %in% names(qic_result$data))
-    expect_true("n.crossings.min" %in% names(qic_result$data))
+  # qicharts2 >= 0.5.5 returnerer S7-objekt — data tilgås via @data-slot
+  # Tidligere versioner brugte $data (S3 list). Understøt begge.
+  qic_data <- tryCatch(qic_result@data, error = function(e) qic_result$data)
+  expect_true(is.data.frame(qic_data))
+  expect_true(nrow(qic_data) > 0)
+
+  # Verify that anhoej signals er beregnet (kolonnenavne afhænger af version)
+  if ("n.crossings" %in% names(qic_data)) {
+    expect_true("n.crossings" %in% names(qic_data))
+    expect_true("n.crossings.min" %in% names(qic_data))
   }
 })
 

--- a/tests/testthat/test-tidyverse-purrr-operations.R
+++ b/tests/testthat/test-tidyverse-purrr-operations.R
@@ -275,9 +275,11 @@ test_that("performance of tidyverse vs base R operations", {
     large_data[1:3] |> purrr::map_int(~ sum(!is.na(.x)))
   })
 
-  # Both should complete successfully
-  expect_true(base_r_time["elapsed"] > 0)
-  expect_true(tidyverse_time["elapsed"] > 0)
+  # Begge operationer skal fuldføres uden fejl.
+  # system.time() kan returnere 0 for meget hurtige operationer på moderne hardware
+  # — brug >= 0 i stedet for > 0 for at undgå flaky tests.
+  expect_true(base_r_time["elapsed"] >= 0)
+  expect_true(tidyverse_time["elapsed"] >= 0)
 
   # Results should be equivalent
   base_result <- sapply(large_data[1:3], function(x) sum(!is.na(x)))


### PR DESCRIPTION
## Sammenfatning

Del af paraply-issue #239. Retter 5 FAIL fordelt på 3 testfiler.

### Per-fil beslutning

**`test-file-operations-tidyverse.R`** — 2 FAIL → 0 FAIL
- `tempfile()` returnerer sti til ikke-eksisterende fil → `validate_uploaded_file` returnerede tidligt med "Uploaded fil findes ikke"
- Fix: `file.create()` så eksistens-tjekket passerer, og regex opdateret til danske fejlbeskeder (`"tom"`, `"størrelse|overskrider|maksimum"`) i stedet for engelsk `"empty"/"size"`

**`test-plot-generation-performance.R`** — 1 FAIL → 0 FAIL
- qicharts2 >= 0.5.5 returnerer S7-objekt: data tilgås via `@data`-slot, ikke `$data` (S3-list)
- Fix: `tryCatch(qic_result@data, error = function(e) qic_result$data)` understøtter begge API-versioner

**`test-tidyverse-purrr-operations.R`** — 2 FAIL → 0 FAIL
- `system.time()["elapsed"] > 0` fejler på hurtig hardware (< 1ms → runder til 0.00)
- Fix: ændret til `>= 0` (korrekt semantik: "operation fuldført uden fejl")

## Test plan

- [x] `test-file-operations-tidyverse.R`: 0 FAIL, 0 WARN, 25 PASS
- [x] `test-plot-generation-performance.R`: 0 FAIL, 1 SKIP (On CRAN), 15 PASS
- [x] `test-tidyverse-purrr-operations.R`: 0 FAIL, 2 SKIP (funktioner ikke tilgængelige i testmiljø), 24 PASS

Closes del af #239.