### PR TITLE
fix(spc): tilføj denominator pre-filter for BFHcharts 0.9.0+ (#342)

### DIFF
--- a/R/fct_spc_plot_generation.R
+++ b/R/fct_spc_plot_generation.R
@@ -581,6 +581,27 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
     x_col_val <- "spc_row_index"
   }
 
+  # Denominator pre-filter: fjern rækker med ugyldige n-værdier
+  # BFHcharts 0.9.0+ kaster hard error ved n <= 0, Inf, NA, eller y > n (P/PP)
+  n_dropped_denom <- 0L
+  if (!is.null(n_col_val) && n_col_val %in% names(data) &&
+    chart_type %in% c("p", "pp", "u", "up")) {
+    n_vals <- suppressWarnings(as.numeric(data[[n_col_val]]))
+    bad_rows <- is.na(n_vals) | n_vals <= 0 | is.infinite(n_vals)
+    if (chart_type %in% c("p", "pp") && !is.null(y_col_val) && y_col_val %in% names(data)) {
+      y_vals <- suppressWarnings(as.numeric(data[[y_col_val]]))
+      bad_rows <- bad_rows | (!is.na(y_vals) & !is.na(n_vals) & y_vals > n_vals)
+    }
+    n_dropped_denom <- sum(bad_rows)
+    if (n_dropped_denom > 0) {
+      data <- data[!bad_rows, ]
+      log_warn(
+        sprintf("Denominator pre-filter: %d rækker fjernet (n<=0, Inf, NA, eller y>n)", n_dropped_denom),
+        .context = "BFH_SERVICE"
+      )
+    }
+  }
+
   # Call BFHchart backend (compute_spc_results_bfh from Task #31)
   # Adapter: Map config object to individual parameters
   result <- tryCatch(
@@ -623,6 +644,10 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
       stop(e) # Re-throw the error - no fallback available
     }
   )
+
+  if (n_dropped_denom > 0) {
+    result$metadata$dropped_denominator_rows <- n_dropped_denom
+  }
 
   return(result)
 }

--- a/R/fct_spc_validate.R
+++ b/R/fct_spc_validate.R
@@ -162,7 +162,7 @@ validate_spc_request <- function(
     }
   }
 
