### PR TITLE
fix(perf): propagér app_state for SPC cache (#284)

### DIFF
--- a/R/fct_spc_plot_generation.R
+++ b/R/fct_spc_plot_generation.R
@@ -491,6 +491,7 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
                                          viewport_height = NULL,
                                          target_text = NULL,
                                          qic_cache = NULL,
+                                         app_state = NULL,
                                          plot_context = "analysis",
                                          override_dpi = NULL) {
   # Supported chart types (fra config_chart_types.R)
@@ -630,7 +631,10 @@ generateSPCPlot_with_backend <- function(data, config, chart_type,
         # via smart_convert_to_inches (som fejlagtigt antager cm for 10-100 range)
         width = viewport_width_inches,
         height = viewport_height_inches,
-        units = "in"
+        units = "in",
+        # Issue #284: app_state required for cache layer (read_spc_cache/write_spc_cache).
+        # Uden app_state er cache no-op og hver kald rekomputerer fra bunden.
+        app_state = app_state
       )
     },
     error = function(e) {

--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -170,6 +170,7 @@ create_spc_results_reactive <- function(
           viewport_width = vp_dims$width,
           viewport_height = vp_dims$height,
           qic_cache = qic_cache,
+          app_state = app_state,
           plot_context = "analysis" # M11: Analyse-side uses "analysis" context
         )
 


### PR DESCRIPTION
## Summary

`generateSPCPlot_with_backend` videregav ikke `app_state` til `compute_spc_results_bfh`. Cache-laget (`read_spc_cache`/`write_spc_cache`) returnerede NULL/no-op fordi de tjekker \`is.null(app_state)\` ved start. Resultat: cache strukturelt non-functional — hver SPC-kald rekomputerede fra bunden.

## Verifikation

1000 rækker, p-chart, lokal:

| Kald | Tid | Forklaring |
|------|-----|------------|
| Cold | 1610ms | Ingen cache |
| Warm 1 | 321ms | Cache hit (~5x speedup) |
| Warm 2 | 215ms | Cache hit (~7.5x speedup) |

Log viser nu \`Cache hit: spc_p_5696...\` i stedet for stille re-compute.

## Test plan

- [x] Unit-tests: 325 PASS / 0 FAIL / 3 SKIP (pre-eksisterende skips)
- [x] Manuel verifikation: cache hits opnås ved gentagne kald
- [x] Pre-push gates: bestået

## Scope

- \`R/fct_spc_plot_generation.R\`: tilføj \`app_state = NULL\` parameter, videregiv til \`compute_spc_results_bfh\`
- \`R/mod_spc_chart_compute.R\`: videregiv \`app_state\` til \`generateSPCPlot\`
- \`qic_cache\` parameter beholdt (dead code) for at undgå breaking call-sites — kan fjernes senere

Closes #284