### PR TITLE
chore(hooks): pre-commit warn-rule for skip() uden SKIP-REASON (Fase 4 af #428)

### DIFF
--- a/dev/git-hooks/pre-commit
+++ b/dev/git-hooks/pre-commit
@@ -123,6 +123,64 @@ if [ "${SKIP_STATE_LINT:-0}" != "1" ]; then
   fi
 fi
 
+# --- Step 0.8: skip()-lint-warning i tests/testthat/ (Issue #428) ---
+# Nye skip()-kald (kun added lines) uden paakraevet SKIP-REASON-kommentar
+# giver warning (ej blokerende). Bypass: SKIP_SKIP_LINT=1 git commit
+if [ "${SKIP_SKIP_LINT:-0}" != "1" ]; then
+  staged_test_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/testthat/.*\.(R|r)$' || true)
+  if [ -n "$staged_test_files" ]; then
+    skip_lint_hits=""
+    for f in $staged_test_files; do
+      [ -f "$f" ] || continue
+      # Hent kun nye (added) linjer fra diff for denne fil
+      prev_line=""
+      while IFS= read -r line; do
+        # Kun added lines (starter med +, ikke +++)
+        case "$line" in
+          "+++"*) prev_line=""; continue ;;
+          "+"*)
+            content="${line:1}"
+            # Tjek om det er et nyt skip()-kald (ej skip_if/skip_if_not/skip_on_*)
+            if printf '%s' "$content" | grep -qE '(^|[^_a-zA-Z])skip\s*\('; then
+              # Tjek SKIP-REASON inline paa samme linje
+              if printf '%s' "$content" | grep -qE '#\s*SKIP-REASON:\s*(env|todo|permanent|regression|manual)'; then
+                prev_line="$content"
+                continue
+              fi
+              # Tjek SKIP-REASON paa foregaaende linje (over skip-kaldet)
+              if printf '%s' "$prev_line" | grep -qE '#\s*SKIP-REASON:\s*(env|todo|permanent|regression|manual)'; then
+                prev_line="$content"
+                continue
+              fi
+              # Intet SKIP-REASON fundet — log warning
+              # Find linjenummer i den faktiske fil
+              lineno=$(grep -n "" "$f" | grep -F "${content}" | head -1 | cut -d: -f1)
+              if [ -n "$lineno" ]; then
+                skip_lint_hits="${skip_lint_hits}\n  --- $f ---\n  ${lineno}:${content}"
+              else
+                skip_lint_hits="${skip_lint_hits}\n  --- $f ---\n  ?:${content}"
+              fi
+            fi
+            prev_line="$content"
+            ;;
+          *) prev_line="" ;;
+        esac
+      done < <(git diff --cached -U1 -- "$f")
+    done
+    if [ -n "$skip_lint_hits" ]; then
+      echo ""
+      echo "WARNING Ny skip()-kald uden SKIP-REASON kommentar (Issue #428)"
+      echo "  Foretraek: tilfoej kommentar over skip() med kategori + deadline"
+      echo "  Format: # SKIP-REASON: <env|todo|permanent|regression|manual> [<deadline>]"
+      printf "%b\n" "$skip_lint_hits"
+      echo ""
+      echo "  Bypass: SKIP_SKIP_LINT=1 git commit"
+      echo "  (commit tilladt -- kun warning)"
+      echo ""
+    fi
+  fi
+fi
+
 # Find staged R-filer (ekskl. dev/ og golem_utils.R)
 staged_r_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(R|r)$' | grep -v 'dev/' | grep -v 'golem_utils.R')
 


### PR DESCRIPTION
## Summary

- Tilfoej **Step 0.7** til `dev/git-hooks/pre-commit`: nye `skip()`-kald i `tests/testthat/` uden paakraevet `SKIP-REASON`-kommentar udloser en warning (ej blokerende — commit tillades altid)
- Diff-baseret: kun *nye* (added) linjer kontrolleres — de eksisterende 96 skip()-kald uden kommentar bryder ingenting
- Bypass: `SKIP_SKIP_LINT=1 git commit` slaar step 0.7 fra

## Hook-step detaljer

**Paakraevet format** (oven over eller inline paa skip()-kaldet):

```r
# SKIP-REASON: <env|todo|permanent|regression|manual> [<deadline>]
skip("Funktion fjernet i refactor")

# eller inline:
skip("X")  # SKIP-REASON: env [permanent]
```

**Eksempel-output ved manglende kommentar:**

```
WARNING Ny skip()-kald uden SKIP-REASON kommentar (Issue #428)
  Foretraek: tilfoej kommentar over skip() med kategori + deadline
  Format: # SKIP-REASON: <env|todo|permanent|regression|manual> [<deadline>]

  --- tests/testthat/test-foo.R ---
  42:    skip("X function missing")

  Bypass: SKIP_SKIP_LINT=1 git commit
  (commit tilladt -- kun warning)
```

## Verifikation

- [x] `bash -n dev/git-hooks/pre-commit` — syntax OK
- [x] Manuel test: ny `skip("X")` uden kommentar → warning vist, commit tilladt
- [x] Manuel test: `# SKIP-REASON: todo [2026-06-01]` over skip() → ingen warning
- [x] Manuel test: `skip("X")  # SKIP-REASON: env [permanent]` inline → ingen warning
- [x] Manuel test: `SKIP_SKIP_LINT=1` → hele step 0.7 skipped
- [x] Pre-push checks bestaaet (mode=fast, 60s)
- [x] `skip_if()`, `skip_if_not()`, `skip_on_cran()` etc. matches IKKE (negative lookbehind `[^_a-zA-Z]`)

## Test plan

- [ ] Bekraeft warning vises ved PR-gennemgang ved at stage en ny skip() uden kommentar
- [ ] Bekraeft at eksisterende tests korer fejlfrit (`devtools::test()`)