### PR TITLE
chore(hooks): blokér direkte commit/push til master

### DIFF
--- a/dev/git-hooks/pre-commit
+++ b/dev/git-hooks/pre-commit
@@ -1,0 +1,87 @@
+#!/bin/bash
+# ==============================================================================
+# pre-commit git hook for biSPCharts
+# ==============================================================================
+# Blokerer direkte commits paa master + koerer lintr/styler paa staged R-filer.
+#
+# Installation:
+#   Rscript dev/install_git_hooks.R --force
+#
+# Bypass (brug sparsomt):
+#   git commit --no-verify                    # Git-native bypass
+#   SKIP_BRANCH_CHECK=1 git commit            # Kun branch-check bypasses
+#
+# Exit koder:
+#   0 = alle checks bestaaet, commit tilladt
+#   1 = commit blokeret (master, lintr-fejl, eller styler aendrede filer)
+# ==============================================================================
+
+# --- Step 0: Block direkte commits paa master ---
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "master" ] && [ "${SKIP_BRANCH_CHECK:-0}" != "1" ]; then
+  echo ""
+  echo "✗ Direkte commit paa master er blokeret"
+  echo ""
+  echo "  Brug feature-branch-flowet:"
+  echo "    git checkout -b feat/<navn>      # eller fix/, chore/, docs/"
+  echo "    git commit ..."
+  echo "    git push -u origin <branch>"
+  echo "    # opret PR mod develop via GitHub UI"
+  echo ""
+  echo "  Bypass (undtagelsestilfaelde):"
+  echo "    SKIP_BRANCH_CHECK=1 git commit"
+  echo "    git commit --no-verify"
+  echo ""
+  exit 1
+fi
+
+echo "Running pre-commit checks..."
+
+# Find staged R-filer (ekskl. dev/ og golem_utils.R)
+staged_r_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(R|r)$' | grep -v 'dev/' | grep -v 'golem_utils.R')
+
+if [ -z "$staged_r_files" ]; then
+    echo "No R files staged — skipping lint/style"
+    exit 0
+fi
+
+echo "Checking: $staged_r_files"
+
+if ! command -v Rscript &> /dev/null; then
+    echo "Rscript not found — skipping"
+    exit 0
+fi
+
+# Koer lint + style
+Rscript dev/lint_and_style.R $staged_r_files
+exit_code=$?
+
+if [ $exit_code -eq 1 ]; then
+    echo ""
+    echo "COMMIT BLOCKED: Kritiske lintr-fejl fundet."
+    echo "Fix dem og proev igen: Rscript dev/lint_and_style.R"
+    exit 1
+elif [ $exit_code -eq 2 ]; then
+    echo ""
+    echo "Lintr warnings fundet (commit tilladt)."
+fi
+
+# Tjek om styler aendrede STAGED filer
+styler_changed=""
+for f in $staged_r_files; do
+    if [ -f "$f" ] && ! git diff --quiet -- "$f" 2>/dev/null; then
+        styler_changed="$styler_changed $f"
+    fi
+done
+if [ ! -z "$styler_changed" ]; then
+    echo ""
+    echo "Styler har formateret filer:"
+    echo "$styler_changed"
+    echo ""
+    echo "Stage aendringerne og commit igen:"
+    echo "  git add$styler_changed && git commit"
+    exit 1
+fi
+
+echo "Pre-commit checks passed."
+exit 0

--- a/dev/git-hooks/pre-push
+++ b/dev/git-hooks/pre-push
@@ -10,8 +10,9 @@
 #   Rscript dev/install_git_hooks.R
 #
 # Bypass (brug sparsomt):
-#   git push --no-verify     # Git-native bypass
-#   SKIP_PREPUSH=1 git push  # Environment-variabel bypass
+#   git push --no-verify          # Git-native bypass (alt)
+#   SKIP_PREPUSH=1 git push       # Bypass test/lintr checks
+#   SKIP_BRANCH_CHECK=1 git push  # Bypass branch-check (master)
 #
 # Hurtig vs fuld tilstand (§3.1.5):
 #   PREPUSH_MODE=fast git push  # Kun lintr + unit-tests (~2 min)
@@ -19,11 +20,31 @@
 #
 # Exit koder:
 #   0 = alle checks bestået, push tilladt
