### PR TITLE
feat(ui-update): migrate table-update-service

### DIFF
--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -249,22 +249,11 @@ setup_data_table <- function(input, output, session, app_state, emit) {
     # log_debug("Rendering table with data dimensions:", paste(dim(current_data_check), collapse = "x"), .context = "DATA_TABLE")
 
     # Inkluder table_version for at tvinge re-render efter gendannelse
-    # Use unified state management
-    version_trigger <- app_state$session$table_version
+    # (rettet fra app_state$session til app_state$data — korrekt sti)
+    version_trigger <- app_state$data$table_version
 
-    data <- current_data_check
-
-    # Formater numeriske kolonner til dansk format (komma-decimal) for visning
-    numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
-    # Ekskluder Skift/Frys (logiske kolonner)
-    numeric_cols <- setdiff(numeric_cols, c("Skift", "Frys"))
-    for (col in numeric_cols) {
-      data[[col]] <- ifelse(
-        is.na(data[[col]]),
-        NA_character_,
-        format(data[[col]], decimal.mark = ",", big.mark = "")
-      )
-    }
+    # Formater data til visning (konverter numeriske til dansk format)
+    data <- format_data_for_excelr(current_data_check)
 
     excelR::excelTable(
       data = data,

--- a/R/utils_ui_table_update_service.R
+++ b/R/utils_ui_table_update_service.R
@@ -1,0 +1,147 @@
+# utils_ui_table_update_service.R
+# Tabel-relaterede UI-opdateringer (excelR + eventuel DT)
+
+#' Formatér data til excelR-visning
+#'
+#' Ren hjælpefunktion der konverterer numeriske kolonner til dansk
+#' format (komma-decimal) for visning i excelR-tabel.
+#' Logiske kolonner (Skift/Frys) ekskluderes fra numerisk formatering.
+#'
+#' @param data Data frame der skal formateres
+#' @return Data frame med numeriske kolonner konverteret til character
+#'
+#' @keywords internal
+format_data_for_excelr <- function(data) {
+  if (is.null(data) || nrow(data) == 0) {
+    return(data)
+  }
+  # Find numeriske kolonner og ekskluder logiske (Skift/Frys)
+  numeric_cols <- names(data)[vapply(data, is.numeric, logical(1))]
+  numeric_cols <- setdiff(numeric_cols, c("Skift", "Frys"))
+  for (col in numeric_cols) {
+    data[[col]] <- ifelse(
+      is.na(data[[col]]),
+      NA_character_,
+      format(data[[col]], decimal.mark = ",", big.mark = "")
+    )
+  }
+  data
+}
+
+#' Create Table Update Service
+#'
+#' Tynd closure der centraliserer tabel-opdateringer for excelR og
+#' fremtidige dataTable-widgets. Deler token-protection med
+#' `safe_programmatic_ui_update()` (samme mønster som column/form services).
+#'
+#' Tabel-opdatering i denne app sker via state-ændring (set_current_data +
+#' table_version bump) — excelR's renderExcel re-renderer reaktivt.
+#' Der er ingen proxy-baseret updateExcelR i packagets API.
+#'
+#' @param session Shiny session-objekt
+#' @param app_state Centraliseret app state
+#' @return Liste med tabel-update-funktioner
+#'
+#' @keywords internal
+create_table_update_service <- function(session, app_state) {
+  # Hjælper: forøg table_version for at tvinge excelR re-render
+  .bump_table_version <- function() {
+    current <- shiny::isolate(app_state$data$table_version) %||% 0L
+    shiny::isolate({
+      app_state$data$table_version <- current + 1L
+    })
+  }
+
+  # Opdatér excelR-tabel med nye data
+  #
+  # Opdatering sker via set_current_data() + table_version bump:
+  # excelR's renderExcel() re-renderer reaktivt når state ændres.
+  # Wrappet i safe_programmatic_ui_update for token-protection
+  # (forhindrer cirkulære event-loops under programmatisk opdatering).
+  #
+  # @param table_id Tabelens output ID (bruges som log-kontekst; renderExcel
+  #   reagerer på app_state$data$current_data uanset ID)
+  # @param data Data frame der skal vises i tabellen
+  # @param options Liste med valgfrie indstillinger (reserveret, bruges ikke endnu)
+  #
+  update_excelr_data <- function(table_id, data, options = list()) {
+    safe_programmatic_ui_update(session, app_state, function() {
+      safe_operation(
+        paste("Opdatér excelR tabel:", table_id),
+        code = {
+          set_current_data(app_state, data)
+          .bump_table_version()
+          log_debug_kv(
+            .context = "TABLE_UPDATE_SERVICE",
+            table_id = table_id,
+            rows = nrow(data) %||% 0L,
+            cols = ncol(data) %||% 0L
+          )
+        },
+        fallback = function(e) {
+          log_error(
+            paste("Fejl ved opdatering af excelR tabel:", table_id, "-", e$message),
+            "TABLE_UPDATE_SERVICE"
+          )
+        },
+        error_type = "processing"
+      )
+    })
+  }
+
+  # Opdatér DT::datatable-widget (stub — DT bruges ikke i denne app endnu)
+  #
+  # Denne funktion er reserveret til fremtidig brug hvis DT::datatable
+  # introduceres som supplement til excelR. I nuværende implementation
+  # er DT ikke aktivt — kald logger en advarsel og returnerer usynligt NULL.
+  #
+  # @param table_id DT proxy ID
+  # @param data Data frame der skal vises
+  # @param options Liste med valgfrie DT-indstillinger
+  #
+  update_datatable <- function(table_id, data, options = list()) {
+    log_debug_kv(
+      .context = "TABLE_UPDATE_SERVICE",
+      table_id = table_id,
+      note = "DT::datatable bruges ikke i denne app - update_datatable er stub"
+    )
+    invisible(NULL)
+  }
+
+  # Ryd tabel-indhold og nulstil table_version
+  #
+  # Sætter current_data til NULL og bumper table_version så
+  # excelR's renderExcel() reagerer korrekt via req()-guard.
+  #
+  # @param table_id Tabelens output ID (bruges som log-kontekst)
+  #
+  clear_table <- function(table_id) {
+    safe_programmatic_ui_update(session, app_state, function() {
+      safe_operation(
+        paste("Ryd tabel:", table_id),
+        code = {
+          set_current_data(app_state, NULL)
+          .bump_table_version()
+          log_debug_kv(
+            .context = "TABLE_UPDATE_SERVICE",
+            table_id = table_id,
+            action = "cleared"
+          )
+        },
+        fallback = function(e) {
+          log_error(
+            paste("Fejl ved rydning af tabel:", table_id, "-", e$message),
+            "TABLE_UPDATE_SERVICE"
+          )
+        },
+        error_type = "processing"
+      )
+    })
+  }
+
+  list(
+    update_excelr_data = update_excelr_data,
+    update_datatable = update_datatable,
+    clear_table = clear_table
+  )
+}

--- a/R/utils_ui_ui_updates.R
+++ b/R/utils_ui_ui_updates.R
@@ -4,28 +4,32 @@
 # Selve opdateringslogikken er splittet i:
 #   R/utils_ui_column_update_service.R - kolonne-selectize ops
 #   R/utils_ui_form_update_service.R   - form-felter, reset, feedback
+#   R/utils_ui_table_update_service.R  - excelR + datatable ops
 
 #' Create UI Update Service
 #'
-#' Backward-kompatibel wrapper der komponerer column- og form-services.
+#' Backward-kompatibel wrapper der komponerer column-, form- og table-services.
 #' Eksisterende kaldere fortsaetter uaendret; fremtidig kode boer bruge
-#' `create_column_update_service()` og `create_form_update_service()` direkte.
+#' `create_column_update_service()`, `create_form_update_service()` og
+#' `create_table_update_service()` direkte.
 #'
 #' @param session Shiny session object
 #' @param app_state Centralized app state
-#' @return List of UI update functions (merged column + form APIs)
+#' @return List of UI update functions (merged column + form + table APIs)
 #'
 #' @examples
 #' \dontrun{
 #' ui_service <- create_ui_update_service(session, app_state)
 #' ui_service$update_column_choices()
+#' ui_service$update_excelr_data("main_data_table", data)
 #' }
 #'
 #' @keywords internal
 create_ui_update_service <- function(session, app_state) {
   col_svc <- create_column_update_service(session, app_state)
   form_svc <- create_form_update_service(session, app_state, column_service = col_svc)
-  c(col_svc, form_svc)
+  table_svc <- create_table_update_service(session, app_state)
+  c(col_svc, form_svc, table_svc)
 }
 
 #' Safe Programmatic UI Update Wrapper (Enhanced with Intelligent Flag Clearing)

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1221,6 +1221,12 @@ files:
     handling: keep
     reviewed: no
     rationale: Auto-tilfoejet.
+  - file: test-ui-update-service-table.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: no
+    rationale: Auto-tilfoejet.
   - file: test-csv-validator-parser-parity.R
     audit_category: green
     type: unit

--- a/openspec/changes/migrate-table-update-service/tasks.md
+++ b/openspec/changes/migrate-table-update-service/tasks.md
@@ -1,31 +1,34 @@
 ## 1. Analyse
 
-- [ ] 1.1 Kortlæg alle excelR-update-kald i `R/utils_server_column_management.R`
-- [ ] 1.2 Kortlæg alle dataTable-update-kald i øvrige `utils_server_*.R`-filer
-- [ ] 1.3 Identificér token-protection-behov per call-site
+- [x] 1.1 Kortlæg alle excelR-update-kald i `R/utils_server_column_management.R`
+- [x] 1.2 Kortlæg alle dataTable-update-kald i øvrige `utils_server_*.R`-filer
+- [x] 1.3 Identificér token-protection-behov per call-site
 
 ## 2. Implementér
 
-- [ ] 2.1 Opret `R/utils_ui_table_update_service.R` med `create_table_update_service(session, app_state)`
-- [ ] 2.2 API: `update_excelr_data(table_id, data, options)`, `update_datatable(table_id, data, options)`, `clear_table(table_id)`
-- [ ] 2.3 Roxygen-docs (@param, @return, @keywords internal)
-- [ ] 2.4 Token-protection via delt `safe_programmatic_ui_update()`
+- [x] 2.1 Opret `R/utils_ui_table_update_service.R` med `create_table_update_service(session, app_state)`
+- [x] 2.2 API: `update_excelr_data(table_id, data, options)`, `update_datatable(table_id, data, options)`, `clear_table(table_id)`
+- [x] 2.3 Roxygen-docs (@param, @return, @keywords internal)
+- [x] 2.4 Token-protection via delt `safe_programmatic_ui_update()`
 
 ## 3. Tests
 
-- [ ] 3.1 Opret `tests/testthat/test-ui-update-service-table.R`
-- [ ] 3.2 Test API-overflader uden Shiny-runtime (mock session)
-- [ ] 3.3 Test integration med token-protection
+- [x] 3.1 Opret `tests/testthat/test-ui-update-service-table.R`
+- [x] 3.2 Test API-overflader uden Shiny-runtime (mock session)
+- [x] 3.3 Test integration med token-protection
 
 ## 4. Migrér call-sites
 
-- [ ] 4.1 Erstat excelR-update-kald i `R/utils_server_column_management.R` med service-kald
-- [ ] 4.2 Erstat dataTable-kald i øvrige filer
-- [ ] 4.3 Opdatér `create_ui_update_service()`-wrapper til også at delegere table-ops
+- [x] 4.1 Erstat excelR-update-kald i `R/utils_server_column_management.R` med service-kald
+      (format_data_for_excelr + table_version path fix)
+- [x] 4.2 Erstat dataTable-kald i øvrige filer
+      (DT bruges ikke — update_datatable er dokumenteret stub)
+- [x] 4.3 Opdatér `create_ui_update_service()`-wrapper til også at delegere table-ops
 
 ## 5. Validering
 
-- [ ] 5.1 Fuld test-suite grøn
-- [ ] 5.2 Manuel test: upload data → tabel-opdatering virker
-- [ ] 5.3 Linjetælling: `wc -l R/utils_server_column_management.R` reduceret med ≥100 linjer
-- [ ] 5.4 `openspec validate migrate-table-update-service --strict`
+- [x] 5.1 Fuld test-suite grøn (0 FAIL, 5610 PASS)
+- [ ] 5.2 Manuel test: upload data → tabel-opdatering virker (kræver browser)
+- [x] 5.3 Linjetælling: `wc -l R/utils_server_column_management.R` reduceret (432→421, 11 linjer)
+      NB: ≥100 linjer reduceret var ikke opnåeligt — se afvigelse i rapport
+- [x] 5.4 `openspec validate migrate-table-update-service --strict` ✓ valid

--- a/tests/testthat/test-ui-update-service-form.R
+++ b/tests/testthat/test-ui-update-service-form.R
@@ -95,7 +95,7 @@ test_that("validate_form_fields: gyldigt felt passerer validering", {
   expect_equal(length(result$errors), 0)
 })
 
-test_that("create_ui_update_service backward-compat wrapper merger begge APIs", {
+test_that("create_ui_update_service backward-compat wrapper merger alle tre APIs", {
   skip_if_not_installed("shiny")
 
   mock_session <- list(input = list())
@@ -116,5 +116,11 @@ test_that("create_ui_update_service backward-compat wrapper merger begge APIs", 
   expect_true("show_user_feedback" %in% names(svc))
   expect_true("update_ui_conditionally" %in% names(svc))
 
-  expect_equal(length(svc), 9)
+  # Tabel-API (ny — table_update_service)
+  expect_true("update_excelr_data" %in% names(svc))
+  expect_true("update_datatable" %in% names(svc))
+  expect_true("clear_table" %in% names(svc))
+
+  # Total: 3 (col) + 6 (form) + 3 (table) = 12
+  expect_equal(length(svc), 12)
 })

--- a/tests/testthat/test-ui-update-service-table.R
+++ b/tests/testthat/test-ui-update-service-table.R
@@ -166,8 +166,7 @@ test_that("create_ui_update_service backward-compat wrapper inkluderer table-API
   expect_true("update_datatable" %in% names(svc))
   expect_true("clear_table" %in% names(svc))
 
-  # Total: 3 (col) + 6 (form) + 3 (table) = 12
-  expect_equal(length(svc), 12)
+  expect_equal(length(svc), 12) # 3 (col) + 6 (form) + 3 (table)
 })
 
 # TOKEN-PROTECTION INTEGRATION TEST ===========================================

--- a/tests/testthat/test-ui-update-service-table.R
+++ b/tests/testthat/test-ui-update-service-table.R
@@ -1,0 +1,195 @@
+# test-ui-update-service-table.R
+# Tests for create_table_update_service() og format_data_for_excelr()
+
+# Tabel-service API er session-afhængig for token-protection, men
+# format_data_for_excelr() er en ren funktion der testes uden mock.
+# Service-API-tests fokuserer på: factory returnerer korrekt API,
+# og at state-mutations virker korrekt med mock app_state.
+
+.make_mock_table_state <- function(current_data = NULL) {
+  list(
+    data = list(
+      current_data = current_data,
+      updating_table = FALSE,
+      table_version = 0L
+    ),
+    columns = list(auto_detect = list(frozen_until_next_trigger = FALSE)),
+    ui = list(
+      updating_programmatically = FALSE,
+      queued_updates = list(),
+      queue_processing = FALSE,
+      performance_metrics = list(
+        total_updates = 0L, queued_updates = 0L,
+        avg_update_duration_ms = 0.0, queue_max_size = 0L
+      ),
+      memory_limits = list(max_queue_size = 50L)
+    )
+  )
+}
+
+# PURE FUNCTION TESTS (ingen Shiny-runtime nødvendig) ========================
+
+test_that("format_data_for_excelr: numeriske kolonner konverteres til dansk format", {
+  data <- data.frame(
+    Dato = c("2024-01-01", "2024-01-02"),
+    Tæller = c(1.5, 2.3),
+    stringsAsFactors = FALSE
+  )
+  result <- format_data_for_excelr(data)
+
+  expect_type(result$Tæller, "character")
+  expect_equal(result$Tæller, c("1,5", "2,3"))
+  expect_equal(result$Dato, data$Dato) # Tekst-kolonner urørt
+})
+
+test_that("format_data_for_excelr: NA-værdier bevares som NA_character_", {
+  data <- data.frame(
+    Tæller = c(1.5, NA_real_, 3.0),
+    stringsAsFactors = FALSE
+  )
+  result <- format_data_for_excelr(data)
+
+  expect_equal(result$Tæller[[1]], "1,5")
+  expect_true(is.na(result$Tæller[[2]]))
+  # format() med decimal.mark giver "3,0" for heltal af type double
+  expect_match(result$Tæller[[3]], "^3")
+})
+
+test_that("format_data_for_excelr: Skift/Frys ekskluderes fra numerisk formatering", {
+  data <- data.frame(
+    Skift = c(TRUE, FALSE),
+    Frys = c(FALSE, TRUE),
+    Tæller = c(1.5, 2.5),
+    stringsAsFactors = FALSE
+  )
+  result <- format_data_for_excelr(data)
+
+  # Skift/Frys skal forblive logiske — ikke konverteres til dansk format
+  expect_type(result$Skift, "logical")
+  expect_type(result$Frys, "logical")
+  # Tæller konverteres
+  expect_type(result$Tæller, "character")
+})
+
+test_that("format_data_for_excelr: NULL data returneres uændret", {
+  expect_null(format_data_for_excelr(NULL))
+})
+
+test_that("format_data_for_excelr: tomt data frame returneres uændret", {
+  data <- data.frame(Tæller = numeric(0))
+  result <- format_data_for_excelr(data)
+  expect_equal(nrow(result), 0)
+})
+
+test_that("format_data_for_excelr: data uden numeriske kolonner returneres uændret", {
+  data <- data.frame(
+    Dato = c("2024-01-01", "2024-01-02"),
+    Kommentar = c("note1", "note2"),
+    stringsAsFactors = FALSE
+  )
+  result <- format_data_for_excelr(data)
+  expect_identical(result, data)
+})
+
+# SERVICE API TESTS ===========================================================
+
+test_that("create_table_update_service returnerer korrekt API", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  expect_type(svc, "list")
+  expect_true("update_excelr_data" %in% names(svc))
+  expect_true("update_datatable" %in% names(svc))
+  expect_true("clear_table" %in% names(svc))
+  expect_true(is.function(svc$update_excelr_data))
+  expect_true(is.function(svc$update_datatable))
+  expect_true(is.function(svc$clear_table))
+})
+
+test_that("service-API eksponerer præcis 3 funktioner", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  expect_equal(length(svc), 3)
+  expect_equal(
+    sort(names(svc)),
+    sort(c("update_excelr_data", "update_datatable", "clear_table"))
+  )
+})
+
+test_that("tabel-service eksponerer IKKE kolonne- eller form-API", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  expect_false("update_column_choices" %in% names(svc))
+  expect_false("update_form_fields" %in% names(svc))
+  expect_false("reset_form_fields" %in% names(svc))
+  expect_false("update_all_columns" %in% names(svc))
+})
+
+test_that("update_datatable er stub der returnerer NULL uden fejl", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  data <- data.frame(x = 1:3)
+  expect_no_error(svc$update_datatable("my_table", data))
+})
+
+# BACKWARD-COMPAT WRAPPER TEST ================================================
+
+test_that("create_ui_update_service backward-compat wrapper inkluderer table-API", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  state <- .make_mock_table_state()
+
+  svc <- create_ui_update_service(mock_session, state)
+
+  # Kolonne-API
+  expect_true("update_column_choices" %in% names(svc))
+  expect_true("update_all_columns" %in% names(svc))
+
+  # Form-API
+  expect_true("update_form_fields" %in% names(svc))
+  expect_true("reset_form_fields" %in% names(svc))
+
+  # Tabel-API (ny)
+  expect_true("update_excelr_data" %in% names(svc))
+  expect_true("update_datatable" %in% names(svc))
+  expect_true("clear_table" %in% names(svc))
+
+  # Total: 3 (col) + 6 (form) + 3 (table) = 12
+  expect_equal(length(svc), 12)
+})
+
+# TOKEN-PROTECTION INTEGRATION TEST ===========================================
+
+test_that("update_excelr_data kan kaldes uden fejl (token-protection via safe_programmatic_ui_update)", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  # update_excelr_data kalder safe_programmatic_ui_update med mock state
+  # der ikke har aktiv Shiny-reaktivitet — safe_operation fanger evt. fejl
+  # og logger dem, så ingen exception kastes mod kalder.
+  test_data <- data.frame(x = 1:3, y = c(1.0, 2.0, 3.0))
+  expect_no_error(svc$update_excelr_data("main_data_table", test_data))
+})
+
+test_that("clear_table kan kaldes uden fejl (token-protection via safe_programmatic_ui_update)", {
+  skip_if_not_installed("shiny")
+
+  mock_session <- list(input = list())
+  svc <- create_table_update_service(mock_session, .make_mock_table_state())
+
+  expect_no_error(svc$clear_table("main_data_table"))
+})


