### PR TITLE
test: konvertér reactive-context-skips til testServer-shim (Fase 2 af #428)

### DIFF
--- a/tests/testthat/test-file-operations.R
+++ b/tests/testthat/test-file-operations.R
@@ -644,10 +644,50 @@ describe("Security Hardening", {
     expect_false(result$valid)
   })
 
-  it("enforces rate limiting on uploads", {
-    skip("Requires session state and timing")
+  it("enforces rate limiting on uploads (#428 Fase 2)", {
+    # Rate-limit-logik bor i setup_file_upload() -> observeEvent(input$data_file):
+    # naar last_upload_time er sat for nylig, returnerer observeren tidligt
+    # (showNotification + return()) *inden* app_state$data$updating_table saettes.
+    # Observable: updating_table forbliver FALSE naar rate-limit trigges.
+    #
+    # Pattern: testServer(server_fn, {test_expr}) — server og test ADSKILT
+    # for korrekt fejl-propagation (se test-chart-type-observer-integration.R).
+    skip_if_not(exists("setup_file_upload", mode = "function"))
+    skip_if_not(exists("create_app_state", mode = "function"))
 
-    # Rate limiting prevents rapid successive uploads
-    # This would require mocking app_state and timing
+    # Opret en valid temp-CSV-fil som input$data_file kan pege paa
+    tmp_csv <- tempfile(fileext = ".csv")
+    writeLines("Dato;Tæller\n2024-01-01;10", tmp_csv)
+    on.exit(unlink(tmp_csv), add = TRUE)
+
+    app_state <- create_app_state()
+    emit <- create_emit_api(app_state)
+
+    # Server-funktion (registrerer upload-handler)
+    server_fn <- function(input, output, session) {
+      setup_file_upload(input, output, session, app_state, emit)
+    }
+
+    shiny::testServer(
+      server_fn,
+      {
+        # Foer-betingelse: updating_table er FALSE
+        expect_false(shiny::isolate(app_state$data$updating_table),
+          label = "updating_table skal starte FALSE"
+        )
+
+        # Simuler at en upload lige er sket (rate-limit vindue = RATE_LIMITS$file_upload_seconds)
+        app_state$session$last_upload_time <- Sys.time()
+
+        # Trigger data_file — rate-limit checker koerer foer req(input$data_file)
+        # saa et scalar-vaerdi er nok til at trigge observeEvent
+        session$setInputs(data_file = tmp_csv)
+
+        # Rate-limit skal have blokeret: updating_table forbliver FALSE
+        expect_false(shiny::isolate(app_state$data$updating_table),
+          label = "updating_table forbliver FALSE naar rate-limit blokerer upload"
+        )
+      }
+    )
   })
 })

--- a/tests/testthat/test-mod-spc-chart-comprehensive.R
+++ b/tests/testthat/test-mod-spc-chart-comprehensive.R
@@ -696,9 +696,48 @@ describe("Viewport Dimensions", {
     })
   })
 
-  it("uses clientData viewport dimensions when available", {
-    # This test requires actual Shiny session with clientData
-    skip("Requires full Shiny session with clientData")
+  it("uses clientData viewport dimensions when available (#428 Fase 2)", {
+    # testServer's mockclientdata returnerer 600x400 for enhver output-width/height.
+    # register_viewport_observer() laester session$clientData og kalder
+    # set_viewport_dims(app_state, width, height) naar dimensioner > 100px.
+    # Observable: app_state$visualization$viewport_dims opdateres med mockclientdata-vaerdier.
+    skip_if_not(exists("visualizationModuleServer", mode = "function"))
+
+    app_state <- create_mock_app_state()
+
+    testServer(
+      visualizationModuleServer,
+      args = list(
+        column_config_reactive = reactive(list(
+          x_col = "Dato", y_col = "Tæller", n_col = NULL
+        )),
+        chart_type_reactive = reactive("i"),
+        target_value_reactive = reactive(NULL),
+        target_text_reactive = reactive(NULL),
+        centerline_value_reactive = reactive(NULL),
+        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
+        frys_config_reactive = reactive(NULL),
+        app_state = app_state
+      ),
+      {
+        # testServer's mockclientdata returnerer 600x400 for output_<id>_width/height.
+        # Flush for at sikre viewport-observer har koert.
+        session$flushReact()
+
+        # Viewport-dims skal vaere opdateret fra clientData (ikke NULL og ikke fallback 800x600)
+        dims <- shiny::isolate(app_state$visualization$viewport_dims)
+        expect_false(is.null(dims),
+          info = "viewport_dims skal vaere sat efter clientData er laest"
+        )
+        # mockclientdata leverer 600x400 — bekraeft at det er laest korrekt
+        expect_equal(dims$width, 600,
+          info = "viewport_dims$width skal matche mockclientdata-vaerdi (600px)"
+        )
+        expect_equal(dims$height, 400,
+          info = "viewport_dims$height skal matche mockclientdata-vaerdi (400px)"
+        )
+      }
+    )
   })
 })
 
