### PR TITLE
perf(ui): debounce target-input for at reducere render-cyklusser (#395)

### DIFF
--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -331,10 +331,18 @@ register_chart_type_events <- function(app_state, emit, input, session, register
     )
   )
 
+  # Debounce target-input for at undgaa re-render + mappings-sync per tastetryk.
+  # Matcher chart_update-debounce (500ms) i fct_visualization_server.R.
+  # Fixes #395: hvert tegn trigrede settings_save + 3 plot-contexts + Typst PDF.
+  debounced_target_value <- shiny::debounce(
+    shiny::reactive(input$target_value %||% ""),
+    millis = DEBOUNCE_DELAYS$chart_update
+  )
+
   # Target value observer - sync to mappings for export module
   observers$target_value <- register_observer(
     "target_value",
-    shiny::observeEvent(input$target_value,
+    shiny::observeEvent(debounced_target_value(),
       {
         safe_operation(
           "Sync target value to mappings",
@@ -343,7 +351,7 @@ register_chart_type_events <- function(app_state, emit, input, session, register
             # Export module reads from mappings, not from reactives
 
             # Parse target_value (same logic as in fct_visualization_server.R)
-            target_input <- input_scalar(input$target_value, default = "")
+            target_input <- input_scalar(debounced_target_value(), default = "")
             if (!nzchar(target_input)) {
               app_state$columns$mappings$target_value <- NULL
               app_state$columns$mappings$target_text <- NULL


### PR DESCRIPTION
## Sammenfatning
- Tilføjer 500ms debounce (`DEBOUNCE_DELAYS\$chart_update`) til target-mappings-sync i `utils_server_events_chart.R`
- Matcher eksisterende `target_value_reactive`/`target_text_reactive` debounce i `fct_visualization_server.R`
- 3+ render-cyklusser pr tastetryk → 1 render efter input stabiliseres

## Fil
- `R/utils_server_events_chart.R:334-354` (+10/-2 linjer)

## Hvad var allerede debounced
- `fct_visualization_server.R` (visualisering): 500ms ✓
- `utils_server_session_helpers.R` (autosave): 1000ms ✓
- `utils_server_events_chart.R` (mappings-sync): **manglede — denne PR**

## Test plan
- [x] `testthat::test_dir(filter='target|chart|spc')` — 635 PASS, 0 FAIL
- [x] Debounced reactive scopes korrekt (oprettes én gang per session via `register_chart_type_events`)

Fixes #395