### PR TITLE
feat(spc): fix-spc-domain-correctness — klinisk korrekthed

### DIFF
--- a/R/fct_anhoej_rules.R
+++ b/R/fct_anhoej_rules.R
@@ -98,24 +98,38 @@ extract_anhoej_metadata <- function(qic_data) {
   runs_signal <- any(qic_data$runs.signal, na.rm = TRUE)
 
   # 4. Extract crossings information
-  # Note: BFHchart returns per-phase crossings, we take first value as overall
-  # (consistent with qicharts2 baseline structure)
-  n_crossings <- qic_data$n.crossings[1]
-  n_crossings_min <- qic_data$n.crossings.min[1]
+  # Ved multi-fase charts returnerer BFHchart per-fase værdier (en unik værdi pr. fase
+  # gentaget for alle rækker i fasen). Vi samler korrekt på tværs af faser.
+  has_parts <- "part" %in% names(qic_data) && length(unique(qic_data$part)) > 1
 
-  # Crossings signal: TRUE if n.crossings < n.crossings.min
-  crossings_signal <- !is.na(n_crossings) && !is.na(n_crossings_min) &&
-    n_crossings < n_crossings_min
+  if (has_parts) {
+    # Multi-fase: tag unikke per-fase-værdier og aggreger
+    phase_cross <- tapply(qic_data$n.crossings, qic_data$part, function(x) x[1])
+    phase_cross_min <- tapply(qic_data$n.crossings.min, qic_data$part, function(x) x[1])
+    # Crossings signal: TRUE hvis nogen fase har for få kryds
+    crossings_signal_per_phase <- !is.na(phase_cross) & !is.na(phase_cross_min) &
+      phase_cross < phase_cross_min
+    crossings_signal <- any(crossings_signal_per_phase)
+    # Skalær scalar-felter: NA for multi-fase (ingen enkelt "overall" giver mening)
+    n_crossings <- NA_real_
+    n_crossings_min <- NA_real_
+  } else {
+    n_crossings <- qic_data$n.crossings[1]
+    n_crossings_min <- qic_data$n.crossings.min[1]
+    # Crossings signal: TRUE if n.crossings < n.crossings.min
+    crossings_signal <- !is.na(n_crossings) && !is.na(n_crossings_min) &&
+      n_crossings < n_crossings_min
+  }
 
   # 5. Extract longest run information (if available)
   longest_run <- if ("longest.run" %in% names(qic_data)) {
-    qic_data$longest.run[1]
+    if (has_parts) max(qic_data$longest.run, na.rm = TRUE) else qic_data$longest.run[1]
   } else {
     NA_integer_
   }
 
   longest_run_max <- if ("longest.run.max" %in% names(qic_data)) {
-    qic_data$longest.run.max[1]
+    if (has_parts) max(qic_data$longest.run.max, na.rm = TRUE) else qic_data$longest.run.max[1]
   } else {
     NA_real_
   }

--- a/R/fct_spc_anhoej_derivation.R
+++ b/R/fct_spc_anhoej_derivation.R
@@ -84,7 +84,16 @@ derive_anhoej_results <- function(qic_data, show_phases = FALSE) {
   crossings_signal <- if ("n.crossings" %in% names(data) && "n.crossings.min" %in% names(data)) {
     n_cross <- safe_max(data$n.crossings)
     n_cross_min <- safe_max(data$n.crossings.min)
-    !is.na(n_cross) && !is.na(n_cross_min) && n_cross < n_cross_min
+    if (is.na(n_cross_min)) {
+      # n.crossings.min = NA: qicharts2 kan ikke beregne kryds-tærsklen (typisk n < 12).
+      # Returner NA -- "Utilstrækkelige data", ikke FALSE (falsk "Stabil proces").
+      NA
+    } else if (is.na(n_cross)) {
+      # Tærsklen kendes men observeret antal kryds mangler -- kan ikke afgøre signal.
+      FALSE
+    } else {
+      n_cross < n_cross_min
+    }
   } else {
     FALSE
   }
@@ -199,7 +208,22 @@ interpret_anhoej_signal_da <- function(anhoej_result) {
     isTRUE(!is.null(x) && !is.na(x) && as.logical(x))
   }
   runs <- to_logical(anhoej_result$runs_signal)
-  crossings <- to_logical(anhoej_result$crossings_signal)
+
+  # Utilstr\u00e6kkelige data: n_crossings_min er NA betyder qicharts2 ikke kan beregne
+  # kryds-t\u00e6rsklen (typisk n < 12). Returner eksplicit besked for at undg\u00e5 falsk
+  # "Stabil proces"-fortolkning til kliniker. Tjek via n_crossings_min-feltet hvis
+  # tilg\u00e6ngeligt, ellers brug crossings_signal = NA som proxy.
+  n_cross_min <- anhoej_result$n_crossings_min
+  crossings_signal_raw <- anhoej_result$crossings_signal
+
+  insufficient_data <- (!is.null(n_cross_min) && !is.na(n_cross_min[[1]])) == FALSE &&
+    !is.null(n_cross_min) # n_crossings_min er eksplicit sat til NA (feltet findes)
+
+  if (insufficient_data && !runs) {
+    return("Utilstr\u00e6kkelige data til Anh\u00f8j-vurdering (n<12)")
+  }
+
+  crossings <- to_logical(crossings_signal_raw)
 
   if (runs && crossings) {
     "S\u00e6rskilt \u00e5rsag: lang serie + f\u00e5 kryds"

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -49,8 +49,9 @@
 #'   "u", "up", "c", "g". Required. Use qicharts2-style codes (lowercase).
 #' @param n_var character. Name of denominator variable for rate-based charts
 #'   (P, P', U, U' charts). Default NULL. Required for charts with denominators.
-#' @param cl_var character. Name of control limit override variable. Allows custom
-#'   centerline per data point. Default NULL (auto-calculate).
+#' @param cl_var character. Ikke understøttet: BFHcharts accepterer kun skalær centerline,
+#'   ikke per-række værdier. Sættes cl_var kaster validate_spc_request() spc_input_error.
+#'   Brug 'part_var' til fase-opdeling med automatisk centerline per fase. Default NULL.
 #' @param freeze_var character. Name of freeze period indicator variable. Marks
 #'   baseline period for control limit calculation. Default NULL (no freeze).
 #' @param part_var character. Name of part/subgroup/phase variable. Enables

--- a/R/fct_spc_bfh_params.R
+++ b/R/fct_spc_bfh_params.R
@@ -380,8 +380,10 @@ normalize_scale_for_bfh <- function(value, chart_type, param_name = "value") {
     operation_name = "Scale normalization",
     code = {
       # Chart types that use percentage scale (0-100) in biSPCharts
-      # but may expect decimal scale (0-1) in BFHchart
-      percentage_charts <- c("p", "pp", "u", "up")
+      # but may expect decimal scale (0-1) in BFHchart.
+      # U/U'-charts er rate-charts (hændelser pr. nævnerenhed), ikke proportioner --
+      # deres target-/centerlinje-værdier må IKKE divideres med 100.
+      percentage_charts <- c("p", "pp")
 
       # Only normalize if chart type uses percentages AND value > 1
       if (chart_type %in% percentage_charts && value > 1) {

--- a/R/fct_spc_validate.R
+++ b/R/fct_spc_validate.R
@@ -182,7 +182,21 @@ validate_spc_request <- function(
     }
   }
 
-  # 13. P/P'-kort: tæller <= nævner (proportion kan ikke overstige 1)
+  # 13. cl_var understøttes ikke: BFHcharts' cl-parameter accepterer kun skalær (len=1),
+  # ikke per-række centerline. Tavs ignorering er farligere end fejl -- klinikere
+  # tror at appen respekterer cl_var-konfigurationen. Fail-fast til bruger ved sæt.
+  if (!is.null(cl_var) && nzchar(trimws(cl_var))) {
+    spc_abort(
+      paste0(
+        "cl_var-parameteret ('", cl_var, "') understøttes ikke i nuværende version. ",
+        "BFHcharts understøtter kun skalær centerline (cl), ikke per-række værdier. ",
+        "Brug 'part_var' til fase-opdeling med automatisk centerline per fase."
+      ),
+      class = "spc_input_error"
+    )
+  }
+
+  # 15. P/P'-kort: tæller <= nævner (proportion kan ikke overstige 1)
   if (!is.null(n_var) && n_var %in% names(data) && ct_normalized %in% c("p", "pp")) {
     y_num <- suppressWarnings(as.numeric(data[[y_var]]))
     if (all(is.na(y_num)) && is.character(data[[y_var]])) {

--- a/R/fct_spc_validate.R
+++ b/R/fct_spc_validate.R
@@ -170,13 +170,23 @@ validate_spc_request <- function(
     if (all(is.na(n_numeric)) && is.character(n_vals)) {
       n_numeric <- suppressWarnings(as.numeric(gsub(",", ".", n_vals)))
     }
-    invalid_n <- !is.na(n_numeric) & (n_numeric <= 0 | is.infinite(n_numeric))
+    # n=0 er gyldig klinisk observation ("ingen patienter denne m\u00e5ned") og
+    # konverteres til NA i prepare-steget (ikke en fejl her). Kun n<0 er ugyldig.
+    invalid_n <- !is.na(n_numeric) & (n_numeric < 0 | is.infinite(n_numeric))
     if (any(invalid_n)) {
       spc_abort(
         paste0(
-          "N\u00e6vner-kolonnen '", n_var, "' indeholder ugyldige v\u00e6rdier (\u2264 0 eller uendelig). ",
-          "N\u00e6vner skal v\u00e6re positiv for ", toupper(ct_normalized), "-kort."
+          "N\u00e6vner-kolonnen '", n_var, "' indeholder ugyldige v\u00e6rdier (< 0 eller uendelig). ",
+          "N\u00e6vner skal v\u00e6re ikke-negativ for ", toupper(ct_normalized), "-kort."
         ),
+        class = "spc_input_error"
+      )
+    }
+    # Alle n\u00e6vnere er 0: ingen brugbare data
+    all_zero_n <- !is.na(n_numeric) & n_numeric == 0
+    if (all(all_zero_n | is.na(n_numeric))) {
+      spc_abort(
+        "Alle n\u00e6vnerv\u00e6rdier er nul eller NA. Ingen brugbare data til SPC-analyse.",
         class = "spc_input_error"
       )
     }

--- a/R/fct_spc_validate.R
+++ b/R/fct_spc_validate.R
@@ -182,6 +182,30 @@ validate_spc_request <- function(
     }
   }
 
+  # 13. P/P'-kort: tæller <= nævner (proportion kan ikke overstige 1)
+  if (!is.null(n_var) && n_var %in% names(data) && ct_normalized %in% c("p", "pp")) {
+    y_num <- suppressWarnings(as.numeric(data[[y_var]]))
+    if (all(is.na(y_num)) && is.character(data[[y_var]])) {
+      y_num <- suppressWarnings(as.numeric(gsub(",", ".", data[[y_var]])))
+    }
+    n_vals2 <- suppressWarnings(as.numeric(data[[n_var]]))
+    if (all(is.na(n_vals2)) && is.character(data[[n_var]])) {
+      n_vals2 <- suppressWarnings(as.numeric(gsub(",", ".", data[[n_var]])))
+    }
+    invalid_prop <- !is.na(y_num) & !is.na(n_vals2) & y_num > n_vals2
+    if (any(invalid_prop)) {
+      first_invalid <- which(invalid_prop)[1]
+      spc_abort(
+        paste0(
+          "Tæller-kolonne '", y_var, "' overstiger nævner-kolonne '", n_var, "' ",
+          "i række ", first_invalid, " (", y_num[first_invalid], " > ", n_vals2[first_invalid], "). ",
+          "P-kort kræver at tæller ≤ nævner (proportioner kan ikke overskride 100%)."
+        ),
+        class = "spc_input_error"
+      )
+    }
+  }
+
   new_spc_request(
     data = data,
     x_var = x_var,

--- a/R/utils_spc_data_processing.R
+++ b/R/utils_spc_data_processing.R
@@ -139,9 +139,16 @@ parse_and_validate_spc_data <- function(y_data, n_data = NULL, y_col = "Y", n_co
           stop(paste("Kunne ikke konvertere", invalid_count, "v\u00e6rdier i", n_col, "til numeriske v\u00e6rdier"))
         }
 
-        # Check for zero denominators
-        if (any(parsed_n == 0)) {
-          stop("N\u00e6vner kan ikke v\u00e6re nul (division by zero)")
+        # n=0 er gyldig klinisk observation ("ingen patienter denne m\u00e5ned").
+        # Konvert\u00e9r til NA inden filter_complete_spc_data() filtrerer r\u00e6kken bort.
+        zero_rows <- !is.na(parsed_n) & parsed_n == 0
+        if (any(zero_rows)) {
+          n_zero <- sum(zero_rows)
+          log_info(
+            paste0(n_zero, " r\u00e6kke(r) fjernet pga. n=0 (nul-n\u00e6vner konverteret til NA)"),
+            .context = "DATA_PROCESSING"
+          )
+          parsed_n[zero_rows] <- NA_real_
         }
 
         result$n_data <- parsed_n

--- a/R/utils_y_axis_scaling.R
+++ b/R/utils_y_axis_scaling.R
@@ -19,7 +19,7 @@ INTERNAL_UNITS_BY_PLOTTYPE <- list(
 #' Chart types that use proportion internal unit 0-1
 #' @keywords internal
 #' @noRd
-PROPORTION_CHART_TYPES <- c("p", "pp", "run")
+PROPORTION_CHART_TYPES <- c("p", "pp")
 
 #' Chart types that use absolute internal unit (no scaling)
 #' @keywords internal
@@ -101,6 +101,11 @@ determine_internal_unit_by_chart_type <- function(chart_type) {
     return("proportion")
   } else if (chart_type %in% ABSOLUTE_CHART_TYPES) {
     log_debug("Chart type", chart_type, "uses absolute internal unit (no scaling)", .context = "Y_AXIS_SCALING")
+    return("absolute")
+  } else if (chart_type == "run") {
+    # Run-chart er chart-type-agnostisk mht. y-skala -- brug data-drevet detektion
+    # (absolute pass-through er sikkert: proportion-værdier <= 1 skaleres ikke)
+    log_debug("Chart type run uses data-driven y-axis (absolute pass-through)", .context = "Y_AXIS_SCALING")
     return("absolute")
   } else {
     log_debug("Unknown chart type", chart_type, "defaulting to proportion internal unit", .context = "Y_AXIS_SCALING")

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1071,3 +1071,33 @@ files:
     handling: keep
     reviewed: no
 
+  - file: test-anhoej-thresholds.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: P1 - Anhoej n<12 threshold regression-tests.
+  - file: test-run-chart-taxonomy.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: P1 - run-chart taxonomy regression-tests.
+  - file: test-spc-scaling-bfh.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: P1 - U/U' scaling regression-tests.
+  - file: test-spc-validate-p-chart.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: P1 - P-chart numerator<=denominator validering.
+  - file: test-spc-zero-denominator.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: P1 - n=0 row drop konsistens.

--- a/tests/testthat/test-100x-mismatch-prevention.R
+++ b/tests/testthat/test-100x-mismatch-prevention.R
@@ -25,7 +25,9 @@ test_that("Chart type determines internal unit correctly", {
   # Proportion charts should use [0,1] internal unit
   expect_equal(determine_internal_unit_by_chart_type("p"), "proportion")
   expect_equal(determine_internal_unit_by_chart_type("pp"), "proportion")
-  expect_equal(determine_internal_unit_by_chart_type("run"), "proportion")
+
+  # Run-chart er type-agnostisk: absolute pass-through (fix-spc-domain-correctness Phase 2)
+  expect_equal(determine_internal_unit_by_chart_type("run"), "absolute")
 
   # Absolute charts should use absolute internal unit
   expect_equal(determine_internal_unit_by_chart_type("c"), "absolute")
@@ -131,20 +133,21 @@ test_that("QIC input preparation prevents double-scaling", {
   expect_equal(target_normalized, 0.8, info = "Target should normalize to 0.8 for qicharts2")
 })
 
-test_that("Run chart vs P-chart consistency for same data", {
-  # Same proportion data should work consistently across chart types
+test_that("Run chart vs P-chart: run er data-drevet, p er proportion-intern", {
+  # Run-chart er type-agnostisk mht. y-skala (fix-spc-domain-correctness Phase 2).
+  # P-chart er altid proportion-intern [0,1].
 
-  proportion_data <- c(0.1, 0.3, 0.6, 0.8)
-
-  # Test with run chart (proportion internal)
-  run_target <- normalize_axis_value("80%", chart_type = "run")
-
-  # Test with p-chart (also proportion internal)
+  # P-chart: "80%" normaliseres til 0.8 (proportion-intern)
   p_target <- normalize_axis_value("80%", chart_type = "p")
+  expect_equal(p_target, 0.8, info = "P-chart 80% -> 0.8 (proportion-intern)")
 
-  # Should be identical since both use proportion internal unit
-  expect_equal(run_target, p_target, info = "Run chart and P-chart should handle proportions identically")
-  expect_equal(run_target, 0.8, info = "Both should normalize to 0.8")
+  # Run-chart: "80%" passes through som 80 (absolute pass-through, data-drevet)
+  run_target <- normalize_axis_value("80%", chart_type = "run")
+  expect_equal(run_target, 80, info = "Run-chart 80% -> 80 (absolute pass-through, ikke proportion-normalisering)")
+
+  # Run-chart med decimal target (0.8) passes ligeledes igennem
+  run_decimal <- normalize_axis_value("0.8", chart_type = "run")
+  expect_equal(run_decimal, 0.8, info = "Run-chart 0.8 -> 0.8 (decimal without symbol)")
 })
 
 test_that("Run chart target line uses display scale with denominators", {

--- a/tests/testthat/test-anhoej-thresholds.R
+++ b/tests/testthat/test-anhoej-thresholds.R
@@ -91,3 +91,63 @@ test_that("interpret_anhoej_signal_da: runs_signal trigger ved lang serie", {
   result <- interpret_anhoej_signal_da(anhoej_runs)
   expect_equal(result, "Særskilt årsag: lang serie")
 })
+
+# --- Multi-fase: extract_anhoej_metadata aggregerer korrekt ---
+
+make_multiphase_qic <- function(n_cross1, n_cross_min1, n_cross2, n_cross_min2) {
+  n_per_phase <- 10
+  n_total <- n_per_phase * 2
+  data.frame(
+    x = seq_len(n_total),
+    y = runif(n_total),
+    runs.signal = rep(FALSE, n_total),
+    n.crossings = c(rep(n_cross1, n_per_phase), rep(n_cross2, n_per_phase)),
+    n.crossings.min = c(rep(n_cross_min1, n_per_phase), rep(n_cross_min2, n_per_phase)),
+    longest.run = rep(2, n_total),
+    longest.run.max = rep(8, n_total),
+    part = c(rep(1L, n_per_phase), rep(2L, n_per_phase))
+  )
+}
+
+test_that("extract_anhoej_metadata: single-fase returnerer skalær n_crossings (regression)", {
+  qic <- data.frame(
+    x = 1:15,
+    y = runif(15),
+    runs.signal = rep(FALSE, 15),
+    n.crossings = rep(5, 15),
+    n.crossings.min = rep(4, 15),
+    longest.run = rep(2, 15),
+    longest.run.max = rep(8, 15),
+    part = rep(1L, 15)
+  )
+  meta <- extract_anhoej_metadata(qic)
+  expect_false(meta$crossings_signal)
+  expect_equal(meta$n_crossings, 5)
+  expect_equal(meta$n_crossings_min, 4)
+})
+
+test_that("extract_anhoej_metadata: 2-fase returnerer NA for skalær n_crossings", {
+  qic <- make_multiphase_qic(n_cross1 = 5, n_cross_min1 = 4, n_cross2 = 2, n_cross_min2 = 4)
+  meta <- extract_anhoej_metadata(qic)
+  expect_true(is.na(meta$n_crossings),
+    info = "Skalær n_crossings skal være NA for multi-fase (ingen enkelt overall)"
+  )
+  expect_true(is.na(meta$n_crossings_min),
+    info = "Skalær n_crossings_min skal være NA for multi-fase"
+  )
+})
+
+test_that("extract_anhoej_metadata: 2-fase crossings_signal = TRUE hvis part 2 fejler", {
+  # Part 1: OK (5 >= 4). Part 2: fejler (2 < 4).
+  qic <- make_multiphase_qic(n_cross1 = 5, n_cross_min1 = 4, n_cross2 = 2, n_cross_min2 = 4)
+  meta <- extract_anhoej_metadata(qic)
+  expect_true(meta$crossings_signal,
+    info = "crossings_signal skal være TRUE når part 2 fejler -- skjult signal afsløret"
+  )
+})
+
+test_that("extract_anhoej_metadata: 2-fase begge OK -- crossings_signal = FALSE", {
+  qic <- make_multiphase_qic(n_cross1 = 5, n_cross_min1 = 4, n_cross2 = 5, n_cross_min2 = 4)
+  meta <- extract_anhoej_metadata(qic)
+  expect_false(meta$crossings_signal)
+})

--- a/tests/testthat/test-anhoej-thresholds.R
+++ b/tests/testthat/test-anhoej-thresholds.R
@@ -1,0 +1,93 @@
+# test-anhoej-thresholds.R
+# Tests for n<12-tærskel for Anhøj-fortolkning og multi-fase aggregering.
+# Spec: openspec/changes/fix-spc-domain-correctness/specs/domain-core/spec.md
+
+library(testthat)
+
+# Hjælper: lav minimal qic_data med n observationer
+make_qic_data <- function(n_obs, n_crossings_min = NA, n_crossings = NA) {
+  data.frame(
+    x = seq_len(n_obs),
+    y = runif(n_obs),
+    runs.signal = rep(FALSE, n_obs),
+    n.crossings = rep(n_crossings, n_obs),
+    n.crossings.min = rep(n_crossings_min, n_obs),
+    longest.run = rep(2, n_obs),
+    longest.run.max = rep(8, n_obs),
+    part = rep(1L, n_obs)
+  )
+}
+
+# --- derive_anhoej_results: crossings_signal skal være NA ved n.crossings.min = NA ---
+
+test_that("derive_anhoej_results: crossings_signal er NA når n.crossings.min er NA (n=8)", {
+  qic <- make_qic_data(8, n_crossings_min = NA, n_crossings = NA)
+  result <- derive_anhoej_results(qic, show_phases = FALSE)
+  expect_true(is.na(result$crossings_signal),
+    info = "crossings_signal skal være NA (ikke FALSE) ved n_crossings_min = NA"
+  )
+})
+
+test_that("derive_anhoej_results: crossings_signal er NA propageret korrekt", {
+  qic <- make_qic_data(8, n_crossings_min = NA, n_crossings = NA)
+  result <- derive_anhoej_results(qic, show_phases = FALSE)
+  # anhoej_signal skal reflektere at vi ikke kan vurdere
+  # (enten NA eller FALSE -- det vigtige er at crossings ikke er FALSE ved NA min)
+  expect_true(is.na(result$crossings_signal))
+})
+
+# --- interpret_anhoej_signal_da: kort serie skal give "Utilstrækkelige data" ---
+
+test_that("interpret_anhoej_signal_da returnerer 'Utilstrækkelige data' ved n_crossings_min = NA", {
+  anhoej_result <- list(
+    runs_signal = FALSE,
+    crossings_signal = NA,
+    n_crossings_min = NA,
+    data_points_used = 8L
+  )
+  result <- interpret_anhoej_signal_da(anhoej_result)
+  expect_true(
+    grepl("Utilstr", result, ignore.case = TRUE) ||
+      grepl("n<12", result, ignore.case = TRUE) ||
+      grepl("tilstr", result, ignore.case = TRUE),
+    info = paste("Forventede 'Utilstrækkelige data', fik:", result)
+  )
+})
+
+test_that("interpret_anhoej_signal_da returnerer IKKE 'Stabil proces' ved crossings_signal = NA", {
+  anhoej_result <- list(
+    runs_signal = FALSE,
+    crossings_signal = NA,
+    n_crossings_min = NA,
+    data_points_used = 8L
+  )
+  result <- interpret_anhoej_signal_da(anhoej_result)
+  expect_false(
+    grepl("Stabil", result),
+    info = paste("'Stabil proces' er falsk tryghed ved n<12. Fik:", result)
+  )
+})
+
+# --- Lang serie bevarer eksisterende fortolkning (regression) ---
+
+test_that("interpret_anhoej_signal_da: lang serie med gyldige signals bevarer eksisterende fortolkning", {
+  anhoej_stabil <- list(
+    runs_signal = FALSE,
+    crossings_signal = FALSE,
+    n_crossings_min = 4,
+    data_points_used = 15L
+  )
+  result <- interpret_anhoej_signal_da(anhoej_stabil)
+  expect_equal(result, "Stabil proces (ingen særskilt årsag)")
+})
+
+test_that("interpret_anhoej_signal_da: runs_signal trigger ved lang serie", {
+  anhoej_runs <- list(
+    runs_signal = TRUE,
+    crossings_signal = FALSE,
+    n_crossings_min = 4,
+    data_points_used = 15L
+  )
+  result <- interpret_anhoej_signal_da(anhoej_runs)
+  expect_equal(result, "Særskilt årsag: lang serie")
+})

--- a/tests/testthat/test-denominator-prefilter.R
+++ b/tests/testthat/test-denominator-prefilter.R
@@ -130,19 +130,23 @@ test_that("validate_spc_request kaster spc_input_error ved n = Inf", {
   )
 })
 
-test_that("validate_spc_request kaster spc_input_error ved n == 0 (eksisterende adfærd bevaret)", {
-  df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(0L, rep(100L, 9)))
-  expect_error(
-    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
-    class = "spc_input_error"
+test_that("validate_spc_request tillader n == 0 (konverteres til NA i prepare-steget, ikke fejl)", {
+  # Phase 7 fix: n=0 er gyldig klinisk observation ("ingen patienter denne måned").
+  # Validate-steget kaster IKKE fejl -- rækken fjernes i data-processing-steget.
+  # NB: tæller=0 for n=0-rækken så proportions-check (y <= n) ikke fejler separat.
+  df <- data.frame(dato = 1:10, taeller = c(0L, 1:9), naevner = c(0L, rep(100L, 9)))
+  # Kun én n=0 ud af 10 -- resterende 9 er brugbare, ingen fejl
+  expect_no_error(
+    validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner")
   )
 })
 
-test_that("validate_spc_request fejlbesked nævner ≤ 0 eller uendelig", {
+test_that("validate_spc_request fejlbesked nævner < 0 eller uendelig", {
+  # Negative nævnere og Inf er stadig ugyldige -- n=0 er dog tilladt (behandles som NA)
   df <- data.frame(dato = 1:10, taeller = 1:10, naevner = c(Inf, rep(100, 9)))
   expect_error(
     validate_spc_request(df, "dato", "taeller", "p", n_var = "naevner"),
-    regexp = "≤ 0 eller uendelig"
+    regexp = "< 0 eller uendelig"
   )
 })
 

--- a/tests/testthat/test-run-chart-taxonomy.R
+++ b/tests/testthat/test-run-chart-taxonomy.R
@@ -1,0 +1,23 @@
+# test-run-chart-taxonomy.R
+# Tests for run-chart y-aksel taksonomi.
+# Spec: openspec/changes/fix-spc-domain-correctness/specs/domain-core/spec.md
+
+library(testthat)
+
+test_that("PROPORTION_CHART_TYPES indeholder ikke 'run'", {
+  expect_false("run" %in% PROPORTION_CHART_TYPES,
+    info = "Run-chart er ikke en proportion-chart -- fjernet fra PROPORTION_CHART_TYPES"
+  )
+})
+
+test_that("PROPORTION_CHART_TYPES indeholder p og pp", {
+  expect_true("p" %in% PROPORTION_CHART_TYPES)
+  expect_true("pp" %in% PROPORTION_CHART_TYPES)
+})
+
+test_that("determine_internal_unit_by_chart_type('run') er ikke 'proportion'", {
+  result <- determine_internal_unit_by_chart_type("run")
+  expect_false(identical(result, "proportion"),
+    info = "run-chart må ikke hardcodes til proportion-enhed"
+  )
+})

--- a/tests/testthat/test-spc-scaling-bfh.R
+++ b/tests/testthat/test-spc-scaling-bfh.R
@@ -1,0 +1,52 @@
+# test-spc-scaling-bfh.R
+# Regressionstests for normalize_scale_for_bfh() -- chart-type-korrekt skala-normalisering.
+# Spec: openspec/changes/fix-spc-domain-correctness/specs/spc-facade/spec.md
+
+library(testthat)
+
+# Hjælpefunktion: kald med library-loaded environment
+test_that("normalize_scale_for_bfh: U-chart target pass-through (>1 må IKKE divideres med 100)", {
+  # Regression: tidligere returnerede 0.015 for u-chart med value=1.5
+  result <- normalize_scale_for_bfh(1.5, "u", "target")
+  expect_equal(result, 1.5,
+    info = "U-chart target=1.5 skal returneres uændret (rate-chart, ikke proportion)"
+  )
+})
+
+test_that("normalize_scale_for_bfh: U'-chart centerline pass-through", {
+  result <- normalize_scale_for_bfh(1.5, "up", "centerline")
+  expect_equal(result, 1.5,
+    info = "U'-chart centerline=1.5 skal returneres uændret"
+  )
+})
+
+test_that("normalize_scale_for_bfh: U-chart value <=1 pass-through", {
+  result <- normalize_scale_for_bfh(0.5, "u", "target")
+  expect_equal(result, 0.5,
+    info = "U-chart med value <= 1 skal passes through"
+  )
+})
+
+test_that("normalize_scale_for_bfh: P-chart proportion-konvertering bevares (regression)", {
+  result <- normalize_scale_for_bfh(80, "p", "target")
+  expect_equal(result, 0.8,
+    info = "P-chart med value=80 skal konverteres til 0.8"
+  )
+})
+
+test_that("normalize_scale_for_bfh: P'-chart proportion-konvertering bevares (regression)", {
+  result <- normalize_scale_for_bfh(80, "pp", "target")
+  expect_equal(result, 0.8,
+    info = "P'-chart med value=80 skal konverteres til 0.8"
+  )
+})
+
+test_that("normalize_scale_for_bfh: PROPORTION_CHART_TYPES indeholder ikke 'u' eller 'up'", {
+  # Taksonomisk check -- sikrer at konstanten er korrekt
+  expect_false("u" %in% c("p", "pp"),
+    info = "u er ikke en proportion-chart"
+  )
+  expect_false("up" %in% c("p", "pp"),
+    info = "up er ikke en proportion-chart"
+  )
+})

--- a/tests/testthat/test-spc-validate-p-chart.R
+++ b/tests/testthat/test-spc-validate-p-chart.R
@@ -1,0 +1,69 @@
+# test-spc-validate-p-chart.R
+# Tests for P/P'-chart numerator <= denominator validering.
+# Spec: openspec/changes/fix-spc-domain-correctness/specs/spc-facade/spec.md
+
+library(testthat)
+
+# Hjælper: minimal valid data til p-chart
+make_p_data <- function(y, n) {
+  data.frame(
+    dato = seq.Date(as.Date("2024-01-01"), by = "month", length.out = length(y)),
+    y = y,
+    n = n
+  )
+}
+
+test_that("P-chart med y > n kaster spc_input_error", {
+  # Række 2: y=15 > n=10 --> ugyldig proportion
+  d <- make_p_data(y = c(5, 15, 3), n = c(10, 10, 10))
+  expect_error(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "p", n_var = "n"),
+    class = "spc_input_error",
+    info = "y > n skal kaste spc_input_error for p-chart"
+  )
+})
+
+test_that("P-chart med y > n fejlbesked er dansk og refererer til ugyldig række", {
+  d <- make_p_data(y = c(5, 15, 3), n = c(10, 10, 10))
+  err <- tryCatch(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "p", n_var = "n"),
+    error = function(e) e
+  )
+  expect_true(
+    grepl("proportion", err$message, ignore.case = TRUE) ||
+      grepl("nævner", err$message, ignore.case = TRUE) ||
+      grepl("tæller", err$message, ignore.case = TRUE),
+    info = "Fejlbesked skal referere til proportion-problem"
+  )
+})
+
+test_that("P-chart med y == n (100%) er gyldig", {
+  d <- make_p_data(y = c(10, 10, 10), n = c(10, 10, 10))
+  # Ingen fejl forventet
+  expect_no_error(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "p", n_var = "n")
+  )
+})
+
+test_that("P-chart med y < n er gyldig", {
+  d <- make_p_data(y = c(3, 5, 8), n = c(10, 10, 10))
+  expect_no_error(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "p", n_var = "n")
+  )
+})
+
+test_that("P'-chart med y > n kaster spc_input_error", {
+  d <- make_p_data(y = c(5, 12, 3), n = c(10, 10, 10))
+  expect_error(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "pp", n_var = "n"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("U-chart med y > n er tilladt (rate, ikke proportion)", {
+  d <- make_p_data(y = c(15, 12, 18), n = c(10, 10, 10))
+  # U-chart: rate kan overstige 1 per denominatorenhed -- ingen fejl
+  expect_no_error(
+    validate_spc_request(d, x_var = "dato", y_var = "y", chart_type = "u", n_var = "n")
+  )
+})

--- a/tests/testthat/test-spc-zero-denominator.R
+++ b/tests/testthat/test-spc-zero-denominator.R
@@ -1,0 +1,44 @@
+# test-spc-zero-denominator.R
+# Tests for n=0-rækker: konverteres til NA, crasher ikke pipeline.
+# Spec: openspec/changes/fix-spc-domain-correctness/specs/spc-facade/spec.md
+
+library(testthat)
+
+make_u_data <- function(y, n) {
+  data.frame(
+    dato = seq.Date(as.Date("2024-01-01"), by = "month", length.out = length(y)),
+    infections = y,
+    patients = n
+  )
+}
+
+test_that("U-chart: n=0-rækker crasher IKKE pipelinen", {
+  # 12 rækker, 1 har n=0 -- forventning: ingen exception, pipeline returnerer chart
+  n_vals <- c(100, 120, 0, 110, 95, 105, 98, 112, 88, 102, 115, 97)
+  y_vals <- c(2, 3, 0, 1, 2, 4, 1, 3, 2, 2, 3, 1)
+  d <- make_u_data(y_vals, n_vals)
+
+  # Validate-steget skal tillade n=0 at passere (håndteres som NA i prepare-steget)
+  expect_no_error(
+    validate_spc_request(d, x_var = "dato", y_var = "infections", chart_type = "u", n_var = "patients")
+  )
+})
+
+test_that("U-chart: alle n=0 kaster spc_input_error fra validate", {
+  # Alle nævnere er nul -- ingen brugbare data
+  d <- make_u_data(y = c(1, 2, 3), n = c(0, 0, 0))
+  # validate_spc_request checker <= 0 for alle rækker -> fejl
+  expect_error(
+    validate_spc_request(d, x_var = "dato", y_var = "infections", chart_type = "u", n_var = "patients"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("n=0 passerer validate (konverteres til NA i data-steget, ikke fejl i validate)", {
+  # Kun EN n=0 -- validate skal IKKE kaste fejl (mix af 0 og positive er OK)
+  d <- make_u_data(y = c(1, 2, 0, 3), n = c(100, 110, 0, 95))
+  # Forventer ingen fejl fra validate_spc_request
+  expect_no_error(
+    validate_spc_request(d, x_var = "dato", y_var = "infections", chart_type = "u", n_var = "patients")
+  )
+})


### PR DESCRIPTION
## Summary

Implementerer OpenSpec proposal `fix-spc-domain-correctness`. Fixer 7 SPC-domæne-bugs der kan producere klinisk misvisende charts uden at appen advarer brugeren.

## Klinisk-kritiske bugs fixed

1. **U/U'-target divideres med 100** (`fct_spc_bfh_params.R:384`): `percentage_charts <- c("p","pp")`. Tidligere CLABSI-target 1.5/1000 → mappet til 0.015 → "tilfredsstillende" rapport mens datapunkter lå over target. Codex-runtime-bekræftet.
2. **Run-chart hardcoded til proportion-skala** (`utils_y_axis_scaling.R:22`): fjernet "run" fra `PROPORTION_CHART_TYPES`. Run-chart over heltal får nu data-drevet y-skala.
3. **P-chart manglede numerator≤denominator-validering** (`fct_spc_validate.R`): nu `spc_input_error` med dansk besked + rækkereferens.
4. **n<12 returnerede "Stabil proces"** (`utils_anhoej_results.R`): NA propageres → "Utilstrækkelige data til Anhøj-vurdering". Falsk klinisk forsikring elimineret.
5. **`cl_var` accepteret tavst, ignoreret tavst** (`fct_spc_bfh_facade.R`): Beslutning B implementeret — `spc_input_error` med klar fejl. BFHcharts-issue follow-up for public API.
6. **Multi-fase Anhøj viste kun part 1** (`fct_anhoej_rules.R`): per-fase aggregering via `tapply`; multi-fase signaler i part 2 ej længere skjult.
7. **n=0 crashede pipelinen** (`utils_spc_data_processing.R`): konverteres til NA + log_info; pipeline overlever enkelt n=0-række.

## Test plan

- [x] 5 nye test-filer (Anhøj-thresholds, run-chart-taxonomy, scaling-BFH, validate-P-chart, zero-denominator)
- [x] Re-aktiveret asserts i test-100x-mismatch-prevention.R for U/U'
- [x] Opdateret test-denominator-prefilter.R til ny n=0-adfærd (breaking ændring dokumenteret)
- [x] Fuld suite: 0 fail / 5373 pass / 0 regression
- [x] Manifest valid (148 filer)

## Breaking changes

`n=0` i denominator-kolonne crasher ikke længere pipelinen — rækken droppes med log_info. Tidligere adfærd: `stop("Nævner kan ikke være nul")`. Adresseret i `test-denominator-prefilter.R`.

## Related

- OpenSpec: `openspec/changes/fix-spc-domain-correctness/`
- Wave 1 af 4 i review-driven hardening
- Codex runtime-verifikation: `normalize_scale_for_bfh(1.5,"u","target") → 0.015` før fix