### PR TITLE
fix(tests): #239-klynge state/cache tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,19 @@
 
 ## Bug fixes
 
+* **Cache-invalidering for all-NA data frames** (#239 — state/cache): Fundet
+  under #239-test-fix-arbejde. `evaluate_data_content_cached()` returnerede
+  fejlagtigt `TRUE` for data frames hvor alle værdier er `NA`, fordi
+  `nzchar(NA, keepNA = FALSE)` uventet returnerer `TRUE`. Konsekvens: cache
+  blev ikke invalideret når data mistede alt indhold → stale UI-tilstand.
+  Fix i `R/utils_performance.R`: eksplicit `!is.na(col) & nzchar(col)`.
+
+* **POSIXct-klasse mistet i data-signature cache-stats** (#239 — state/cache):
+  `get_data_signature_cache_stats()` brugte `sapply()` på POSIXct-timestamps,
+  hvilket strippede klassen til `numeric`. `min()`/`max()` returnerede derfor
+  `numeric` fremfor `POSIXct` med tidszone-info. Fix i
+  `R/utils_data_signatures.R`: `do.call(c, lapply(...))` bevarer klassen.
+
 * **Package/infrastructure tests: opdatér forventninger til nuværende API**
   (#239 — package/infra): 3 test-filer med 6 FAIL + 1 ERR opdateret:
   (1) `test-package-initialization.R`: branding-globals er migreret fra

--- a/R/utils_data_signatures.R
+++ b/R/utils_data_signatures.R
@@ -203,10 +203,11 @@ get_data_signature_cache_stats <- function() {
     ))
   }
 
-  cache_times <- sapply(cache_keys, function(k) {
+  # vapply med POSIXct som returntype bevarer klassen (sapply stripper den)
+  cache_times <- do.call(c, lapply(cache_keys, function(k) {
     entry <- get(k, envir = .data_signature_cache)
     entry$timestamp
-  })
+  }))
 
   list(
     size = length(cache_keys),

--- a/R/utils_performance.R
+++ b/R/utils_performance.R
@@ -98,7 +98,8 @@ evaluate_data_content_cached <- function(data, cache_key = NULL, session = NULL,
         } else if (is.numeric(col)) {
           col_results[i] <- any(!is.na(col))
         } else if (is.character(col)) {
-          col_results[i] <- any(nzchar(col, keepNA = FALSE), na.rm = TRUE)
+          # nzchar(NA, keepNA = FALSE) returnerer uventet TRUE — brug eksplicit NA-tjek
+          col_results[i] <- any(!is.na(col) & nzchar(col))
         } else {
           col_results[i] <- FALSE
         }

--- a/R/utils_spc_cache.R
+++ b/R/utils_spc_cache.R
@@ -314,3 +314,40 @@ cache_spc_result <- function(cache_key, result, cache, ttl = 3600) {
     error_type = "cache_storage"
   )
 }
+
+
+#' Clear All SPC Cache Entries
+#'
+#' Removes all entries from a QIC cache object. Wrapper around `cache$clear()`
+#' som muliggør testbar og eksplicit oprydning af SPC-cachen.
+#'
+#' @param cache cache object. QIC cache instance fra `get_or_init_qic_cache()` eller `create_qic_cache()`.
+#'
+#' @return TRUE hvis ryddet succesfuldt, FALSE ved fejl.
+#'
+#' @examples
+#' \dontrun{
+#' qic_cache <- get_or_init_qic_cache(app_state)
+#' clear_spc_cache(qic_cache)
+#' }
+#'
+#' @keywords internal
+clear_spc_cache <- function(cache) {
+  safe_operation(
+    operation_name = "Clear SPC cache",
+    code = {
+      if (is.null(cache) || !is.list(cache) || !is.function(cache$clear)) {
+        log_warn("Invalid cache object provided", .context = "SPC_CACHE")
+        return(FALSE)
+      }
+
+      cache$clear()
+
+      log_debug("SPC cache ryddet", .context = "SPC_CACHE")
+
+      return(TRUE)
+    },
+    fallback = FALSE,
+    error_type = "cache_clear"
+  )
+}


### PR DESCRIPTION
## Del af #239-paraply

Fikser 4 failures/errors fordelt på 3 testfiler i state/cache-klyngen.

## Ændringer per fil

### test-cache-data-signature-bugs.R — 1 FAIL → 0
**Triage:** (a) Bug i produktion  
**Fix:** `nzchar(NA, keepNA = FALSE)` returnerer uventet `TRUE`, hvorved `evaluate_data_content_cached` fejlagtigt returnerer `TRUE` for data med udelukkende NA-værdier i character-kolonner. Rettet til `!is.na(col) & nzchar(col)`.

### test-shared-data-signatures.R — 2 FAIL → 0
**Triage:** (a) Bug i produktion  
**Fix:** `sapply()` på en liste af `POSIXct`-timestamps stripper klassen og returnerer `numeric`. `min()`/`max()` mister dermed `POSIXct`-klassen. Rettet til `do.call(c, lapply(...))` der bevarer klassen.

### test-spc-cache-integration.R — 1 ERR → 0
**Triage:** (b) Manglende produktion-funktion  
**Fix:** Test kalder `clear_spc_cache(qic_cache)` men funktionen eksisterede ikke. Tilføjet som tynd wrapper om `cache$clear()` med `safe_operation`-guard og logging — konsistent med eksisterende mønstre i `utils_spc_cache.R`.

## Verifikation

- [x] test-cache-data-signature-bugs.R: FAIL 1 → 0 (SKIP 1 bevaret)
- [x] test-shared-data-signatures.R: FAIL 2 → 0 (SKIP 1 bevaret)
- [x] test-spc-cache-integration.R: ERR 1 → 0 (PASS 41)
- [ ] CI validerer efter merge

Part of #239.