### PR TITLE
docs: opdatér test-fejl-tal efter #239-lukning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -347,12 +347,12 @@ git push
 # Hurtig pre-push (kun lintr + udvalgte unit-tests, ~2 min)
 PREPUSH_MODE=fast git push
 
-# Bypass (brug sparsomt, fx når #239-paraply blokerer)
+# Bypass (brug sparsomt, fx når #279/#280 blokerer)
 SKIP_PREPUSH=1 git push
 git push --no-verify        # Git-native alternativ
 ```
 
-⚠️ **VIGTIG:** Pre-push-hooken vil blokere push indtil paraply-issue #239 er lukket (suite har 43 fails + 21 errors pre-existing). Brug `SKIP_PREPUSH=1` midlertidigt.
+⚠️ **VIGTIG:** Test-suiten har stadig 2 fails + 17 errors pre-existing, sporet i #279 (BFHcharts-integration) og #280 (E2E shinytest2). Pre-push-hooken blokerer push indtil disse er lukket. Brug `SKIP_PREPUSH=1` midlertidigt.
 
 **Rprofile-advarsel:** Interaktive R-sessioner i dette repo logger advarsel hvis pre-push ikke er installeret. Ignoreres i Rscript/CI.
 

--- a/dev/install_git_hooks.R
+++ b/dev/install_git_hooks.R
@@ -146,9 +146,9 @@ install_git_hooks <- function(force = FALSE, uninstall = FALSE) {
     message(" Bypass (nyttigt nu):   SKIP_PREPUSH=1 git push")
     message(" Fuld dokumentation:    docs/CONFIGURATION.md §Git Hooks")
     message("")
-    message(" ⚠ VIGTIG: Pre-push vil blokere push indtil #239-paraply er")
-    message("   lukket (43 fails + 21 errors i suite). Brug SKIP_PREPUSH=1")
-    message("   indtil da. Se CLAUDE.md §6 for detaljer.")
+    message(" ⚠ VIGTIG: Pre-push vil blokere push indtil #279 + #280 er lukket")
+    message("   (2 fails + 17 errors i suite). Brug SKIP_PREPUSH=1 indtil da.")
+    message("   Se CLAUDE.md §6 for detaljer.")
     message("")
   }
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -487,7 +487,7 @@ SKIP_PREPUSH=1 git push      # Environment variable
 git push --no-verify         # Git-native bypass
 ```
 
-⚠️ **Kendt begrænsning:** Pre-push vil blokere push indtil paraply-issue #239 er lukket (suite har pre-existing 43 fails + 21 errors). Brug `SKIP_PREPUSH=1` indtil da.
+⚠️ **Kendt begrænsning:** Pre-push vil blokere push indtil #279 + #280 er lukket (suite har pre-existing 2 fails + 17 errors). Brug `SKIP_PREPUSH=1` indtil da.
 
 ### Interaktiv R-session advarsel
 


### PR DESCRIPTION
## Beskrivelse

Opdaterer 3 filer med aktuelt test-suite-status efter #239 er lukket.

**Før:** 43 fails + 21 errors, blokeret af #239-paraply
**Efter:** 2 fails + 17 errors, sporet i #279 + #280

## Aendringer

- `CLAUDE.md` §6: pre-push-hook-advarsel + bypass-kommentar
- `dev/install_git_hooks.R`: post-install-besked
- `docs/CONFIGURATION.md`: kendt begraensning-sektion

## Type

- [x] Docs/test/chore

## Test plan

- [x] Alle 3 filer peger paa rigtige issue-numre (#279, #280)
- [x] Tal matcher seneste devtools::test()-kørsel
- [ ] CI greens