### PR TITLE
fix(events): warn-on-fallback i classify_update_context (#425)

### DIFF
--- a/R/utils_event_context_handlers.R
+++ b/R/utils_event_context_handlers.R
@@ -94,7 +94,18 @@ classify_update_context <- function(update_context) {
     return("data_change")
   }
 
-  # Fallback
+  # Fallback — warn for at fange ukendte contexts der utilsigtet rammer general-grenen.
+  # General-handler trigger ej auto-detection eller plot-render, kun column-choices.
+  # Hvis nyt emit-kald skal trigge plot-update, skal context matche load|change|edit|modify|column-regex
+  # eller tilfoejes som eksplicit branch ovenfor. Se issue #425.
+  log_warn(
+    paste0(
+      "classify_update_context fald til 'general' for context: '", context,
+      "'. Verificer intent — tilfoej til load/data_change/table_edit/session_restore-grenen ",
+      "hvis context skal trigge plot-opdatering eller auto-detection."
+    ),
+    .context = "EVENT_CONTEXT_HANDLER"
+  )
   "general"
 }
 

--- a/tests/testthat/test-utils-event-context-handlers.R
+++ b/tests/testthat/test-utils-event-context-handlers.R
@@ -76,6 +76,56 @@ test_that("classify_update_context returnerer 'general' for ukendte contexts", {
   }
 })
 
+test_that("classify_update_context udsender warning for ukendt context (#425)", {
+  skip_if_not(exists("classify_update_context", mode = "function"))
+  skip_if_not(exists("log_warn", mode = "function"))
+
+  # Sikrer at warning udsendes saa nye unknown contexts fanges i logs.
+  # Beskytter mod fremtidig regression hvor ny emit-call bruger context-streng
+  # der utilsigtet falder til general-grenen (som ej trigger plot-render).
+  withr::local_envvar(SPC_LOG_LEVEL = "WARN")
+
+  output <- utils::capture.output(
+    res <- classify_update_context(list(context = "calc_refresh"))
+  )
+
+  expect_equal(res, "general")
+  combined <- paste(output, collapse = " ")
+  expect_match(
+    combined,
+    "calc_refresh",
+    info = "Warning skal navngive den ukendte context"
+  )
+  expect_match(
+    combined,
+    "EVENT_CONTEXT_HANDLER",
+    info = "Warning skal indeholde EVENT_CONTEXT_HANDLER-tag"
+  )
+})
+
+test_that("classify_update_context udsender IKKE warning for kendte contexts (#425)", {
+  skip_if_not(exists("classify_update_context", mode = "function"))
+  skip_if_not(exists("log_warn", mode = "function"))
+
+  withr::local_envvar(SPC_LOG_LEVEL = "WARN")
+
+  known_contexts <- c(
+    "file_upload", "data_loaded", "paste_data",
+    "column_changed", "table_cells_edited", "session_restore"
+  )
+
+  for (ctx in known_contexts) {
+    output <- utils::capture.output(
+      classify_update_context(list(context = ctx))
+    )
+    combined <- paste(output, collapse = " ")
+    expect_false(
+      grepl("fald til 'general'", combined, fixed = TRUE),
+      info = paste("Kendt context", ctx, "skal IKKE udloese fallback-warning")
+    )
+  }
+})
+
 test_that("classify_update_context returnerer kun gyldige output-værdier", {
   skip_if_not(exists("classify_update_context", mode = "function"))
 


### PR DESCRIPTION
## Summary

Tilføjer `log_warn` når `classify_update_context()` falder til 'general'-grenen for ukendt context-streng.

## Problem (issue #425)

`classify_update_context` mapper context-strings til handler-typer via regex. Hvis ny developer tilføjer `emit\$data_updated(context = "calc_refresh")` (eller anden ord udenfor regex `load|change|edit|modify|column|file|paste|new`), falder den lydløst til 'general'-grenen. General-handler trigger ej auto-detection eller plot-render — kun column-choices. Resultat: stale chart uden fejl.

## Vurdering

- **Teoretisk reel**: ja
- **Praktisk reel i nuværende kode**: nej — alle 9 emit-call-sites mappes korrekt
- **Risiko**: fremtidig regression hvis ny developer ej læser regex-pattern

## Løsning (Option B fra review-vurdering)

Lav-effort guardrail: én log_warn-kald i fallback-branchen. Ingen funktionel ændring. Ingen migration af eksisterende call-sites.

```r
# I classify_update_context, foer "general" returneres:
log_warn(
  paste0("classify_update_context fald til 'general' for context: '", context, "'..."),
  .context = "EVENT_CONTEXT_HANDLER"
)
```

## Tests

- Ny: warning udsendes for ukendt context (\`calc_refresh\`)
- Ny: warning IKKE udsendes for kendte contexts (file_upload, paste_data, column_changed, etc.)
- Eksisterende: general-fallback-tests passerer uændret

## Severity

LOW. Defensive forbedring uden funktionel risiko.

## Closes

#425