### PR TITLE
docs(news): tilfoej entry for dead token-state cleanup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,19 @@
   BOM, mixed CRLF/LF, dansk komma-decimal med tab-delimiter. OpenSpec:
   `align-csv-validator-and-pkgload-runtime` Phase 1.
 
+## Interne ændringer
+
+* **Fjernet dead token-tracking-state fra `app_state$ui`:** Felterne
+  `pending_programmatic_inputs` og `programmatic_token_counter` var
+  defineret i `R/state_management.R`, men ingen produktionskode populerede
+  dem længere (producent fjernet i tidligere refaktor `a4c1c399` uden
+  consumer-cleanup). Fire observer-bodies læste/ryddede defensivt felter
+  der aldrig blev sat. Cleanup sletter dead state, fjerner ~17 linjer
+  observer-defensiv-kode og sletter `test-ui-token-management.R`
+  (kun plumbing-tests af dead state). `queued_updates`-feltet bibeholdes
+  som legitim session-global UI-update-queue. OpenSpec:
+  `extract-ui-tokens-to-observer-env`.
+
 # biSPCharts 0.3.1
 
 ## Interne ændringer

--- a/openspec/changes/extract-ui-tokens-to-observer-env/tasks.md
+++ b/openspec/changes/extract-ui-tokens-to-observer-env/tasks.md
@@ -38,7 +38,7 @@
 
 ## 6. Release
 
-- [ ] 6.1 PR til develop fra `feat/extract-ui-tokens-to-observer-env`
-- [ ] 6.2 NEWS.md entry (interne ændringer): "Fjernet dead token-tracking-state fra `app_state$ui`"
-- [ ] 6.3 CI grøn
-- [ ] 6.4 Merge
+- [x] 6.1 PR til develop fra `feat/extract-ui-tokens-to-observer-env` (PR #388 merged 2026-04-30)
+- [x] 6.2 NEWS.md entry (interne ændringer): "Fjernet dead token-tracking-state fra `app_state$ui`" (separat PR `chore/news-token-cleanup`)
+- [x] 6.3 CI grøn
+- [x] 6.4 Merge


### PR DESCRIPTION
## Sammenfatning

Foelge-op til PR #388 (`extract-ui-tokens-to-observer-env`). Release-task 6.2 (NEWS-entry) blev ikke commit'et som del af original PR. Denne PR tilfoejer:

- `NEWS.md`: ny `## Interne aendringer`-sektion under `# biSPCharts 0.3.2` der dokumenterer fjernelse af dead token-tracking-state (`pending_programmatic_inputs`, `programmatic_token_counter`)
- `openspec/changes/extract-ui-tokens-to-observer-env/tasks.md`: marker release-tasks 6.1-6.4 som faerdige

## Test plan

- [x] `git diff` review — ingen utilsigtede aendringer
- [x] Pre-push gate gron (fast mode)
- [x] OpenSpec change er allerede arkiveret-klar (alle Validering-tasks done)

## Reference

- Parent PR: #388
- OpenSpec change: `openspec/changes/extract-ui-tokens-to-observer-env/`