### PR TITLE
feat(ci+hooks): auto-regen manifest + non-ASCII/manifest-stale guards

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,6 +14,7 @@ biSPCharts bruger fire lags CI/CD gates.
 | `shinytest2` | Nightly 02:00 UTC + on-demand | Nej | Visuel regression (miljøfølsom, opt-in) |
 | `lint` | Pushes/PRs | Ja | lintr-linting |
 | `validate-manifest` | Pushes/PRs | Ja | Test-classification manifest + Posit Connect manifest-sync |
+| `auto-regen-manifest` | Push develop (DESCRIPTION-ændring) + dispatch | Nej (auto-fix) | Regenererer `manifest.json` når `DESCRIPTION:Imports/Remotes/Depends` ændres; committer tilbage med `[skip manifest]`-flag |
 
 ## Gate-aktivering: afhængigheder
 

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -1,0 +1,143 @@
+# Auto-regenerér manifest.json når DESCRIPTION:Imports/Remotes/Depends ændres.
+#
+# Adresserer fix-pattern `manifest-stale` (recurrence=4 i .claude/fix-patterns.jsonl).
+# Sikkerhedsnet hvis pre-push hook bypasses eller ikke installeret hos bidragyder.
+#
+# Trigger: push til develop med DESCRIPTION-ændring.
+# Recursion-guard: bot's egen commit indeholder `[skip manifest]` så workflow
+# ikke trigger sig selv. Workflow skipper også commits hvor manifest.json
+# allerede er staget af user (no-op hvis regen producerer identisk fil).
+#
+# Manuel trigger: workflow_dispatch — fx hvis manifest blev glemt i historik.
+#
+# Required secret: BFH_ASSETS_PAT med repo:contents:write + branch-protection-bypass.
+# Falder tilbage til GITHUB_TOKEN hvis BFH_ASSETS_PAT mangler (men branch
+# protection kan blokere bot-push i så fald).
+name: auto-regen-manifest
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'DESCRIPTION'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: auto-regen-manifest-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  regen:
+    # Skip rekursive runs fra bot + eksplicitte opt-out commits.
+    # head_commit-fields evalueres i `if:`-context (sikker, ej shell-injection).
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.head_commit.author.username != 'github-actions[bot]' &&
+          !contains(github.event.head_commit.message, '[skip manifest]')
+        )
+      }}
+    runs-on: ubuntu-latest
+    name: regen-on-deps-change
+
+    env:
+      GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      GOOGLE_API_KEY: ""
+      GEMINI_API_KEY: ""
+      # Trigger-commit-SHA exposes via env-var ej direkte ${{ }}-interpolation
+      # i run:-blocks (best practice for at undgå skript-injection)
+      TRIGGER_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          # PAT-token tillader workflow at push tilbage til develop selv ved
+          # branch-protection. GITHUB_TOKEN-pushes trigger ikke andre workflows.
+          token: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 2
+
+      - name: Detect DESCRIPTION:Imports/Remotes/Depends change
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "deps_changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manuel trigger — kør regen ubetinget"
+            exit 0
+          fi
+
+          # Compare HEAD vs HEAD~1 (sidste commit på develop)
+          if git diff HEAD~1 HEAD -- DESCRIPTION | grep -qE '^[+-]\s*(Imports|Remotes|Depends):'; then
+            echo "deps_changed=true" >> "$GITHUB_OUTPUT"
+            echo "DESCRIPTION dependency-fields ændret — regen påkrævet"
+          else
+            echo "deps_changed=false" >> "$GITHUB_OUTPUT"
+            echo "Kun ikke-dependency-fields ændret — skip regen"
+          fi
+
+      - name: Setup pandoc
+        if: steps.check.outputs.deps_changed == 'true'
+        uses: r-lib/actions/setup-pandoc@v2
+
+      - name: Setup R
+        if: steps.check.outputs.deps_changed == 'true'
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - name: Install R dependencies
+        if: steps.check.outputs.deps_changed == 'true'
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rsconnect, any::pkgload, any::renv
+          needs: check
+
+      - name: Regenerate manifest.json
+        if: steps.check.outputs.deps_changed == 'true'
+        run: Rscript dev/_regen_manifest.R
+
+      - name: Validate regenerated manifest
+        if: steps.check.outputs.deps_changed == 'true'
+        run: Rscript dev/validate_connect_manifest.R manifest.json
+
+      - name: Commit + push if manifest changed
+        if: steps.check.outputs.deps_changed == 'true'
+        run: |
+          if git diff --quiet -- manifest.json; then
+            echo "manifest.json allerede i sync — ingen commit nødvendig"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git commit -m "chore(deploy): auto-regen manifest.json [skip manifest]
+
+          Triggered by DESCRIPTION dependency change in ${TRIGGER_SHA}.
+          Adresserer fix-pattern \`manifest-stale\` (recurrence=4)."
+          git push origin develop
+          echo "Pushed regenereret manifest.json til develop"
+
+      - name: Summary
+        if: always()
+        env:
+          DEPS_CHANGED: ${{ steps.check.outputs.deps_changed }}
+        run: |
+          if [ "$DEPS_CHANGED" = "true" ]; then
+            if git diff --quiet HEAD~1 HEAD -- manifest.json 2>/dev/null; then
+              echo "::notice::manifest.json var allerede i sync — ingen ændring"
+            else
+              echo "::notice::manifest.json regenereret + committed"
+            fi
+          else
+            echo "::notice::DESCRIPTION dependency-fields uændret — regen sprunget over"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,6 +241,15 @@ Alle fejl/forbedringer dokumenteres som GitHub Issues. Reference i commits:
 `fix: beskrivelse (fixes #123)`. Labels: `bug`, `enhancement`,
 `documentation`, `technical-debt`, `performance`, `testing`.
 
+### Fix-patterns store
+
+Recurring fix-mønstre logges i `.claude/fix-patterns.jsonl` (append-only,
+JSONL). Schema: `{date, pr, category, symptom, root_cause, fix, files,
+detection, recurrence, prevention, related_prs}`. **Slå op før fix:**
+`jq 'select(.category == "<cat>")' .claude/fix-patterns.jsonl`.
+**Tilføj efter merge** hvis ikke-trivielt fix; bump `recurrence` hvis
+samme pattern set før. Top-recurrence-patterns driver hook/skill-prioritering.
+
 ### AI/LLM Integration (BFHllm)
 
 biSPCharts = thin wrapper omkring BFHllm-pakken (`Suggests + Remotes`,

--- a/dev/git-hooks/pre-commit
+++ b/dev/git-hooks/pre-commit
@@ -37,6 +37,50 @@ fi
 
 echo "Running pre-commit checks..."
 
+# --- Step 0.5: Non-ASCII detect i staged R-filer (fix-patterns: non-ascii) ---
+# Fanger danske tegn / unicode-symboler i R-kode foer R CMD check faar
+# chance for at klage. Bypass: SKIP_NONASCII=1 git commit
+if [ "${SKIP_NONASCII:-0}" != "1" ]; then
+  staged_r_for_ascii=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(R|r)$' | grep -v 'dev/')
+  if [ -n "$staged_r_for_ascii" ]; then
+    nonascii_hits=""
+    for f in $staged_r_for_ascii; do
+      [ -f "$f" ] || continue
+      hits=$(LC_ALL=C grep -nP '[^\x00-\x7F]' "$f" 2>/dev/null || true)
+      if [ -n "$hits" ]; then
+        nonascii_hits="${nonascii_hits}\n--- $f ---\n$hits"
+      fi
+    done
+    if [ -n "$nonascii_hits" ]; then
+      echo ""
+      echo "✗ Non-ASCII chars i R-kode — commit blokeret (R CMD check WARNING)"
+      echo ""
+      printf "%b\n" "$nonascii_hits" | head -30
+      echo ""
+      echo "  Fix: erstat aeoeaa/AEOEAA eller brug \\uXXXX escape-sequences"
+      echo "  Bypass: SKIP_NONASCII=1 git commit"
+      exit 1
+    fi
+  fi
+fi
+
+# --- Step 0.6: Manifest-sync warning (fix-patterns: manifest-stale) ---
+# Hvis DESCRIPTION staged uden manifest.json: warn (ikke blokerende — pre-push
+# blokerer hvis stadig stale). Bypass automatisk hvis manifest.json staged.
+desc_staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^DESCRIPTION$' || true)
+manifest_staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^manifest\.json$' || true)
+if [ -n "$desc_staged" ] && [ -z "$manifest_staged" ]; then
+  imports_changed=$(git diff --cached -- DESCRIPTION | grep -E '^[+-]\s*(Imports|Remotes|Depends):' || true)
+  if [ -n "$imports_changed" ]; then
+    echo ""
+    echo "⚠ DESCRIPTION:Imports/Remotes/Depends aendret men manifest.json IKKE staged"
+    echo "  Connect Cloud-deploy vil fejle hvis manifest ude af sync."
+    echo "  Foer push: Rscript -e 'rsconnect::writeManifest()' && git add manifest.json"
+    echo "  (commit tilladt — pre-push blokerer hvis stadig stale)"
+    echo ""
+  fi
+fi
+
 # Find staged R-filer (ekskl. dev/ og golem_utils.R)
 staged_r_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(R|r)$' | grep -v 'dev/' | grep -v 'golem_utils.R')
 

--- a/dev/git-hooks/pre-push
+++ b/dev/git-hooks/pre-push
@@ -127,6 +127,36 @@ if [ -n "$SWALLOWED" ]; then
 fi
 echo "✓ Swallowed error check OK"
 
+# --- Step 1c: rsconnect manifest.json sync (fix-patterns: manifest-stale) ---
+# Hvis DESCRIPTION:Imports/Remotes/Depends ændret siden remote uden tilsvarende
+# manifest.json-update -> Connect Cloud deploy fejler.
+# Bypass: SKIP_MANIFEST_SYNC=1 git push
+echo ""
+echo "[1c/4] Validerer rsconnect manifest.json sync mod DESCRIPTION ..."
+if [ "${SKIP_MANIFEST_SYNC:-0}" != "1" ]; then
+  REMOTE_BASE=$(git rev-parse "@{u}" 2>/dev/null || git rev-parse "origin/develop" 2>/dev/null || echo "")
+  if [ -n "$REMOTE_BASE" ]; then
+    DESC_DIFF=$(git diff "$REMOTE_BASE"...HEAD -- DESCRIPTION | grep -E '^[+-]\s*(Imports|Remotes|Depends):' || true)
+    MANIFEST_DIFF=$(git diff "$REMOTE_BASE"...HEAD -- manifest.json || true)
+    if [ -n "$DESC_DIFF" ] && [ -z "$MANIFEST_DIFF" ]; then
+      echo ""
+      echo "✗ DESCRIPTION:Imports/Remotes/Depends ændret men manifest.json uændret"
+      echo "  Connect Cloud-deploy vil fejle (recurrence=4 i fix-patterns.jsonl)"
+      echo ""
+      echo "  Fix: Rscript -e 'rsconnect::writeManifest()' && git add manifest.json"
+      echo "       git commit -m 'chore(deploy): regen manifest.json'"
+      echo ""
+      echo "  Bypass: SKIP_MANIFEST_SYNC=1 git push"
+      exit 1
+    fi
+    echo "✓ Manifest-sync OK"
+  else
+    echo "  (skipped — ingen remote tracking branch fundet)"
+  fi
+else
+  echo "  (skipped — SKIP_MANIFEST_SYNC=1)"
+fi
+
 # --- Step 2: manifest validation ---
 echo ""
 echo "[2/4] Validerer test-classification manifest ..."


### PR DESCRIPTION
## Summary

Tre relaterede ændringer der adresserer de 3 hyppigste fix-patterns observeret i biSPCharts deploy-historik (manifest-stale, non-ASCII, R-CMD-check-warnings):

1. **`feat(ci): auto-regen manifest.json on DESCRIPTION dependency change`**
   Ny workflow `.github/workflows/auto-regen-manifest.yaml` der trigges ved push til `develop` med ændring i `DESCRIPTION:Imports/Remotes/Depends`. Regenererer `manifest.json` via `dev/_regen_manifest.R` og committer tilbage med `[skip manifest]`-marker (recursion-guard). Sikkerhedsnet hvis pre-push hook bypasses eller mangler installation.

2. **`feat(hooks): block non-ASCII + guard manifest-stale i git-hooks`**
   - `pre-commit`: blokerer non-ASCII chars i staged R-filer (PCRE-grep). Bypass: `SKIP_NONASCII=1`. Plus warn (ikke-blokerende) hvis DESCRIPTION-deps staget uden manifest.
   - `pre-push`: blokerer push hvis DESCRIPTION-deps ændret siden remote uden manifest-update. Bypass: `SKIP_MANIFEST_SYNC=1`.

3. **`docs(claude): tilfoej fix-patterns store reference til §6`**
   Tilføjer reference til `.claude/fix-patterns.jsonl` (gitignored, lokal-til-bruger) i CLAUDE.md §6 Domain-Specific Guidance. Definerer schema + jq-query-mønster.

## Defense-in-depth lag

```
Local:    pre-commit (block non-ASCII, warn manifest)
       -> pre-push (block manifest-stale)
Remote:   validate-manifest workflow (existing — fanger hvis hook bypassed)
       -> auto-regen-manifest workflow (NEW — fixer hvis stadig stale)
```

Hvert lag har failure-mode hvor user kan gå udenom (`--no-verify`, `SKIP_*=1`, ej hook installed). Defense-in-depth gør sandsynligheden for stale-manifest i deploy ekstrem lav.

## Test plan

- [x] Pre-push gate bestået lokalt (58s, mode=fast)
- [x] YAML-syntax verificeret (`yaml::read_yaml()`)
- [x] Bash-syntax verificeret (`bash -n`)
- [x] Non-ASCII grep-pattern testet på sample R-fil
- [ ] Auto-regen workflow trigget via `workflow_dispatch` (kører efter merge)
- [ ] Real-trigger test via DESCRIPTION:Imports-ændring (efter merge)

## Verifikation efter merge

```bash
# Test 1: workflow_dispatch (force regen)
gh workflow run auto-regen-manifest.yaml --ref develop
gh run watch
```

## Permissions

- Workflow bruger `contents: write` + `BFH_ASSETS_PAT || GITHUB_TOKEN` til bot-push
- Develop har ingen branch protection → bot-push fungerer out-of-box
- Recursion-guard via `[skip manifest]`-marker + path-filter på DESCRIPTION

## Bemærkning om history

Lokal develop var divergeret fra remote (force-push af #412 efter rebase). Cherry-picked 3 commits fra clean `origin/develop`-tip til denne feature-branch frem for `git reset --hard` på lokal develop.