### PR TITLE
fix(table): fjern big.mark for numeriske kolonner i excelR-display

### DIFF
--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -292,7 +292,7 @@ setup_data_table <- function(input, output, session, app_state, emit) {
       data[[col]] <- ifelse(
         is.na(data[[col]]),
         NA_character_,
-        format(data[[col]], decimal.mark = ",", big.mark = ".")
+        format(data[[col]], decimal.mark = ",", big.mark = "")
       )
     }
 


### PR DESCRIPTION
## Problem

`big.mark = "."` i excelR-display formaterede tal som 3529 → "3.529". `parse_danish_number()` tolkede "3.529" som 3.529 (decimal), ikke 3529.

Effekten: efter at brugeren satte et "signal for skifte" (part_var) rekonstruerede appen tabeldataene, og brugerdefinerede kolonner (fx `taeller0`, `sengedage`) forblev som character-strenge. Da disse strenge efterfølgende parses til numerisk, gav `parse_danish_number("3.529")` = 3.529 i stedet for 3529. BFHcharts beregnede dermed `3.529 / 26.74 ≈ 0.132` per observation → centrallinje ~0.15 i stedet for ~154.

## Fix

`big.mark = ""` — tal over 999 vises uden tusindtalsseparator (1500 i stedet for 1.500 eller 1 500). Entydig parse-round-trip.

## Test

5102 pass, 0 fail, 124 skip (alle kendte, dokumenterede).