@@ -706,10 +745,24 @@ describe("Viewport Dimensions", {
 
 describe("Debouncing", {
   it("debounces chart_config to prevent redundant renders", {
-    skip("Debouncing requires time-based testing framework")
+    # chart_config-debouncing (DEBOUNCE_DELAYS$input_change = 150ms) er
+    # allerede daekkket af §2.3.1d-testen (linje 533):
+    #   "debounces rapid events to single render (§2.3.1d)"
+    # Den test bruger testServer + chart_type reactiveVal + later::run_now(2)
+    # og verificerer at 3 hurtige chart_type-aendringer giver < 3 chart_config-eval.
+    # Denne test er en conscioest besluttet reference til §2.3.1d fremfor
+    # duplikeret daekning med identiske assertions.
+    # Afventer: konsolidering af debounce-teststruktur i #428 Fase 3.
+    skip("chart_config-debouncing daekkket af §2.3.1d (linje 533) — #428 Fase 3")
   })
 
   it("debounces spc_inputs to prevent redundant renders", {
-    skip("Debouncing requires time-based testing framework")
+    # spc_inputs = debounce(spc_inputs_raw, DEBOUNCE_DELAYS$file_select = 500ms).
+    # spc_inputs er modul-intern — ingen direkte ekstern observable returneres.
+    # Indirekte observable: visualization_update_needed event-taeller.
+    # Kompleksitet: kraever session$elapse(650+) + oevrig reaktiv kaedeventetid.
+    # Afventer: dedikeret test-infrastruktur for modulinterne debouncede reactives.
+    # Deadline: #428 Fase 3.
+    skip("spc_inputs modul-intern debounce — kræver dedikeret infrastruktur — #428 Fase 3")
   })
 })


### PR DESCRIPTION
## Opsummering

Fase 2 af Issue #428 — konverterer reactive-context-skips til kørende `testServer`-tests i to filer.

### Konverterede skips

| Fil | Linje | Gammel skip-grund | Status |
|-----|-------|-------------------|--------|
| `test-file-operations.R` | 648 | `"Requires session state and timing"` | Konverteret til testServer |
| `test-mod-spc-chart-comprehensive.R` | 701 | `"Requires full Shiny session with clientData"` | Konverteret til testServer |
| `test-mod-spc-chart-comprehensive.R` | 709 | `"Debouncing requires time-based testing framework"` | Behold skip — dækket af §2.3.1d (linje 533) |
| `test-mod-spc-chart-comprehensive.R` | 713 | `"Debouncing requires time-based testing framework"` | Behold skip — modul-intern debounce, kræver #428 Fase 3 |

### Skip-count reduktion

| Fil | Før | Efter |
|-----|-----|-------|
| `test-file-operations.R` | 2 skips | 1 skip |
| `test-mod-spc-chart-comprehensive.R` | 5 skips | 4 skips |

### Tekniske detaljer

**Rate-limit test (`test-file-operations.R`):**
- Server-fn og test-expr adskilt i `testServer()` (korrekt mønster, undgår teardown-fejl med kombineret funktion)
- Pre-sæt `app_state$session$last_upload_time = Sys.time()` simulerer nylig upload
- Observable: `app_state$data$updating_table` forbliver `FALSE` når rate-limit blokerer

**clientData-test (`test-mod-spc-chart-comprehensive.R`):**
- `testServer`'s `mockclientdata` returnerer 600×400 for output-width/height by default
- `register_viewport_observer()` læser clientData → kalder `set_viewport_dims()`
- Observable: `app_state$visualization$viewport_dims` opdateres til `{width=600, height=400}`

**Bevarede skips med opdaterede kommentarer:**
- Line 709 (chart_config 150ms): bevidst reference til §2.3.1d-dekning fremfor duplikering
- Line 713 (spc_inputs 500ms): modul-intern reactive uden ekstern observable uden dedikeret infrastruktur

### Ingen regression

- `test-label-placement-core.R` fejl (6 stk.) er pre-eksisterende og ikke relaterede til disse ændringer
- Alle øvrige tests fortsætter med at bestå

## Test plan

- [x] `test-file-operations.R`: FAIL 0 | SKIP 1 | PASS 68 (var: SKIP 2 | PASS 66)
- [x] `test-mod-spc-chart-comprehensive.R`: FAIL 0 | SKIP 4 | PASS 54 (var: SKIP 5 | PASS 51)
- [x] Pre-push hook bestået (fast mode)
- [x] Atomiske commits: én per fil