### PR TITLE
chore(ci): gitflow-light + auto-tagging paa master

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,9 +4,9 @@ name: R-CMD-check
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,9 +4,9 @@ name: lint
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
   workflow_dispatch:
 
 permissions: read-all

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,66 @@
+# Auto-tagging workflow for master releases.
+# Triggers efter groenne R-CMD-check runs paa master og opretter
+# det naeste vMAJOR.MINOR.PATCH-tag baseret paa DESCRIPTION + eksisterende tags.
+#
+# Versioning-strategi (se CLAUDE.md og VERSIONING_POLICY.md):
+# - MAJOR.MINOR laeses fra DESCRIPTION (bumpes manuelt i PR)
+# - PATCH auto-inkrementeres pr. merge til master
+# - Hvis ingen tag matcher nuvaerende MAJOR.MINOR → baseline vMAJOR.MINOR.0
+name: tag-release
+
+on:
+  workflow_run:
+    workflows: ["R-CMD-check"]
+    branches: [master]
+    types: [completed]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    # Koer kun hvis den triggende CI-run var groen
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Compute next tag
+        id: compute
+        run: |
+          set -euo pipefail
+          VERSION=$(grep '^Version:' DESCRIPTION | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "FEJL: Kunne ikke laese Version fra DESCRIPTION" >&2
+            exit 1
+          fi
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          git fetch --tags origin
+          HIGHEST=$(git tag -l "v${MAJOR}.${MINOR}.*" \
+                    | grep -E "^v${MAJOR}\.${MINOR}\.[0-9]+$" \
+                    | sed "s/^v${MAJOR}\.${MINOR}\.//" \
+                    | sort -n | tail -1 || true)
+          if [ -z "$HIGHEST" ]; then
+            NEXT_TAG="v${MAJOR}.${MINOR}.0"
+          else
+            NEXT_TAG="v${MAJOR}.${MINOR}.$((HIGHEST + 1))"
+          fi
+          echo "Computed next tag: $NEXT_TAG (from DESCRIPTION $VERSION)"
+          echo "tag=${NEXT_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push annotated tag
+        env:
+          NEXT_TAG: ${{ steps.compute.outputs.tag }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEXT_TAG" "$COMMIT_SHA" -m "Release $NEXT_TAG"
+          git push origin "$NEXT_TAG"
+          echo "Pushed tag $NEXT_TAG → $COMMIT_SHA"

--- a/.github/workflows/validate-manifest.yaml
+++ b/.github/workflows/validate-manifest.yaml
@@ -4,9 +4,9 @@ name: validate-manifest
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
  - Tilfoej develop til workflow-triggers (feature → develop → master)
  - Nyt tag-release.yaml: auto-opretter vMAJOR.MINOR.PATCH efter groen R-CMD-check paa master
  - MAJOR.MINOR laeses fra DESCRIPTION (bumpes manuelt i PR)
  - PATCH auto-inkrementeres; baseline vMAJOR.MINOR.0 hvis ingen tag matcher
  - Connect Cloud deployer git-backed fra develop (staging) og master (prod); test-gating sker implicit via branch protection paa PR-tidspunkt

<!-- Behold relevante sektioner; slet dem der ikke passer. -->

## Beskrivelse

<!-- Kort beskrivelse af hvad denne PR ændrer og hvorfor. -->

## Type

- [ ] Bug fix
- [ ] Ny feature
- [ ] Refactor (ingen adfærdsændring)
- [ ] Docs/test/chore
- [ ] Breaking change (kræver MAJOR bump + NEWS.md-entry)

## Relaterede issues

<!-- fx: Closes #123, Relateret til #456 -->

## Test plan

- [ ] Unit tests bestået (`devtools::test()` eller `testthat::test_file(...)`)
- [ ] Manual functionality test gennemført
- [ ] Ingen regressioner i relaterede tests
- [ ] NEWS.md opdateret (hvis bruger-synlig ændring)

## Security review — kræves for ændringer i supply-chain-følsomme filer

Hvis denne PR ændrer **en eller flere** af følgende filer, skal reviewer
eksplicit verificere security-impact inden approval:

- [ ] `.Rprofile` (auto-executing ved R session-start)
- [ ] `.Renviron` eller anden secrets-håndtering
- [ ] `dev/git-hooks/*` (kører automatisk ved git-operationer)
- [ ] `dev/install_git_hooks.R` (symlink-creation)
- [ ] `.github/workflows/*` (CI/CD-pipelines med repo-adgang)
- [ ] `tests/e2e/setup.R` eller andre test-bootstrap-filer
- [ ] `DESCRIPTION` (nye dependencies eller `Remotes:`-entries)
- [ ] `renv.lock` (bundlede afhængigheder)

**Review-checklist ved supply-chain-filer:**
1. Ingen netværkskald (`curl`, `download.file`, `httr::GET` uden explicit purpose)
2. Ingen fil-skrivning uden for logs/temp
3. Ingen `system()`/`system2()`-kald uden sanitiseret input
4. Ingen code fra eksterne kilder uden pinned hash/version
5. Ændringer matcher PR-beskrivelsen (ingen "incidental" additions)

Se `.Rprofile`-header for baggrund (#247 M5).

## Danish-language checklist

- [ ] UI-tekst og fejlbeskeder på dansk
- [ ] NEWS.md-entry på dansk
- [ ] Commit-message format: `type(scope): beskrivelse`
- [ ] Ingen Claude attribution footers
