### PR TITLE
fix(ci): elimer non-ASCII chars i R-kode for R CMD check gate

### DIFF
--- a/R/fct_spc_plot_generation.R
+++ b/R/fct_spc_plot_generation.R
@@ -581,12 +581,12 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
     x_col_val <- "spc_row_index"
   }
 
-  # Denominator pre-filter: fjern rækker med ugyldige n-værdier
+  # Denominator pre-filter: fjern raekker med ugyldige n-vaerdier
   # BFHcharts 0.9.0+ kaster hard error ved n <= 0, Inf, NA, eller y > n (P/PP)
   n_dropped_denom <- 0L
   if (!is.null(n_col_val) && n_col_val %in% names(data) &&
     chart_type %in% c("p", "pp", "u", "up")) {
-    # parse_danish_number håndterer "50,0" → 50 korrekt (as.numeric ville give NA)
+    # parse_danish_number haandterer "50,0" -> 50 korrekt (as.numeric ville give NA)
     n_vals <- suppressWarnings(parse_danish_number(data[[n_col_val]]))
     bad_rows <- is.na(n_vals) | n_vals <= 0 | is.infinite(n_vals)
     if (chart_type %in% c("p", "pp") && !is.null(y_col_val) && y_col_val %in% names(data)) {
@@ -597,7 +597,7 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
     if (n_dropped_denom > 0) {
       data <- data[!bad_rows, ]
       log_warn(
-        sprintf("Denominator pre-filter: %d rækker fjernet (n<=0, Inf, NA, eller y>n)", n_dropped_denom),
+        sprintf("Denominator pre-filter: %d r\u00e6kker fjernet (n<=0, Inf, NA, eller y>n)", n_dropped_denom),
         .context = "BFH_SERVICE"
       )
     }

--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -173,12 +173,12 @@ create_spc_results_reactive <- function(
           plot_context = "analysis" # M11: Analyse-side uses "analysis" context
         )
 
-        # Vis advarsel hvis denominator-rækker blev filtreret
+        # Vis advarsel hvis denominator-raekker blev filtreret
         n_dropped <- spc_result$metadata$dropped_denominator_rows %||% 0L
         if (n_dropped > 0) {
           shiny::showNotification(
             sprintf(
-              "Droppet %d rækker med ugyldig nævner (n ≤ 0, uendelig eller y > n). Chartet viser resterende %d rækker.",
+              "Droppet %d r\u00e6kker med ugyldig n\u00e6vner (n \u2264 0, uendelig eller y > n). Chartet viser resterende %d r\u00e6kker.",
               n_dropped, nrow(spc_result$qic_data)
             ),
             type = "warning",


### PR DESCRIPTION
## Summary

PR #351 introducerede non-ASCII karakterer (æ, ø, å, ≤) i R/-kildekode der ikke var unicode-escaped. R CMD check med \`error-on: \"warning\"\` (gate-jobbet i CI) fejler på dette og blokerer #356 (promote develop→master).

- **Strings**: unicode-escapes (\`\\u00e6\`, \`\\u00f8\`, \`\\u00e5\`, \`\\u2264\`) for sprintf-args
- **Kommentarer**: transliteration (raekker, vaerdier, haandterer)

## Test plan

- [x] \`tools::showNonASCIIfile()\`: ingen non-ASCII tilbage
- [x] \`testthat::test_file('test-denominator-prefilter.R')\`: 13 PASS / 0 FAIL
- [x] Pre-commit hooks: bestået