### PR TITLE
docs(roxygen): regenerér .Rd for app_state-parameter

### DIFF
--- a/man/generateSPCPlot.Rd
+++ b/man/generateSPCPlot.Rd
@@ -21,6 +21,7 @@ generateSPCPlot(
   viewport_height = NULL,
   target_text = NULL,
   qic_cache = NULL,
+  app_state = NULL,
   plot_context = "analysis",
   override_dpi = NULL
 )

--- a/man/generateSPCPlot_with_backend.Rd
+++ b/man/generateSPCPlot_with_backend.Rd
@@ -21,6 +21,7 @@ generateSPCPlot_with_backend(
   viewport_height = NULL,
   target_text = NULL,
   qic_cache = NULL,
+  app_state = NULL,
   plot_context = "analysis",
   override_dpi = NULL
 )


### PR DESCRIPTION
Fix codoc mismatch fra PR #361 (`app_state`-parameter mangler i .Rd). Blokerer #363 promote-PR's gate-job.

## Test plan
- [x] `devtools::document()` kørt
- [x] 2 .Rd-filer opdateret