### PR TITLE
chore(ci): drop windows-latest fra R-CMD-check matrix

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,6 @@ jobs:
       matrix:
         config:
           - {os: ubuntu-latest,  r: 'release'}
-          - {os: windows-latest, r: 'release'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Beskrivelse

Halverer CI-varighed ved at fjerne windows-latest fra R-CMD-check matrix.

## Rationale

- Appen deployer paa Linux-baseret Connect Cloud
- Udvikling sker kun paa macOS
- Windows-CI fanger ikke praktiske bugs i denne kontekst
- Offentligt repo giver gratis minutter, saa cost er ikke drivkraften — det er feedback-tid

## Type

- [x] Docs/test/chore

## Test plan

- [x] Workflow-syntaks valid (kun én matrix-linje fjernet)
- [ ] CI greens paa denne PR (bekraefter at ubuntu-latest alene fungerer)