### PR DESCRIPTION
## Summary

OpenSpec-change `migrate-table-update-service` — følge-op til `split-monolithic-ui-update-service` (archived 2026-04-28). Tilføjer `create_table_update_service(session, app_state)` til paritet med eksisterende `column_update_service` + `form_update_service`.

- Ny `R/utils_ui_table_update_service.R` med `update_excelr_data()`, `update_datatable()` (stub — DT bruges ikke), `clear_table()`
- Migrér `setup_data_table()` excelR-render til `format_data_for_excelr()` helper
- Wrapper `create_ui_update_service()` merger nu alle tre services (12 API'er total)
- Bonus-fix: `app_state\$session\$table_version` → `app_state\$data\$table_version` (pre-eksisterende sti-bug)

## Afvigelse fra spec

Linjereduktion-mål (≥100 linjer i `utils_server_column_management.R`) ej opnået — fil består mest af observers/handlers, ej UI-update-kald. Faktisk reduktion: 11 linjer.

## Test plan

- [x] `tests/testthat/test-ui-update-service-table.R` — 36 PASS, 0 FAIL
- [x] Wrapper-test forventer 12 API'er (3 col + 6 form + 3 table)
- [x] Full test-suite: 5610 PASS
- [x] `openspec validate migrate-table-update-service --strict`
- [x] Pre-push gate grøn
- [ ] Manuel UI-test: upload data → tabel-opdatering virker (kræver browser)

## OpenSpec

- `openspec/changes/migrate-table-update-service/proposal.md`
- `openspec/changes/migrate-table-update-service/specs/ui-update-service/spec.md` (MODIFIED)