### PR TITLE
fix(export): guard auto-analysis observer på eksporter-tab (#394)

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -234,6 +234,8 @@ main_app_server <- function(input, output, session) {
       previous_tab(old_tab)
     }
     current_tab(new_tab)
+    # Opdater app_state saa eksport-observere kan gate paa aktiv tab (Issue #394)
+    app_state$session$active_tab <- new_tab
   })
 
   ## App-vejledning modul (tilbagenavigation til forrige tab)

--- a/R/mod_export_analysis.R
+++ b/R/mod_export_analysis.R
@@ -31,15 +31,22 @@ register_analysis_autogen <- function(session, input, output, export_plot, app_s
   # pga. Shiny flush-timing issues.
   last_auto_analysis <- shiny::reactiveVal("")
 
-  # Auto-generer analysetekst når SPC-resultat er tilgængeligt
-  shiny::observeEvent(export_plot(),
+  # Auto-generer analysetekst når SPC-resultat er tilgængeligt.
+  # Bruger observe() (ikke observeEvent) saa tab-guard evalueres FØR
+  # export_plot() -- observeEvent evaluerer altid trigger-udtrykket
+  # hvilket kalder generateSPCPlot() som side-effekt (Issue #394).
+  shiny::observe(
     {
-      # Review fund #3: Auto-genereret analysetekst bruges KUN i PDF-eksport
-      # (pdf_improvement-feltet). Når formatet er png er analysen
+      # TAB-GUARD (Issue #394): Afbryd straks hvis brugeren IKKE er paa
+      # eksporter-tab. req() forhindrer at export_plot() evalueres paa
+      # andre tabs og sparer CPU + Typst PDF-render i baggrunden.
+      shiny::req(app_state$session$active_tab == "eksporter")
+
+      # FORMAT-GUARD: Auto-genereret analysetekst bruges KUN i PDF-eksport
+      # (pdf_improvement-feltet). Naar formatet er png er analysen
       # irrelevant, og den resulterende updateTextAreaInput trigger en ny
-      # preview-render uden reel brugerændring. Guard på format sparer
-      # unødig reactive chain (preview → autosave → debounce → preview).
-      fmt <- shiny::isolate(input$export_format) %||% "pdf"
+      # preview-render uden reel brugeraendring.
+      fmt <- input$export_format %||% "pdf"
       if (!identical(fmt, "pdf")) {
         return()
       }

--- a/R/state_management.R
+++ b/R/state_management.R
@@ -188,7 +188,11 @@ create_app_state <- function() {
 
     # Excel multi-sheet sheet-picker (add-excel-sheet-picker)
     # NULL = ingen pending upload; ellers list(datapath, name, sheets, empty_flags)
-    pending_excel_upload = NULL
+    pending_excel_upload = NULL,
+
+    # Aktiv navbar-tab (Issue #394): opdateres fra app_server_main.R observeEvent(input$main_navbar).
+    # Bruges til at gate eksport-observere saa de kun korer paa eksporter-tab.
+    active_tab = "upload"
   )
 
   # Test Mode Management with Startup Optimization


### PR DESCRIPTION
## Sammenfatning
- Konverterer `observeEvent(export_plot(), {...})` → `observe({ req(active_tab=='eksporter'); ... })`
- `observeEvent` evaluerer trigger-expr ALTID (= bugkilden); `observe()` + `req()` dropper hele reactive dependency-kæden når guard fejler
- Tilføjer `app_state$session$active_tab` (event-bus pattern) — undgår direkte navbar-input-coupling
- Reducerer også symptom for #396 (færre `pdf_improvement` regen → færre auto-save events)

## Filer
- `R/mod_export_analysis.R:34–99` (kerneændring)
- `R/state_management.R:193` (ny `active_tab` state)
- `R/app_server_main.R:237` (sync state fra navbar-observer)

## Designvalg
Issue's foreslåede `isolate(input$main_navbar)` inde i `observeEvent`-body ville ikke virke — `observeEvent` kalder allerede `export_plot()` som side-effekt før body kører. `observe()` med `req()` som første expression er korrekt løsning.

## Test plan
- [x] `testthat::test_dir(filter='export|analysis')` — 454 PASS, 0 FAIL

Fixes #394