-#   1 = lintr eller test fejl, push blokeret
+#   1 = branch-check, lintr eller test fejl, push blokeret
 #   2 = Rscript ikke tilgængelig (skippes med advarsel)
 # ==============================================================================
 
 set -euo pipefail
+
+# --- Step 0: Block direkte push til master ---
+# Laes stdin (git giver refs som: <local-ref> <local-sha> <remote-ref> <remote-sha>)
+# og blokerer hvis nogen line peger paa refs/heads/master.
+# Kan bypasses med SKIP_BRANCH_CHECK=1 (fx til emergency hotfix).
+PUSH_REFS=$(cat || true)
+if [ "${SKIP_BRANCH_CHECK:-0}" != "1" ]; then
+  if echo "$PUSH_REFS" | awk '{print $3}' | grep -qx "refs/heads/master"; then
+    echo ""
+    echo "✗ Direkte push til master er blokeret"
+    echo ""
+    echo "  Brug PR-flow via GitHub: feature → develop → master"
+    echo ""
+    echo "  Bypass (undtagelsestilfaelde):"
+    echo "    SKIP_BRANCH_CHECK=1 git push"
+    echo "    git push --no-verify"
+    echo ""
+    exit 1
+  fi
+fi
 
 # Bypass via env-variabel (nyttigt når #239-paraply blokerer)
 if [ "${SKIP_PREPUSH:-0}" = "1" ]; then

--- a/dev/install_git_hooks.R
+++ b/dev/install_git_hooks.R
@@ -13,10 +13,11 @@
 #   Rscript dev/install_git_hooks.R --uninstall
 #
 # Hooks installeret:
-#   - pre-push: dev/git-hooks/pre-push (lintr + testthat full suite)
+#   - pre-commit: dev/git-hooks/pre-commit (blokerer master-commits + lintr/styler)
+#   - pre-push:   dev/git-hooks/pre-push   (blokerer master-push + lintr + testthat)
 #
-# NB: pre-commit-hook håndteres separat (eksisterer allerede direkte i
-# .git/hooks/pre-commit via pre-existing workflow, ikke symlink).
+# NB: Hvis .git/hooks/pre-commit allerede eksisterer som en rigtig fil (ikke
+# symlink), skal du køre med --force for at overskrive den med symlinket version.
 # ==============================================================================
 
 install_git_hooks <- function(force = FALSE, uninstall = FALSE) {


### PR DESCRIPTION
## Beskrivelse

Soft enforcement af GitFlow-workflow via lokale git-hooks. Lokalt installeret `pre-commit` og `pre-push` blokerer utilsigtede direkte operationer paa master.

## Rationale

- Offentligt repo har nu adgang til klassisk branch protection
- Hooks bevares som **hurtig lokal fejl-feedback** foer push sker
- Catcher problemet foer CI paa GitHub skal afvise det
- Brancn protection kan laegges paa som senere supplement (belt and suspenders)

## Aendringer

- Ny `dev/git-hooks/pre-commit`: blokerer commits paa master, bevarer eksisterende lintr + styler logik
- Udvidet `dev/git-hooks/pre-push`: blokerer push hvor remote-ref er `refs/heads/master` (step 0, hurtig feedback foer test-suite)
- Begge bypasses med `SKIP_BRANCH_CHECK=1` ved emergency hotfix
- Opdateret `dev/install_git_hooks.R` kommentar (pre-commit nu del af allowlist)

## Type

- [x] Docs/test/chore

## Test plan

- [x] Begge hooks koert lokalt gennem install script (symlinks verificeret)
- [x] `SKIP_BRANCH_CHECK=1` bypasser korrekt
- [ ] Efter merge: `Rscript dev/install_git_hooks.R --force` skal erstatte pre-existing `.git/hooks/pre-commit` med symlink

## Security review — kraevet (dev/git-hooks/*)

Denne PR aendrer hooks der koerer automatisk ved git-operationer.

- [x] Ingen netvaerkskald
- [x] Ingen fil-skrivning uden for logs/temp
- [x] Ingen `system()`/`system2()`-kald uden sanitiseret input
- [x] Ingen ekstern kode uden pinned hash/version
- [x] Aendringer matcher PR-beskrivelsen