### PR TITLE
fix(autodetect): dansk talformat detekteres korrekt i auto-detect

### DIFF
--- a/R/fct_autodetect_helpers.R
+++ b/R/fct_autodetect_helpers.R
@@ -211,8 +211,8 @@ find_numeric_columns <- function(data) {
     # Test sample for performance
     test_sample <- head(non_missing, 20)
 
-    # Try to convert to numeric
-    converted <- suppressWarnings(as.numeric(test_sample))
+    # Try to convert to numeric (parse_danish_number håndterer komma-decimaler)
+    converted <- suppressWarnings(parse_danish_number(test_sample))
     success_rate <- sum(!is.na(converted)) / length(test_sample)
 
     # If most values convert successfully, consider it numeric
@@ -417,9 +417,9 @@ score_by_data_characteristics <- function(col_data, role = NULL, type = NULL) {
     return(0)
   }
 
-  # Convert to numeric if needed
+  # Convert to numeric if needed (parse_danish_number håndterer komma-decimaler)
   if (!is.numeric(clean_data)) {
-    clean_data <- suppressWarnings(as.numeric(as.character(clean_data)))
+    clean_data <- suppressWarnings(parse_danish_number(as.character(clean_data)))
     clean_data <- clean_data[!is.na(clean_data)]
     if (length(clean_data) == 0) {
       return(0)
@@ -497,9 +497,9 @@ score_by_statistical_properties <- function(col_data, role = NULL, type = NULL) 
     return(0)
   }
 
-  # Convert to numeric if needed
+  # Convert to numeric if needed (parse_danish_number håndterer komma-decimaler)
   if (!is.numeric(clean_data)) {
-    clean_data <- suppressWarnings(as.numeric(as.character(clean_data)))
+    clean_data <- suppressWarnings(parse_danish_number(as.character(clean_data)))
     clean_data <- clean_data[!is.na(clean_data)]
     if (length(clean_data) < 2) {
       return(0)

--- a/openspec/changes/fix-danish-autodetect/tasks.md
+++ b/openspec/changes/fix-danish-autodetect/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: fix-danish-autodetect
+
+- [ ] Fix linje 215 i `R/fct_autodetect_helpers.R` (`as.numeric` → `parse_danish_number`)
+- [ ] Fix linje 422 i `R/fct_autodetect_helpers.R` (scoring-funktion)
+- [ ] Fix linje 502 i `R/fct_autodetect_helpers.R` (scoring-funktion)
+- [ ] Skriv tests i `tests/testthat/test-fct_autodetect_helpers.R`
+- [ ] Verificer alle tests består

--- a/openspec/changes/fix-danish-autodetect/tasks.md
+++ b/openspec/changes/fix-danish-autodetect/tasks.md
@@ -1,7 +1,7 @@
 # Tasks: fix-danish-autodetect
 
-- [ ] Fix linje 215 i `R/fct_autodetect_helpers.R` (`as.numeric` → `parse_danish_number`)
-- [ ] Fix linje 422 i `R/fct_autodetect_helpers.R` (scoring-funktion)
-- [ ] Fix linje 502 i `R/fct_autodetect_helpers.R` (scoring-funktion)
-- [ ] Skriv tests i `tests/testthat/test-fct_autodetect_helpers.R`
-- [ ] Verificer alle tests består
+- [x] Fix linje 215 i `R/fct_autodetect_helpers.R` (`as.numeric` → `parse_danish_number`)
+- [x] Fix linje 422 i `R/fct_autodetect_helpers.R` (scoring-funktion)
+- [x] Fix linje 502 i `R/fct_autodetect_helpers.R` (scoring-funktion)
+- [x] Skriv tests i `tests/testthat/test-autodetect-unified-comprehensive.R`
+- [x] Verificer alle tests består (125 PASS, 0 FAIL)

--- a/tests/testthat/test-autodetect-unified-comprehensive.R
+++ b/tests/testthat/test-autodetect-unified-comprehensive.R
@@ -787,6 +787,42 @@ test_that("find_numeric_columns identificerer numeriske kolonner", {
   expect_false("Navn" %in% result)
 })
 
+test_that("find_numeric_columns detekterer danske talformater (komma-decimal)", {
+  test_data <- data.frame(
+    Dato = c("2024-01-01", "2024-01-02", "2024-01-03"),
+    Tæller = c("10,5", "3,14", "100,0"),
+    Tekst = c("Ja", "Nej", "Ja"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- find_numeric_columns(test_data)
+  expect_true("Tæller" %in% result, info = "Kolonne med komma-decimaler skal detekteres som numerisk")
+  expect_false("Dato" %in% result)
+  expect_false("Tekst" %in% result)
+})
+
+test_that("find_numeric_columns detekterer engelske talformater (punktum-decimal)", {
+  test_data <- data.frame(
+    Dato = c("2024-01-01", "2024-01-02", "2024-01-03"),
+    Tæller = c("10.5", "3.14", "100.0"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- find_numeric_columns(test_data)
+  expect_true("Tæller" %in% result, info = "Engelske talformater (punktum) skal fortsat virke")
+})
+
+test_that("find_numeric_columns returnerer tom vektor for rene tekst-kolonner", {
+  test_data <- data.frame(
+    A = c("Ja", "Nej", "Måske"),
+    B = c("Afd. 1", "Afd. 2", "Afd. 3"),
+    stringsAsFactors = FALSE
+  )
+
+  result <- find_numeric_columns(test_data)
+  expect_length(result, 0)
+})
+
 test_that("detect_columns_name_based finder danske kolonne navne", {
   col_names <- c("Dato", "Tæller", "Nævner", "Kommentar", "Skift", "Frys", "ID")
   result <- detect_columns_name_based(col_names)


### PR DESCRIPTION
## Summary
- `find_numeric_columns()` brugte `as.numeric()` som returnerer `NA` for `"10,5"` — dansk CSV-data med komma-decimaler fejlede auto-detection
- Erstattet med `parse_danish_number()` på 3 steder i `fct_autodetect_helpers.R` (linje 215 detection gate + 422 + 502 scoring-funktioner)
- `parse_danish_number()` håndterer både komma og punktum — ingen regression for engelske tal

## Tests
3 nye tests tilføjet til `test-autodetect-unified-comprehensive.R`:
- Dansk format (`"10,5"`) detekteres som numerisk ✓
- Engelsk format (`"10.5"`) fortsat virker ✓
- Rene tekst-kolonner returnerer tom vektor ✓

Samlet resultat: **125 PASS, 0 FAIL**

## Test plan
- [x] Kør `test-autodetect-unified-comprehensive.R` — 125 PASS
- [x] Pre-push regressionstests bestået

Closes #302