### PR TITLE
fix(export): escape user-input metadata for Typst-template (#427)

### DIFF
--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -144,12 +144,18 @@ generate_pdf_export <- function(input, app_state, file) {
   }
 
   # PDF-specifik metadata til BFHcharts Typst-template
+  # escape_typst_metadata() beskytter mod markup-injection (#427)
+  hospital_value <- if (nzchar(input$export_hospital %||% "")) {
+    input$export_hospital
+  } else {
+    get_hospital_name_for_export()
+  }
   metadata <- list(
-    hospital = if (nzchar(input$export_hospital %||% "")) input$export_hospital else get_hospital_name_for_export(),
-    department = input$export_department,
-    title = input$export_title,
-    analysis = input$pdf_improvement,
-    data_definition = data_definition_with_note,
+    hospital = escape_typst_metadata(hospital_value),
+    department = escape_typst_metadata(input$export_department),
+    title = escape_typst_metadata(input$export_title),
+    analysis = escape_typst_metadata(input$pdf_improvement),
+    data_definition = escape_typst_metadata(data_definition_with_note),
     date = Sys.Date()
   )
 

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -309,18 +309,24 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       # Bemaerk: bfh_create_typst_document() (preview-vejen) auto-genererer ikke
       # details -- det goer kun bfh_export_pdf(). Vi saetter derfor selv details
       # via BFHcharts::bfh_generate_details() saa preview matcher eksport.
+      # escape_typst_metadata() beskytter mod markup-injection (#427)
+      preview_hospital_value <- if (nzchar(hospital_input)) {
+        hospital_input
+      } else {
+        get_hospital_name_for_export()
+      }
       metadata <- list(
-        hospital = if (nzchar(hospital_input)) hospital_input else get_hospital_name_for_export(),
-        department = dept_input,
-        title = title_input,
-        analysis = analysis_input,
+        hospital = escape_typst_metadata(preview_hospital_value),
+        department = escape_typst_metadata(dept_input),
+        title = escape_typst_metadata(title_input),
+        analysis = escape_typst_metadata(analysis_input),
         details = safe_operation(
           operation_name = "Generate PDF preview details",
           code = BFHcharts::bfh_generate_details(pdf_result$bfh_qic_result),
           fallback = NULL,
           error_type = "processing"
         ),
-        data_definition = data_def_input,
+        data_definition = escape_typst_metadata(data_def_input),
         date = Sys.Date()
       )
 

--- a/R/utils_export_validation.R
+++ b/R/utils_export_validation.R
@@ -315,6 +315,36 @@ validate_aspect_ratio <- function(width, height, warn_only = TRUE) {
   return(TRUE)
 }
 
+# ESCAPE TYPST METADATA =======================================================
+
+#' Escape user-input for Typst-template
+#'
+#' Escapes Typst-markup characters: #, $, backtick, backslash.
+#' Defense-in-depth -- BFHcharts forventes ogsaa at escape, men app-laget
+#' tilfoejer ekstra beskyttelse mod markup-injection.
+#'
+#' @param value Character or NULL/non-character (returneres uaendret).
+#'   Vectors behandles per element.
+#' @return Escaped character, eller value uaendret hvis NULL/non-character.
+#' @keywords internal
+escape_typst_metadata <- function(value) {
+  if (is.null(value) || !is.character(value)) {
+    return(value)
+  }
+  if (length(value) != 1L) {
+    return(vapply(value, escape_typst_metadata, character(1L)))
+  }
+
+  # Backslash foerst -- undgaar dobbelt-escape af efterfoelgende erstatninger.
+  # Alle erstatninger bruger regex-mode (uden fixed=TRUE) saa replacement-strengen
+  # fortolkes korrekt: \\\\ (4 tegn i kode) = \\ (2 tegn) = et \ i output.
+  value <- gsub("\\\\", "\\\\\\\\", value)
+  value <- gsub("#", "\\\\#", value)
+  value <- gsub("\\$", "\\\\$", value)
+  value <- gsub("`", "\\\\`", value)
+  value
+}
+
 # HELPER: NULL coalescing operator ============================================
 
 # %||% operatoren er defineret i golem_utils.R (fjernet duplikat, se #102)

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1024,6 +1024,14 @@ files:
     reviewed: yes
     reviewer: johanreventlow
     reviewed_date: '2026-04-17'
+  - file: test-escape-typst-metadata.R
+    audit_category: green
+    type: unit
+    handling: keep
+    reviewed: yes
+    rationale: Nye unit tests for escape_typst_metadata() helper (#427). 25 tests, alle passerer.
+    reviewer: johanreventlow
+    reviewed_date: '2026-05-01'
   - file: test-utils_export_validation.R
     audit_category: green
     type: unit

--- a/tests/testthat/test-escape-typst-metadata.R
+++ b/tests/testthat/test-escape-typst-metadata.R
@@ -1,0 +1,131 @@
+# ==============================================================================
+# TEST: ESCAPE_TYPST_METADATA
+# ==============================================================================
+# FORMAL: Unit tests for escape_typst_metadata() helper.
+#         Sikrer at Typst markup-tegn i bruger-input escapes korrekt
+#         inden indsaettelse i Typst-template (#427).
+#
+# TEST COVERAGE:
+#   - Typst-markup tegn: #, $, backtick, backslash
+#   - NULL og non-character returneres uaendret
+#   - Vector-input behandles per element
+#   - Kombination af markup-tegn
+#
+# NOTE om R string-escaping i tests:
+#   "\\" i R kode = et backslash-tegn i strengen.
+#   Forventede vaerdier er R-strenge -- "\\#" er saaledes to tegn: \ og #.
+# ==============================================================================
+
+library(testthat)
+
+# TEST: Typst-injection pattern ================================================
+
+test_that("escape_typst_metadata escaper hash (#)", {
+  result <- escape_typst_metadata("#raw(block: true, \"hack\")")
+  expect_equal(substr(result, 1L, 2L), "\\#")
+  expect_false(startsWith(result, "#"))
+})
+
+test_that("escape_typst_metadata escaper dollartegn ($)", {
+  result <- escape_typst_metadata("Patient $X")
+  # Forventet: "Patient \$X" -- i R-streng = "Patient \\$X"
+  expect_equal(result, "Patient \\$X")
+  # Sikrer at dollar ikke starter et Typst math-mode
+  expect_false(grepl("[^\\]\\$", result))
+})
+
+test_that("escape_typst_metadata escaper backtick (`)", {
+  result <- escape_typst_metadata("`rm -rf /`")
+  # Forventet: "\`rm -rf /\`" -- i R-streng = "\\`rm -rf /\\`"
+  expect_equal(result, "\\`rm -rf /\\`")
+  # Ingen uescapede backticks
+  expect_false(grepl("(?<!\\\\)`", result, perl = TRUE))
+})
+
+test_that("escape_typst_metadata escaper backslash (\\)", {
+  result <- escape_typst_metadata("C:\\Users\\Patient")
+  # Forventet: "C:\\\\Users\\\\Patient" i R (= C:\\Users\\Patient i output-streng)
+  expect_equal(result, "C:\\\\Users\\\\Patient")
+})
+
+test_that("escape_typst_metadata haandterer kombination af markup-tegn", {
+  # Input: #raw(`$hack`)
+  result <- escape_typst_metadata("#raw(`$hack`)")
+  # Alle tre markup-tegn skal vaere escaped
+  expect_true(startsWith(result, "\\#"))
+  # Regex-mode: \\\\ matcher en backslash, ` er literal
+  expect_true(grepl("\\\\`", result))
+  # Regex-mode: \\\\ matcher en backslash, \\$ matcher literal dollar
+  expect_true(grepl("\\\\\\$", result))
+})
+
+# TEST: Backslash foerst (orden er kritisk) =====================================
+
+test_that("escape_typst_metadata escaper ikke allerede-escaped tegn dobbelt", {
+  # Backslash skal kun escapes een gang
+  r_single_bs <- escape_typst_metadata("\\") # Input: et backslash
+  expect_equal(nchar(r_single_bs), 2L) # Output: to backslashes
+  chars <- strsplit(r_single_bs, "")[[1]]
+  expect_equal(chars, c("\\", "\\"))
+})
+
+# TEST: NULL og non-character ==================================================
+
+test_that("escape_typst_metadata returnerer NULL uaendret", {
+  result <- escape_typst_metadata(NULL)
+  expect_null(result)
+})
+
+test_that("escape_typst_metadata returnerer integer uaendret", {
+  result <- escape_typst_metadata(42L)
+  expect_identical(result, 42L)
+})
+
+test_that("escape_typst_metadata returnerer logical uaendret", {
+  result <- escape_typst_metadata(TRUE)
+  expect_identical(result, TRUE)
+})
+
+test_that("escape_typst_metadata returnerer liste uaendret", {
+  val <- list(a = 1, b = "x")
+  result <- escape_typst_metadata(val)
+  expect_identical(result, val)
+})
+
+# TEST: Vector-input ===========================================================
+
+test_that("escape_typst_metadata behandler vector per element", {
+  input <- c("#hash", "normal", "$dollar")
+  result <- escape_typst_metadata(input)
+
+  expect_length(result, 3L)
+  expect_equal(result[[1L]], "\\#hash")
+  expect_equal(result[[2L]], "normal")
+  expect_equal(result[[3L]], "\\$dollar")
+})
+
+test_that("escape_typst_metadata returnerer character vector for character vector input", {
+  input <- c("a", "b#c")
+  result <- escape_typst_metadata(input)
+  expect_type(result, "character")
+  expect_length(result, 2L)
+})
+
+# TEST: Upaavirkede inputs =====================================================
+
+test_that("escape_typst_metadata beroerer ikke normale strenge", {
+  normal_input <- "Bispebjerg og Frederiksberg Hospital"
+  result <- escape_typst_metadata(normal_input)
+  expect_equal(result, normal_input)
+})
+
+test_that("escape_typst_metadata beroerer ikke danske tegn", {
+  danish_input <- "æøåÆØÅ"
+  result <- escape_typst_metadata(danish_input)
+  expect_equal(result, danish_input)
+})
+
+test_that("escape_typst_metadata haandterer tom streng", {
+  result <- escape_typst_metadata("")
+  expect_equal(result, "")
+})


### PR DESCRIPTION
## Summary

- Tilfoej `escape_typst_metadata()` helper i `R/utils_export_validation.R` som escaper Typst markup-tegn (`#`, `$`, backtick, backslash) i bruger-input
- Anvend escaping ved begge Typst-boundaries: PDF download (`mod_export_download.R`) og PDF preview (`mod_export_server.R`)
- Bevar eksisterende `nzchar()`-baseret hospital-fallback semantik i begge call-sites
- Defense-in-depth: BFHcharts forventes ogsaa at escape, men app-laget tilfojer ekstra lag

## Test plan

- [x] Ny testfil `tests/testthat/test-escape-typst-metadata.R` med 25 tests daekkende: `#`, `$`, backtick, backslash, kombinationer, NULL/non-character, vector-input, upaavirkede strenge
- [x] Fuld testsuite: 5714 PASS, 0 FAIL (`devtools::test()`)
- [ ] Manuel smoke-test: generer PDF med markup-input (f.eks. titel `#raw(block: true, "hack")`) og verificer literal tekst i PDF-output