### PR TITLE
fix(tests): brug info= i expect_equal i yaml-config-adherence

### DIFF
--- a/tests/testthat/test-yaml-config-adherence.R
+++ b/tests/testthat/test-yaml-config-adherence.R
@@ -162,7 +162,7 @@ test_that("Configuration precedence order is respected", {
   configure_logging_from_yaml(log_level = "ERROR")
   expect_equal(
     Sys.getenv("SPC_LOG_LEVEL"), "ERROR",
-    "Explicit log level should have highest precedence"
+    info = "Explicit log level should have highest precedence"
   )
 
   # 2. When no explicit parameter, should use YAML or fallback


### PR DESCRIPTION
## Summary

Fixer R-CMD-check `gate (tests + warnings)`-fejl på develop→master promote-PR (#406). Pre-existing test-bug fra commit \`f4e95c7\` (2026-04-20).

## Root cause

\`expect_equal(object, expected, ...)\` — 3. positional arg er \`...\`-forwarding til waldo. Streng som 3. arg trigger waldo's \`old_opts\` med \"Unused arguments\"-warning, hvilket failer R-CMD-check tests+warnings-gate.

## Fix

Tilføj \`info = \` så strengen bindes som testthat info-label (not waldo arg).

## Test plan

- [x] \`testthat::test_file('tests/testthat/test-yaml-config-adherence.R')\` — 0 WARN, 8 PASS, 2 SKIP (lokal)
- [x] Pre-push gate grøn
- [ ] CI \`gate (tests + warnings)\` skal passere efter merge

## Effekt på #406

Efter merge → develop → re-run \`gate\` på #406 → master-promote unblocket.