### PR TITLE
fix(cache): resolve #212 in create_cached_reactive (reactive cache-key + timeout)

### DIFF
--- a/R/utils_performance_caching.R
+++ b/R/utils_performance_caching.R
@@ -68,9 +68,38 @@ create_cached_reactive <- function(reactive_expr, cache_key, cache_timeout = CAC
     function() as.character(cache_key)
   }
 
+  # Instance-scoped nonce for cache isolation mellem forskellige wrappers
+  # (undgår utilsigtede key-kollisioner på tværs af callers/sessions).
+  instance_nonce <- digest::digest(
+    list(
+      as.numeric(Sys.time()),
+      stats::runif(1)
+    ),
+    algo = "xxhash64"
+  )
+
+  # Revision bumpes ved hver reaktiv re-evaluering (dependency ændring eller
+  # timeout-baseret invalidation). Dette sikrer at stale cache entries ikke
+  # genbruges efter dependency change.
+  reactive_revision <- 0L
+
   return(reactive({
+    reactive_revision <<- reactive_revision + 1L
+
+    # Sørg for timeout-baseret re-evaluering, så cache-expiry faktisk kan
+    # træde i kraft selv når dependencies ikke ændrer sig.
+    if (is.numeric(cache_timeout) && length(cache_timeout) == 1 && is.finite(cache_timeout) && cache_timeout > 0) {
+      shiny::invalidateLater(max(1L, as.integer(cache_timeout * 1000)))
+    }
+
     # Generate actual cache key
-    actual_key <- key_func()
+    actual_key <- paste0(
+      key_func(),
+      "::",
+      instance_nonce,
+      "::rev_",
+      reactive_revision
+    )
 
     # Check if cached result exists and is fresh
     cached_result <- get_cached_result(actual_key)

--- a/tests/testthat/test-cache-reactive-lazy-evaluation.R
+++ b/tests/testthat/test-cache-reactive-lazy-evaluation.R
@@ -2,17 +2,6 @@
 # Salvage Fase 2: Opdateret mod nuværende cache API
 # Baseret paa R/utils_performance_caching.R
 #
-# NOTE: Alle testServer-baserede tests er markeret SKIP fordi
-# create_cached_reactive() kaster fejl pga. manage_cache_size() ikke
-# eksisterer i namespace. Se Issue #203 for Fase 3 followup.
-
-# =============================================================================
-# KENDTE BEGRAENSNINGER I NUVAERENDE IMPLEMENTATION (dokumenteret):
-#
-# 1. manage_cache_size() ikke i namespace — create_cached_reactive() fejler
-#    naar reactive evalueres, selvom funktionen oprettes uden fejl.
-# =============================================================================
-
 # Minimal module server til at teste reactive caching
 mock_cache_server <- function(id = "test") {
   shiny::moduleServer(id, function(input, output, session) {
@@ -53,7 +42,6 @@ test_that("create_cached_reactive evaluerer lazy", {
 })
 
 test_that("create_cached_reactive reagerer paa reaktive dependencies", {
-  skip("Afventer fix i create_cached_reactive cache-key — se #212")
   skip_if_not(exists("create_cached_reactive"))
 
   shiny::testServer(mock_cache_server, {
@@ -99,7 +87,6 @@ test_that("create_cached_reactive cacher inden for timeout", {
 })
 
 test_that("create_cached_reactive haandterer cache-udloeb", {
-  skip("Afventer fix i create_cached_reactive timeout-handling — se #212")
   skip_if_not(exists("create_cached_reactive"))
 
   shiny::testServer(mock_cache_server, {


### PR DESCRIPTION
### Motivation
- Prevent stale cache entries being reused after reactive dependency updates by making cache keys instance-scoped and revisioned to cover the reactive lifecycle (addresses #212). 
- Ensure cache expiry actually triggers in reactive contexts so timeout-based invalidation is effective. 
- Re-enable the tests that were previously skipped while this behaviour was incorrect so regressions are detectable.

### Description
- `R/utils_performance_caching.R`: added an `instance_nonce` and a `reactive_revision` counter and build `actual_key` as `key_func()::instance_nonce::rev_<n>` so keys are isolated per wrapper and change on re-evaluation. 
- `R/utils_performance_caching.R`: added `shiny::invalidateLater()` scheduling based on `cache_timeout` to drive timeout-based re-evaluation inside the reactive. 
- `tests/testthat/test-cache-reactive-lazy-evaluation.R`: removed two `skip()` calls that were waiting on #212 and removed outdated header comments about the previous limitation so the dependency-invalidation and expiry tests run.

### Testing
- Attempted to run the targeted test file `tests/testthat/test-cache-reactive-lazy-evaluation.R` via `R -q -e "source('global.R'); testthat::test_file('tests/testthat/test-cache-reactive-lazy-evaluation.R')"` but the run failed because `R` is not available in the execution environment (`/bin/bash: R: command not found`). 
- No other automated test runs were executed in this environment due to the missing `R` runtime. 
- Static inspection and local file checks were performed to verify the intended diffs were applied to the two files listed above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6481dc6648330b9de5f7c791632f6)