### PR TITLE
fix(ci): tilfoej repos-arg til install.packages i lint-workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
           use-public-rspm: true
 
       - name: Install lintr
-        run: install.packages("lintr")
+        run: install.packages("lintr", repos = "https://packagemanager.posit.co/cran/latest")
         shell: Rscript {0}
 
       - name: Lint


### PR DESCRIPTION
## Beskrivelse

Fixer pre-existing regression i lint-workflow'en. `install.packages()` uden eksplicit `repos`-argument fejlede med:

```
Error in contrib.url(repos, type) : trying to use CRAN without setting a mirror
```

Selvom `setup-r@v2` satte `RSPM`-env-var, saetter R ikke automatisk `options(repos = ...)`.

## Aendring

En linje i `.github/workflows/lint.yaml`:

```diff
- run: install.packages("lintr")
+ run: install.packages("lintr", repos = "https://packagemanager.posit.co/cran/latest")
```

Matcher den URL som `RSPM`-env-var allerede pegede paa.

## Type

- [x] Bug fix

## Test plan

- [x] Ændring isoleret til én YAML-linje
- [ ] CI paa denne PR skal nu koere groen lint-workflow (verifikation)

## Relaterede

Pre-existing regression siden 2026-04-19. Ikke relateret til #270/#271/#272 (CI/CD-setup).