-  # 12. n_var maa ikke indeholde nul-vaerdier for rate-baserede kort
+  # 12. n_var maa ikke indeholde ugyldige vaerdier for rate-baserede kort (BFHcharts 0.9.0+)
   if (!is.null(n_var) && n_var %in% names(data) &&
     ct_normalized %in% c("p", "pp", "u", "up")) {
     n_vals <- data[[n_var]]
@@ -170,11 +170,12 @@ validate_spc_request <- function(
     if (all(is.na(n_numeric)) && is.character(n_vals)) {
       n_numeric <- suppressWarnings(as.numeric(gsub(",", ".", n_vals)))
     }
-    if (any(!is.na(n_numeric) & n_numeric == 0)) {
+    invalid_n <- !is.na(n_numeric) & (n_numeric <= 0 | is.infinite(n_numeric))
+    if (any(invalid_n)) {
       spc_abort(
         paste0(
-          "N\u00e6vner-kolonnen '", n_var, "' indeholder nul-v\u00e6rdier. ",
-          "N\u00e6vner m\u00e5 ikke v\u00e6re nul for ", toupper(ct_normalized), "-kort."
+          "N\u00e6vner-kolonnen '", n_var, "' indeholder ugyldige v\u00e6rdier (\u2264 0 eller uendelig). ",
+          "N\u00e6vner skal v\u00e6re positiv for ", toupper(ct_normalized), "-kort."
         ),
         class = "spc_input_error"
       )

--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -173,6 +173,19 @@ create_spc_results_reactive <- function(
           plot_context = "analysis" # M11: Analyse-side uses "analysis" context
         )
 
+        # Vis advarsel hvis denominator-rækker blev filtreret
+        n_dropped <- spc_result$metadata$dropped_denominator_rows %||% 0L
+        if (n_dropped > 0) {
+          shiny::showNotification(
+            sprintf(
+              "Droppet %d rækker med ugyldig nævner (n ≤ 0, uendelig eller y > n). Chartet viser resterende %d rækker.",
+              n_dropped, nrow(spc_result$qic_data)
+            ),
+            type = "warning",
+            duration = 8
+          )
+        }
+
         # CRITICAL: Skip applyHospitalTheme() for BFHcharts plots
         # BFHcharts applies its own theme and label layers which are incompatible
         # with our theme system. Check metadata$backend flag to determine if plot

--- a/tests/testthat/test-denominator-prefilter.R
+++ b/tests/testthat/test-denominator-prefilter.R
@@ -1,0 +1,153 @@
+# test-denominator-prefilter.R
+# Tests for denominator pre-filter (issue #342)
+# BFHcharts 0.9.0+ kaster hard error ved ugyldige n-værdier.
+# Pre-filteret fjerner sådanne rækker FØR BFHcharts-kaldet.
+
+# Hjælpefunktion: byg minimal p-chart testdata
+make_p_data <- function(n_vals, y_vals = NULL, nrow = NULL) {
+  if (is.null(nrow)) nrow <- length(n_vals)
+  if (is.null(y_vals)) y_vals <- rep(1L, nrow)
+  data.frame(
+    dato = seq_len(nrow),
+    taeller = y_vals,
+    naevner = n_vals,
+    stringsAsFactors = FALSE
+  )
+}
+
+# --- generateSPCPlot pre-filter tests ----------------------------------------
+
+test_that("pre-filter fjerner rækker med n == 0 for p-kort", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  # 12 rækker: én har n == 0 → forventer 11 rækker i resultatet
+  n_vals <- c(0L, rep(100L, 11))
+  y_vals <- c(1L, rep(5L, 11))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(nrow(result$qic_data), 11)
+})
+
+test_that("pre-filter fjerner rækker med n < 0 for p-kort", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  n_vals <- c(-5L, rep(100L, 11))
+  y_vals <- c(1L, rep(5L, 11))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(nrow(result$qic_data), 11)
+})
+
+test_that("pre-filter fjerner rækker med n = Inf for u-kort", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  n_vals <- c(Inf, rep(100, 11))
+  y_vals <- c(1, rep(5, 11))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "u")
+
+  expect_equal(nrow(result$qic_data), 11)
+})
+
+test_that("pre-filter fjerner rækker med n = NA for p-kort", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  n_vals <- c(NA_real_, rep(100, 11))
+  y_vals <- c(1, rep(5, 11))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(nrow(result$qic_data), 11)
+})
+
+test_that("pre-filter fjerner rækker med y > n for p-kort", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  # Én række: y (10) > n (5) → ugyldig for P-chart
+  n_vals <- c(5L, rep(100L, 11))
+  y_vals <- c(10L, rep(5L, 11))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(nrow(result$qic_data), 11)
+})
+
+test_that("pre-filter sætter dropped_denominator_rows i metadata", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  # 2 dårlige rækker: én n==0, én n<0
+  n_vals <- c(0L, -3L, rep(100L, 10))
+  y_vals <- c(1L, 1L, rep(5L, 10))
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(result$metadata$dropped_denominator_rows, 2L)
+})
+
+test_that("pre-filter påvirker IKKE data med udelukkende gyldige n-værdier", {
+  skip_if_not(exists("generateSPCPlot", mode = "function"), "generateSPCPlot ikke tilgængelig")
+
+  n_vals <- rep(100L, 12)
+  y_vals <- rep(5L, 12)
+  df <- make_p_data(n_vals, y_vals)
+
+  config <- list(x_col = NULL, y_col = "taeller", n_col = "naevner")
+  result <- generateSPCPlot(data = df, config = config, chart_type = "p")
+
+  expect_equal(nrow(result$qic_data), 12)
+  expect_null(result$metadata$dropped_denominator_rows)
+})
+
+# --- validate_spc_request check #12 tests ------------------------------------
+
+test_that("validate_spc_request kaster spc_input_error ved n <= 0 (negativ)", {
+  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(-1L, rep(100L, 9)))
+  expect_error(
+    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("validate_spc_request kaster spc_input_error ved n = Inf", {
+  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(Inf, rep(100, 9)))
+  expect_error(
+    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("validate_spc_request kaster spc_input_error ved n == 0 (eksisterende adfærd bevaret)", {
+  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(0L, rep(100L, 9)))
+  expect_error(
+    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("validate_spc_request fejlbesked nævner ≤ 0 eller uendelig", {
+  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(Inf, rep(100, 9)))
+  expect_error(
+    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
+    regexp = "≤ 0 eller uendelig"
+  )
+})
+
+test_that("validate_spc_request accepterer p-kort med alle positive n-værdier", {
+  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = rep(100L, 10))
+  req <- validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner")
+  expect_s3_class(req, "spc_request")
+})


### PR DESCRIPTION
## Summary

- `R/fct_spc_plot_generation.R`: Denominator pre-filter fjerner rækker med `n ≤ 0`, `Inf`, `NA`, eller `y > n` (P/PP-charts) FØR `compute_spc_results_bfh()`-kaldet. Antal droppede rækker gemmes i `result$metadata$dropped_denominator_rows`
- `R/mod_spc_chart_compute.R`: `showNotification(type = "warning")` viser antal droppede rækker og resterende datapunkter
- `R/fct_spc_validate.R`: Check #12 udvides fra kun `n == 0` til `n ≤ 0 | is.infinite(n)` — matcher BFHcharts 0.9.0+ validering
- `tests/testthat/test-denominator-prefilter.R`: 13 nye tests

**Klinisk korrekthed:** BFHcharts 0.9.0+ kaster hard error ved ugyldige n-værdier. Uden pre-filter fejler chartet. Nu degraderer det gracefully med bruger-synlig advarsel.

## Test plan

- [x] 13/13 nye tests grønne
- [x] 30/30 eksisterende validate-tests grønne
- [x] Pre-push gate bestået

Closes #342