### PR TITLE
feat(branding): finalize adopt-bfhcharts-assets-companion (tests + NEWS + docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@
 **Technology Stack:**
 - Shiny + Golem
 - BFHcharts (SPC visualization), BFHtheme (branding), BFHllm (AI/LLM)
+- BFHchartsAssets (privat companion-pkg med proprietære fonts/logoer; staages via `inject_template_assets()` ved runtime; kræver `GITHUB_PAT` for Connect Cloud)
 - qicharts2 (Anhøj rules)
 - Ragnar (RAG knowledge store, via BFHllm)
 
@@ -108,7 +109,8 @@ Implementation: `R/fct_spc_file_save_load.R`, `R/fct_excel_sheet_detection.R`,
 ### External Package Ownership
 
 ✅ **Maintainer kontrollerer fuldt:** BFHcharts (rendering), BFHtheme (branding),
-BFHllm (LLM/RAG/caching), Ragnar (knowledge store).
+BFHllm (LLM/RAG/caching), Ragnar (knowledge store), BFHchartsAssets (proprietære
+fonts/logoer; privat repo, kræver `GITHUB_PAT`).
 
 ❌ **ALDRIG implementér** funktionalitet i biSPCharts som hører hjemme i ekstern
 pakke (eks: target lines, font fallback, hospital colors, embeddings, BM25,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,26 @@
 # biSPCharts 0.3.2
 
+## Sikkerhed
+
+* **Adopt BFHchartsAssets companion-pakke for proprietære fonts og
+  hospital-logoer:** biSPCharts bundler ikke længere Mari-fonts (Region
+  Hovedstadens custom font, proprietær), Arial TTF-kopier (Microsoft/
+  Monotype EULA) eller hospital-logoer (Region Hovedstadens brand-
+  ejendom) i det public repo. Assets leveres nu fra privat
+  `BFHchartsAssets` companion-pakke (>= 0.1.0) der staages ved runtime
+  via `inject_template_assets()` → `BFHchartsAssets::inject_bfh_assets()`.
+  Fjernet 30 filer fra git tracking (~22 fonts + 7 logoer) i
+  `inst/templates/typst/bfh-template/{fonts,images}/`. `.gitignore`
+  opdateret med defensive patterns. Connect Cloud-deployment kræver
+  `GITHUB_PAT`-env-var med privat repo-adgang. Graceful fallback ved
+  manglende companion: PDF eksporteres uden hospital-branding +
+  log_warn, ingen error. OpenSpec:
+  `adopt-bfhcharts-assets-companion`. PRs: #379, #381, #387.
+
+  ⚠️ **Open follow-up:** proprietære assets forbliver i biSPCharts git
+  history indtil eventuel `git filter-repo`-operation. Denne change
+  adresserer kun fremtidig tracking.
+
 ## Bug fixes
 
 * **Fix Connect Cloud deployment-fejl:** `app.R` brugte `library(biSPCharts)`

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -559,6 +559,18 @@ files:
     reviewed: yes
     reviewer: johanreventlow
     reviewed_date: '2026-04-17'
+  - file: test-inject-template-assets.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: yes
+    rationale: >
+      NY i adopt-bfhcharts-assets-companion (Phase 5). 4 tests med
+      mockery-stubs: missing companion (FALSE + no error), delegation-success,
+      companion-fejl-fallback. Daekker spec-scenarier fra
+      openspec/specs/export-preview. 7/7 PASS.
+    reviewer: johanreventlow
+    reviewed_date: '2026-04-30'
   - file: test-integration-workflows.R
     audit_category: green
     type: integration

--- a/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
+++ b/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
@@ -57,6 +57,6 @@
 
 ## 9. Release
 
-- [ ] 9.1 PR til develop fra `feat/adopt-bfhcharts-assets-companion`
-- [ ] 9.2 CI grøn
-- [ ] 9.3 Merge + bump biSPCharts version
+- [x] 9.1 PR til develop — implementation via #379/#381/#387; finalize-PR #398 (`feat/adopt-bfhcharts-finalize`)
+- [ ] 9.2 CI grøn (afventer PR #398)
+- [ ] 9.3 Merge + bump biSPCharts version (afventer CI grøn)

--- a/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
+++ b/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
@@ -32,8 +32,8 @@
 
 - [x] 5.1 Opdatér tests for `inject_template_assets()` (hvis findes) — N/A, ingen eksisterende tests; nyt `tests/testthat/test-inject-template-assets.R` oprettet
 - [x] 5.2 Tilføj test der mocker `BFHchartsAssets`-fravær (4 tests: missing+no-error + delegation + companion-fail)
-- [ ] 5.3 Kør `devtools::test()`
-- [ ] 5.4 Kør `devtools::check()`
+- [x] 5.3 Kør `devtools::test()` — 5552 PASS, 0 FAIL, 101 SKIP, 50 WARN (alle pre-existing, ej introducerede regressions)
+- [ ] 5.4 Kør `devtools::check()` — DEFERRED til PR CI-gate (`gate (tests + warnings)` job)
 
 ## 6. Connect Cloud setup (MANUELT)
 

--- a/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
+++ b/openspec/changes/adopt-bfhcharts-assets-companion/tasks.md
@@ -30,8 +30,8 @@
 
 ## 5. Tests
 
-- [ ] 5.1 Opdatér tests for `inject_template_assets()` (hvis findes)
-- [ ] 5.2 Tilføj test der mocker `BFHchartsAssets`-fravær
+- [x] 5.1 Opdatér tests for `inject_template_assets()` (hvis findes) — N/A, ingen eksisterende tests; nyt `tests/testthat/test-inject-template-assets.R` oprettet
+- [x] 5.2 Tilføj test der mocker `BFHchartsAssets`-fravær (4 tests: missing+no-error + delegation + companion-fail)
 - [ ] 5.3 Kør `devtools::test()`
 - [ ] 5.4 Kør `devtools::check()`
 

--- a/tests/testthat/test-inject-template-assets.R
+++ b/tests/testthat/test-inject-template-assets.R
@@ -1,0 +1,60 @@
+#  Tests for inject_template_assets()
+#
+#  Spec: openspec/specs/export-preview (ADDED via adopt-bfhcharts-assets-companion)
+#
+#  Scenarier dækket:
+#   1. BFHchartsAssets installeret + reachable -> delegation virker, returns invisible(TRUE)
+#   2. BFHchartsAssets ikke installeret -> log_warn + invisible(FALSE), kaster ej error
+#   3. BFHchartsAssets::inject_bfh_assets() fejler -> safe_operation fallback til FALSE
+
+test_that("inject_template_assets returns invisible(FALSE) when BFHchartsAssets missing", {
+  mockery::stub(inject_template_assets, "requireNamespace", FALSE)
+
+  tmp <- tempfile("inject-test-")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  result <- expect_invisible(inject_template_assets(tmp))
+  expect_false(result)
+})
+
+test_that("inject_template_assets does not raise error when companion missing", {
+  mockery::stub(inject_template_assets, "requireNamespace", FALSE)
+
+  tmp <- tempfile("inject-test-")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  expect_no_error(inject_template_assets(tmp))
+})
+
+test_that("inject_template_assets delegates to companion when available", {
+  skip_if_not_installed("BFHchartsAssets")
+
+  tmp <- tempfile("inject-test-")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  result <- inject_template_assets(tmp)
+  expect_true(result)
+
+  # Verificér at companion-pakken faktisk har staged assets
+  expect_gt(length(list.files(file.path(tmp, "fonts"))), 0L)
+  expect_gt(length(list.files(file.path(tmp, "images"))), 0L)
+})
+
+test_that("inject_template_assets returns FALSE when companion's inject fails", {
+  mockery::stub(inject_template_assets, "requireNamespace", TRUE)
+  mockery::stub(
+    inject_template_assets,
+    "BFHchartsAssets::inject_bfh_assets",
+    function(td) stop("simuleret companion-fejl")
+  )
+
+  tmp <- tempfile("inject-test-")
+  dir.create(tmp)
+  on.exit(unlink(tmp, recursive = TRUE), add = TRUE)
+
+  result <- inject_template_assets(tmp)
+  expect_false(result)
+})


### PR DESCRIPTION
## Sammenfatning

Foelger op paa OpenSpec-change `adopt-bfhcharts-assets-companion`. Implementation merged via PRs #379, #381, #387 (manifest-hotfix). Denne PR daekker resterende tasks fra Phase 5 + 7:

### Tests (Phase 5)
- Nyt `tests/testthat/test-inject-template-assets.R` med 4 testthat-blocks (7 expects):
  - Missing companion -> `invisible(FALSE)` + ingen error
  - Delegation til `BFHchartsAssets::inject_bfh_assets()` (skip\\_if\\_not\\_installed)
  - Companion-fejl -> safe\\_operation fallback til FALSE
- Bruger `mockery::stub` jvf. patternet i `test-utils-bfhllm-integration.R`
- Test-classification manifest opdateret

### Docs (Phase 7)
- `NEWS.md`: ny `## Sikkerhed`-sektion under 0.3.2 med detaljeret beskrivelse af asset-removal + open follow-up (git history-purge)
- `CLAUDE.md`: tilfoej BFHchartsAssets til Technology Stack + External Package Ownership (privat repo, kraever `GITHUB_PAT`)

## Test plan

- [x] `devtools::test()` — 5552 PASS, 0 FAIL, 101 SKIP
- [x] Pre-push gate (lint + classify + manifest) — gron
- [ ] CI: testthat + smoke + lint + manifest
- [ ] CI: gate (R CMD check + warnings)

## Resterende tasks (out of scope for denne PR)

- **6.x [MANUELT]:** Connect Cloud `GITHUB_PAT`-setup + re-deploy + verifikation (kraever admin-adgang)
- **8.x [BESLUTNING]:** Skal git history purges via `git filter-repo`? (destruktiv operation, kraever bruger-godkendelse)
- **9.3:** Merge + bump version (efter CI gron)

## Reference

- OpenSpec change: `openspec/changes/adopt-bfhcharts-assets-companion/`
- Implementation: PR #379, #381, #387
- Spec: `openspec/changes/adopt-bfhcharts-assets-companion/specs/export-preview/spec.md`