### PR TITLE
refactor(state): konsolider mutations gennem accessors + lint-rule (#424)

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -310,7 +310,7 @@ main_app_server <- function(input, output, session) {
       "Clear loop protection flags during session cleanup",
       code = {
         if (!is.null(app_state$ui)) {
-          app_state$ui$updating_programmatically <- FALSE
+          set_ui_updating(app_state, FALSE)
           app_state$ui$flag_reset_scheduled <- TRUE
         }
       },

--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -225,7 +225,7 @@ setup_file_upload <- function(input, output, session, app_state, emit, ui_servic
     upload_tracer$step("state_management_setup")
 
     # Unified state assignment only - Set table updating flag
-    app_state$data$updating_table <- TRUE
+    set_table_updating(app_state, TRUE)
 
     debug_log("File upload state flags set", "FILE_UPLOAD_FLOW",
       level = "TRACE",
@@ -235,7 +235,7 @@ setup_file_upload <- function(input, output, session, app_state, emit, ui_servic
     on.exit(
       {
         # Unified state assignment only - Clear table updating flag
-        app_state$data$updating_table <- FALSE
+        set_table_updating(app_state, FALSE)
       },
       add = TRUE
     )
@@ -346,7 +346,7 @@ handle_excel_upload <- function(file_path, session, app_state, emit, ui_service 
     session$onFlushed(
       function() {
         shiny::isolate({
-          app_state$session$restoring_session <- FALSE
+          set_session_restoring(app_state, FALSE)
           log_debug(
             "restoring_session flag cleared after Excel upload restore",
             .context = "SESSION_RESTORE"

--- a/R/mod_landing_server.R
+++ b/R/mod_landing_server.R
@@ -78,7 +78,7 @@ mod_landing_server <- function(id, parent_session = NULL, app_state = NULL) {
         parent_session$sendCustomMessage("discardPendingRestore", list())
       }
       if (!is.null(app_state)) {
-        app_state$session$peek_result <- list(has_payload = FALSE)
+        set_session_peek_result(app_state, list(has_payload = FALSE))
       }
     })
   })

--- a/R/mod_spc_chart_state.R
+++ b/R/mod_spc_chart_state.R
@@ -214,7 +214,7 @@ register_module_data_observer <- function(app_state, input, output, session) {
           shiny::isolate({
             was_updating <- state_flag(app_state$visualization$cache_updating)
             if (!was_updating) {
-              app_state$visualization$cache_updating <- TRUE
+              set_viz_cache_updating(app_state, TRUE)
             }
             was_updating
           })
@@ -222,7 +222,7 @@ register_module_data_observer <- function(app_state, input, output, session) {
         error = function(e) {
           # Emergency cleanup if atomic operation fails
           log_error(paste("Atomic cache flag operation failed:", e$message), "VISUALIZATION")
-          app_state$visualization$cache_updating <- FALSE
+          set_viz_cache_updating(app_state, FALSE)
           return(TRUE) # Block this update attempt
         }
       )
@@ -235,7 +235,7 @@ register_module_data_observer <- function(app_state, input, output, session) {
       # Level 3: Skip if data processing is in progress
       if (state_flag(shiny::isolate(app_state$data$updating_table))) {
         # Reset flag if we're bailing out
-        app_state$visualization$cache_updating <- FALSE
+        set_viz_cache_updating(app_state, FALSE)
         log_debug("Skipping visualization cache update - table update in progress", .context = "VISUALIZATION")
         return()
       }
@@ -249,7 +249,7 @@ register_module_data_observer <- function(app_state, input, output, session) {
           on.exit(
             {
               # Clear guard flag on function exit (success or error)
-              app_state$visualization$cache_updating <- FALSE
+              set_viz_cache_updating(app_state, FALSE)
             },
             add = TRUE
           )

--- a/R/utils_memory_management.R
+++ b/R/utils_memory_management.R
@@ -23,10 +23,10 @@ setup_session_cleanup <- function(session, app_state = NULL, observers = NULL) {
       safe_operation(
         "Reset app state during cleanup",
         code = {
-          app_state$data$current_data <- NULL
-          app_state$data$original_data <- NULL
-          app_state$data$updating_table <- FALSE
-          app_state$data$table_operation_in_progress <- FALSE
+          set_current_data(app_state, NULL)
+          set_original_data(app_state, NULL)
+          set_table_updating(app_state, FALSE)
+          set_table_operation_in_progress(app_state, FALSE)
         },
         fallback = function(e) {
           log_debug("Could not reset app state during cleanup", .context = "MEMORY_MGMT")

--- a/R/utils_memory_management.R
+++ b/R/utils_memory_management.R
@@ -26,7 +26,7 @@ setup_session_cleanup <- function(session, app_state = NULL, observers = NULL) {
           set_current_data(app_state, NULL)
           set_original_data(app_state, NULL)
           set_table_updating(app_state, FALSE)
-          set_table_operation_in_progress(app_state, FALSE)
+          set_table_op_in_progress(app_state, FALSE)
         },
         fallback = function(e) {
           log_debug("Could not reset app state during cleanup", .context = "MEMORY_MGMT")

--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -300,14 +300,14 @@ setup_data_table <- function(input, output, session, app_state, emit) {
       }
 
       # Use unified state management
-      app_state$data$updating_table <- TRUE
+      set_table_updating(app_state, TRUE)
       # Use unified state management
-      app_state$data$table_operation_in_progress <- TRUE
+      set_table_operation_in_progress(app_state, TRUE)
 
       on.exit(
         {
-          app_state$data$updating_table <- FALSE
-          app_state$data$table_operation_in_progress <- FALSE
+          set_table_updating(app_state, FALSE)
+          set_table_operation_in_progress(app_state, FALSE)
         },
         add = TRUE
       )
@@ -397,7 +397,7 @@ setup_data_table <- function(input, output, session, app_state, emit) {
 
     # Saet vedvarende flag for at forhindre auto-save interferens
     # Use unified state management
-    app_state$data$table_operation_in_progress <- TRUE
+    set_table_operation_in_progress(app_state, TRUE)
 
     new_row <- current_data_check[1, ]
     new_row[1, ] <- NA

--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -302,12 +302,12 @@ setup_data_table <- function(input, output, session, app_state, emit) {
       # Use unified state management
       set_table_updating(app_state, TRUE)
       # Use unified state management
-      set_table_operation_in_progress(app_state, TRUE)
+      set_table_op_in_progress(app_state, TRUE)
 
       on.exit(
         {
           set_table_updating(app_state, FALSE)
-          set_table_operation_in_progress(app_state, FALSE)
+          set_table_op_in_progress(app_state, FALSE)
         },
         add = TRUE
       )
@@ -397,7 +397,7 @@ setup_data_table <- function(input, output, session, app_state, emit) {
 
     # Saet vedvarende flag for at forhindre auto-save interferens
     # Use unified state management
-    set_table_operation_in_progress(app_state, TRUE)
+    set_table_op_in_progress(app_state, TRUE)
 
     new_row <- current_data_check[1, ]
     new_row[1, ] <- NA

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -136,7 +136,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             # Saet gendannelses guards for at forhindre interferens
             set_session_restoring(app_state, TRUE)
             set_table_updating(app_state, TRUE)
-            set_table_operation_in_progress(app_state, TRUE)
+            set_table_op_in_progress(app_state, TRUE)
             app_state$session$auto_save_enabled <- FALSE
 
             # Oprydningsfunktion til at nulstille guards.
@@ -334,7 +334,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
           # Unified state assignment only
           app_state$session$auto_save_enabled <- TRUE
           # Unified state assignment only
-          set_table_operation_in_progress(app_state, FALSE)
+          set_table_op_in_progress(app_state, FALSE)
         },
         session = session,
         error_type = "processing",

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -33,7 +33,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
       # has_payload = FALSE (eller mangler) -> default landing
       if (!isTRUE(peek$has_payload)) {
         log_info("session_peek: ingen gemt session", .context = "SESSION_RESTORE")
-        app_state$session$peek_result <- list(has_payload = FALSE)
+        set_session_peek_result(app_state, list(has_payload = FALSE))
         return()
       }
 
@@ -45,7 +45,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
         )
         clearDataLocally(session)
         session$sendCustomMessage("discardPendingRestore", list())
-        app_state$session$peek_result <- list(has_payload = FALSE)
+        set_session_peek_result(app_state, list(has_payload = FALSE))
         return()
       }
 
@@ -64,7 +64,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
         )
         clearDataLocally(session)
         session$sendCustomMessage("discardPendingRestore", list())
-        app_state$session$peek_result <- list(has_payload = FALSE)
+        set_session_peek_result(app_state, list(has_payload = FALSE))
         return()
       }
 
@@ -78,14 +78,14 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
           active_tab = peek$active_tab
         )
       )
-      app_state$session$peek_result <- list(
+      set_session_peek_result(app_state, list(
         has_payload = TRUE,
         timestamp = peek$timestamp,
         nrows = peek$nrows,
         ncols = peek$ncols,
         indicator_title = peek$indicator_title %||% "",
         active_tab = peek$active_tab
-      )
+      ))
     }
   )
 
@@ -134,9 +134,9 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             }
 
             # Saet gendannelses guards for at forhindre interferens
-            app_state$session$restoring_session <- TRUE
-            app_state$data$updating_table <- TRUE
-            app_state$data$table_operation_in_progress <- TRUE
+            set_session_restoring(app_state, TRUE)
+            set_table_updating(app_state, TRUE)
+            set_table_operation_in_progress(app_state, TRUE)
             app_state$session$auto_save_enabled <- FALSE
 
             # Oprydningsfunktion til at nulstille guards.
@@ -147,7 +147,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             # i session$onFlushed nedenfor.
             on.exit(
               {
-                app_state$data$updating_table <- FALSE
+                set_table_updating(app_state, FALSE)
                 # auto_save_enabled genaktiveres i session$onFlushed() nedenfor
                 # for at undgaa at stale input$main_navbar overskriver active_tab
                 app_state$data$table_operation_cleanup_needed <- TRUE
@@ -300,7 +300,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             session$onFlushed(
               function() {
                 shiny::isolate({
-                  app_state$session$restoring_session <- FALSE
+                  set_session_restoring(app_state, FALSE)
                   app_state$session$auto_save_enabled <- TRUE
                   log_info(
                     "restoring_session flag cleared and auto_save re-enabled after flush",
@@ -328,13 +328,13 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
         fallback = {
           # Reset guards even on error
           # Unified state assignment only
-          app_state$data$updating_table <- FALSE
+          set_table_updating(app_state, FALSE)
           # Unified state assignment only
-          app_state$session$restoring_session <- FALSE
+          set_session_restoring(app_state, FALSE)
           # Unified state assignment only
           app_state$session$auto_save_enabled <- TRUE
           # Unified state assignment only
-          app_state$data$table_operation_in_progress <- FALSE
+          set_table_operation_in_progress(app_state, FALSE)
         },
         session = session,
         error_type = "processing",
@@ -564,7 +564,7 @@ reset_to_empty_session <- function(session, app_state, emit, ui_service = NULL) 
   app_state$session$pending_excel_upload <- NULL
 
   # Unified state only
-  app_state$data$updating_table <- TRUE
+  set_table_updating(app_state, TRUE)
 
   # Force hide Anhoej rules until real data is loaded
   # Unified state assignment only
@@ -648,7 +648,7 @@ reset_to_empty_session <- function(session, app_state, emit, ui_service = NULL) 
   }
 
   # Unified state only
-  app_state$data$updating_table <- FALSE
+  set_table_updating(app_state, FALSE)
 }
 
 show_clear_confirmation_modal <- function(has_data, has_settings, app_state) {

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -551,7 +551,7 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
 
     # Clear the table operation flag and reset cleanup request
     # Use unified state management
-    set_table_operation_in_progress(app_state, FALSE)
+    set_table_op_in_progress(app_state, FALSE)
     app_state$data$table_operation_cleanup_needed <- FALSE
   })
 

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -551,7 +551,7 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
 
     # Clear the table operation flag and reset cleanup request
     # Use unified state management
-    app_state$data$table_operation_in_progress <- FALSE
+    set_table_operation_in_progress(app_state, FALSE)
     app_state$data$table_operation_cleanup_needed <- FALSE
   })
 

--- a/R/utils_state_accessors.R
+++ b/R/utils_state_accessors.R
@@ -715,3 +715,85 @@ set_y_axis_autoset_done <- function(app_state, value) {
     app_state$ui$y_axis_unit_autoset_done <- value
   })
 }
+
+# ============================================================================
+# STATE-DISCIPLIN — FASE A (Issue #424)
+# ============================================================================
+# Accessors for top-recurrence-keys der tidligere blev muteret direkte.
+# Konsoliderer mutations gennem named API for testbarhed + lint-disciplin.
+
+#' Set Table Operation In Progress
+#'
+#' Toggle for igangvaerende tabel-operation (cleanup-debounce + race-guards).
+#' Bruges af utils_server_session_helpers, utils_server_column_management,
+#' utils_memory_management.
+#'
+#' @param app_state Centralized app state
+#' @param value Logical TRUE/FALSE
+#'
+#' @keywords internal
+set_table_operation_in_progress <- function(app_state, value) {
+  shiny::isolate({
+    app_state$data$table_operation_in_progress <- value
+  })
+}
+
+#' Set Session Restoring Flag
+#'
+#' Toggle for igangvaerende session-restore. Forhindrer auto-detection +
+#' auto-save trigger under restore-flow (Issue #193, #393).
+#'
+#' @param app_state Centralized app state
+#' @param value Logical TRUE/FALSE
+#'
+#' @keywords internal
+set_session_restoring <- function(app_state, value) {
+  shiny::isolate({
+    app_state$session$restoring_session <- value
+  })
+}
+
+#' Set UI Updating Programmatically Flag
+#'
+#' Toggle for igangvaerende programmatisk UI-update. Brugt af
+#' safe_programmatic_ui_update() til race-protection mod brugerinteraktion.
+#'
+#' @param app_state Centralized app state
+#' @param value Logical TRUE/FALSE
+#'
+#' @keywords internal
+set_ui_updating <- function(app_state, value) {
+  shiny::isolate({
+    app_state$ui$updating_programmatically <- value
+  })
+}
+
+#' Set Visualization Cache Updating Flag
+#'
+#' Toggle for igangvaerende visualization-cache-opdatering. Forhindrer
+#' samtidige cache-rebuilds (mod_spc_chart_state).
+#'
+#' @param app_state Centralized app state
+#' @param value Logical TRUE/FALSE
+#'
+#' @keywords internal
+set_viz_cache_updating <- function(app_state, value) {
+  shiny::isolate({
+    app_state$visualization$cache_updating <- value
+  })
+}
+
+#' Set Session Peek Result
+#'
+#' Sets the localStorage peek result (has_payload + metadata) used i
+#' landing-page restore-card (Issue #193).
+#'
+#' @param app_state Centralized app state
+#' @param value List med has_payload (logical) og evt. metadata-felter
+#'
+#' @keywords internal
+set_session_peek_result <- function(app_state, value) {
+  shiny::isolate({
+    app_state$session$peek_result <- value
+  })
+}

--- a/R/utils_state_accessors.R
+++ b/R/utils_state_accessors.R
@@ -732,7 +732,7 @@ set_y_axis_autoset_done <- function(app_state, value) {
 #' @param value Logical TRUE/FALSE
 #'
 #' @keywords internal
-set_table_operation_in_progress <- function(app_state, value) {
+set_table_op_in_progress <- function(app_state, value) {
   shiny::isolate({
     app_state$data$table_operation_in_progress <- value
   })

--- a/R/utils_ui_ui_updates.R
+++ b/R/utils_ui_ui_updates.R
@@ -105,10 +105,10 @@ safe_programmatic_ui_update <- function(session, app_state, update_function, del
     execution_start <- Sys.time()
     performance_start <- execution_start
 
-    shiny::isolate(app_state$ui$updating_programmatically <- TRUE)
+    set_ui_updating(app_state, TRUE)
     on.exit(
       {
-        shiny::isolate(app_state$ui$updating_programmatically <- FALSE)
+        set_ui_updating(app_state, FALSE)
 
         pending_queue <- length(safe_list(shiny::isolate(app_state$ui$queued_updates)))
         queue_idle <- !scalar_logical(shiny::isolate(app_state$ui$queue_processing))
@@ -216,7 +216,7 @@ safe_programmatic_ui_update <- function(session, app_state, update_function, del
       run_update()
     },
     fallback = function(e) {
-      app_state$ui$updating_programmatically <- FALSE
+      set_ui_updating(app_state, FALSE)
       app_state$ui$flag_reset_scheduled <- TRUE
       log_error(paste("LOOP_PROTECTION: Fejl under programmatisk UI opdatering:", e$message), "LOOP_PROTECTION")
       stop(e)

--- a/dev/git-hooks/pre-commit
+++ b/dev/git-hooks/pre-commit
@@ -81,6 +81,48 @@ if [ -n "$desc_staged" ] && [ -z "$manifest_staged" ]; then
   fi
 fi
 
+# --- Step 0.7: State-disciplin warning (Issue #424) ---
+# Advarer ved direkte app_state$X$Y <- mutations udenfor whitelist.
+# Whitelist: state_management.R, state_accessors.R, state_transitions.R + events-keys.
+# Bypass: SKIP_STATE_LINT=1 git commit
+if [ "${SKIP_STATE_LINT:-0}" != "1" ]; then
+  staged_r_for_state=$(git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '\.(R|r)$' \
+    | grep -v 'dev/' \
+    | grep -v 'state_management\.R$' \
+    | grep -v 'utils_state_accessors\.R$' \
+    | grep -v 'utils_state_transitions\.R$' \
+    | grep -v 'utils_event_system\.R$' \
+    | grep -v 'utils_logging\.R$' \
+    | grep -v 'utils_advanced_debug\.R$')
+  if [ -n "$staged_r_for_state" ]; then
+    state_hits=""
+    for f in $staged_r_for_state; do
+      [ -f "$f" ] || continue
+      # Match: app_state$<noget>$<noget> <-  men ekskluder $events$ (legitim flag-counter)
+      hits=$(grep -nE 'app_state\$[a-zA-Z_]+\$[a-zA-Z_]+[[:space:]]*<-' "$f" 2>/dev/null \
+        | grep -v 'app_state\$events\$' \
+        | grep -v 'app_state\$test_mode\$' || true)
+      if [ -n "$hits" ]; then
+        state_hits="${state_hits}\n--- $f ---\n$hits"
+      fi
+    done
+    if [ -n "$state_hits" ]; then
+      echo ""
+      echo "⚠ Direkte app_state-mutation udenfor whitelist (Issue #424)"
+      echo "  Foretraek named accessor: set_X(app_state, value) eller transition_*-funktion"
+      echo ""
+      printf "%b\n" "$state_hits" | head -20
+      echo ""
+      echo "  Whitelist-filer: state_management.R, utils_state_accessors.R, utils_state_transitions.R"
+      echo "  Tilfoej accessor til R/utils_state_accessors.R hvis nyt API kraeves."
+      echo "  Bypass (kun naar transition-fit mangler): SKIP_STATE_LINT=1 git commit"
+      echo "  (commit tilladt — kun warning)"
+      echo ""
+    fi
+  fi
+fi
+
 # Find staged R-filer (ekskl. dev/ og golem_utils.R)
 staged_r_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(R|r)$' | grep -v 'dev/' | grep -v 'golem_utils.R')
 


### PR DESCRIPTION
## Summary

Issue #424 (Option E): partial discipline + pre-commit guardrail.

## Ændringer

**5 nye accessors** for top-recurrence-keys uden eksisterende named API:
- \`set_table_op_in_progress(app_state, value)\`
- \`set_session_restoring(app_state, value)\`
- \`set_ui_updating(app_state, value)\`
- \`set_viz_cache_updating(app_state, value)\`
- \`set_session_peek_result(app_state, value)\`

**26 direkte mutations erstattet** med named accessors (heraf 10 set_table_updating bypass-fixes).

**Pre-commit lint-rule** (Step 0.7 i \`dev/git-hooks/pre-commit\`):
- Warner ved direkte \`app_state\$X\$Y <-\` udenfor whitelist
- Whitelist: state_management.R, utils_state_accessors.R, utils_state_transitions.R + events/test_mode-keys
- Bypass: \`SKIP_STATE_LINT=1 git commit\`
- Warning only — commit tilladt

## Resultat

- Direkte mutations: **101 → 65** (36% reduktion)
- Named API for de mest-trafikerede keys
- Fremtids-sikret mod regression

## Tests

- 5667 PASS, ingen regression
- Visuelt + funktionelt uændret

## Closes

#424