### PR TITLE
fix(check): R CMD check warnings runde 2

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -37,7 +37,7 @@ main_app_server <- function(input, output, session) {
   # get_golem_config() læser inst/golem-config.yml; tryCatch→FALSE hvis nøgle mangler.
   # Matcher mønster i utils_lazy_loading.R (advanced_debug condition).
   debug_mode_on <- isTRUE(tryCatch(
-    golem::get_golem_config("debug_mode_enabled"),
+    golem::get_golem_options("debug_mode_enabled"),
     error = function(e) FALSE
   )) || Sys.getenv("SPC_DEBUG_MODE", "FALSE") == "TRUE"
   if (debug_mode_on) {

--- a/R/utils_async_helpers.R
+++ b/R/utils_async_helpers.R
@@ -134,5 +134,5 @@ make_ai_extended_task <- function(
         }
       )
     })
-  }) |> shiny::bindToSession(session)
+  })
 }

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -9,8 +9,8 @@
 #' @keywords internal
 session_timeout_message <- function() {
   paste0(
-    "Session udløbet pga. inaktivitet. ",
-    "Genindlæs siden for at fortsætte."
+    "Session udl\u00f8bet pga. inaktivitet. ",
+    "Genindl\u00e6s siden for at forts\u00e6tte."
   )
 }
 
@@ -52,7 +52,7 @@ setup_session_timeout <- function(session, minutes,
         if (cancelled) {
           return(invisible(NULL))
         }
-        # Vis dansk notifikation hvis session-context understøtter det
+        # Vis dansk notifikation hvis session-context understoetter det
         tryCatch(
           shiny::showNotification(
             session_timeout_message(),
@@ -109,9 +109,9 @@ setup_session_timeout <- function(session, minutes,
 activate_session_timeout_from_config <- function(input, session,
                                                  .scheduler = later::later) {
   # Hent timeout fra security-blok i golem-config (production: 60 min, dev: 480 min)
-  # Kilde: inst/golem-config.yml → <env>:security:session_timeout_minutes
+  # Kilde: inst/golem-config.yml -> <env>:security:session_timeout_minutes
   timeout_minutes <- tryCatch(
-    golem::get_golem_config("security")$session_timeout_minutes,
+    golem::get_golem_options("security")$session_timeout_minutes,
     error = function(e) {
       log_debug(
         paste("get_golem_config('security') fejlede:", conditionMessage(e)),
@@ -121,10 +121,10 @@ activate_session_timeout_from_config <- function(input, session,
     }
   )
 
-  # Ingen konfigureret timeout: deaktivér stiltiende
+  # Ingen konfigureret timeout: deaktiver stiltiende
   if (is.null(timeout_minutes) || !is.numeric(timeout_minutes) || timeout_minutes <= 0) {
     log_debug(
-      "Ingen session timeout konfigureret — deaktiveret",
+      "Ingen session timeout konfigureret \u2014 deaktiveret",
       .context = "SESSION_TIMEOUT"
     )
     return(invisible(NULL))


### PR DESCRIPTION
Følge-op til PR #378. Yderligere 2 warnings opdaget i `gate (tests + warnings)` på PR #372:

1. **Non-ASCII** i `R/utils_server_session_helpers.R` (P4's session-timeout-helper) — konverteret æøå/→/—
2. **Missing/unexported objects** `golem::get_golem_config` og `shiny::bindToSession`:
   - golem eksporterer `get_golem_options`, ikke `get_golem_config` — rettet i `R/app_server_main.R` + `R/utils_server_session_helpers.R`
   - `shiny::bindToSession` eksisterer ikke — fjernet pipe i `R/utils_async_helpers.R` (ExtendedTask binder implicit)

## Test plan
- [x] test-session-timeout.R: 13/13 PASS
- [x] test-async-export-task.R: 9/9 PASS
- [x] tools::showNonASCIIfile() ren på alle 4 filer

Forventes at lukke PR #372's gate-fejl.