### PR TITLE
fix(analysis): brug rå qic_data$cl primært for målvurdering (#470)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Bug fixes
 
+* **Klinisk kritisk:** `resolve_analysis_centerline()` bruger nu rå
+  `qic_data$cl` (uafrundet qicharts2-værdi) primært i stedet for
+  BFHcharts' afrundede `summary$centerlinje`. Tidligere kunne
+  afrunding flippe målfortolkning ved boundary-cases (eksempel: rå
+  cl=0.9005 opfylder target>=0.9003, men summary-værdi 0.9000 ville
+  forkert vise "ikke opfyldt"). Summary bruges nu kun som fallback
+  hvis qic_data mangler. (#470)
+
 * Erstatter `getFromNamespace()`-brug af BFHcharts-internals med public
   API. `bfh_extract_spc_stats()`, `bfh_merge_metadata()` og
   `bfh_create_typst_document()` er nu alle eksporterede funktioner i

--- a/R/utils_export_analysis_metadata.R
+++ b/R/utils_export_analysis_metadata.R
@@ -23,16 +23,26 @@ resolve_analysis_centerline <- function(bfh_qic_result) {
     return(NULL)
   }
 
+  # #470: Brug qic_data$cl (raa qicharts2-vaerdi) primaert for at undgaa
+  # afrundings-tab i BFHcharts' summary-lag der ellers kan flippe
+  # malfortolkning ved boundary-cases. Eksempel: rå cl=0.9005,
+  # target>=0.9003 → maal opfyldt; men summary-centerlinje 0.9000 vil
+  # forkert give "ikke opfyldt".
+  #
+  # Sidste raekke matcher eksisterende semantik (sidste fase ved freeze/part).
+  qic_data <- bfh_qic_result$qic_data
+  if (!is.null(qic_data) && "cl" %in% names(qic_data) && nrow(qic_data) > 0) {
+    return(qic_data$cl[nrow(qic_data)])
+  }
+
+  # Fallback: summary kun hvis qic_data mangler (degraderet input).
+  # Note: summary-vaerdier er afrundede til UI-format; brug ikke til
+  # praecisionskritisk logik.
   summary_data <- bfh_qic_result$summary
   if (!is.null(summary_data) &&
     "centerlinje" %in% names(summary_data) &&
     nrow(summary_data) > 0) {
     return(summary_data$centerlinje[nrow(summary_data)])
-  }
-
-  qic_data <- bfh_qic_result$qic_data
-  if (!is.null(qic_data) && "cl" %in% names(qic_data) && nrow(qic_data) > 0) {
-    return(qic_data$cl[1])
   }
 
   NULL

--- a/tests/testthat/test-utils-export-analysis-metadata.R
+++ b/tests/testthat/test-utils-export-analysis-metadata.R
@@ -68,3 +68,62 @@ test_that("build_export_analysis_metadata falls back to qic_data centerline and 
   expect_equal(metadata$department, "Akut")
   expect_null(metadata$target)
 })
+
+# ============================================================================
+# Regression tests: #470 - centerlinje-afrunding flipper malfortolkning
+# ============================================================================
+# BFHcharts' summary-lag afrunder kontrolgrænser (jf. utils_qic_summary.R:177).
+# resolve_analysis_centerline() skal bruge qic_data$cl (raa qicharts2-vaerdi)
+# primaert for at undgaa boundary-cases hvor afrunding flipper "maal opfyldt"-
+# vurdering.
+
+make_divergent_bfh_result <- function(raw_cl, summary_cl, y_axis_unit = "percent") {
+  # Mock hvor summary er afrundet vs. qic_data raa - illustrerer #470 bug
+  result <- list(
+    config = list(y_axis_unit = y_axis_unit),
+    summary = data.frame(centerlinje = summary_cl),
+    qic_data = data.frame(cl = rep(raw_cl, 3))
+  )
+  class(result) <- "bfh_qic_result"
+  result
+}
+
+test_that("resolve_analysis_centerline() prefers raw qic_data over rounded summary (#470)", {
+  # Rå cl=0.9005, summary afrundet til 0.9000
+  result <- make_divergent_bfh_result(raw_cl = 0.9005, summary_cl = 0.9000)
+  expect_equal(resolve_analysis_centerline(result), 0.9005)
+})
+
+test_that("at_target uses raw centerline so target=0.9003 with cl=0.9005 = TRUE (#470)", {
+  # Boundary-case: rå cl >= target opfyldt; summary afrundet ville flippe vurdering
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_divergent_bfh_result(raw_cl = 0.9005, summary_cl = 0.9000),
+    target_value = 0.9003,
+    target_text = ">= 90,03%"
+  )
+  expect_true(metadata$at_target,
+    info = "Raw cl=0.9005 >= target=0.9003 -> mål opfyldt (afrundet 0.9000 ville flippe)"
+  )
+})
+
+test_that("centerline value falls back to summary when qic_data mangler (#470)", {
+  # Degraderet input: kun summary tilgaengelig
+  result <- list(
+    config = list(y_axis_unit = "count"),
+    summary = data.frame(centerlinje = 42),
+    qic_data = NULL
+  )
+  class(result) <- "bfh_qic_result"
+  expect_equal(resolve_analysis_centerline(result), 42)
+})
+
+test_that("resolve_analysis_centerline returns last row for variable cl (freeze/part)", {
+  # Variabel cl ved freeze/part - sidste raekke matcher sidste fase
+  result <- list(
+    config = list(y_axis_unit = "count"),
+    summary = data.frame(centerlinje = c(10, 20)),
+    qic_data = data.frame(cl = c(10, 10, 10, 20, 20, 20))
+  )
+  class(result) <- "bfh_qic_result"
+  expect_equal(resolve_analysis_centerline(result), 20)
+})


### PR DESCRIPTION
## Summary

**Klinisk kritisk bug**: \`resolve_analysis_centerline()\` brugte BFHcharts' afrundede summary-værdi til logical comparison i \`compute_at_target()\`. Boundary-cases kunne flippe målfortolkning → klinikere ser "mål ikke opfyldt" når processen faktisk opfylder målet.

## Bug-illustration

\`\`\`
Rå qic_data\$cl     = 0.9005
Summary-centerlinje = 0.9000  (afrundet af BFHcharts)
Target              = >= 0.9003

FØR fix: 0.9000 < 0.9003 → mål IKKE opfyldt (FORKERT)
EFTER fix: 0.9005 >= 0.9003 → mål OPFYLDT (korrekt)
\`\`\`

## Fix

Inverter prioritet i \`resolve_analysis_centerline()\`:

\`\`\`r
# FØR: summary først, qic_data fallback
# EFTER: qic_data\$cl[nrow] først (rå), summary fallback
\`\`\`

\`qic_data\$cl[nrow]\` matcher eksisterende sidste-fase-semantik (ved freeze/part-charts).

## Cross-cutting konsekvenser

- **Display-laget uændret**: \`format_analysis_context_value()\` afrunder stadig til UI-format
- **Logic-laget rettet**: \`compute_at_target()\` får nu rå værdi → korrekt målvurdering
- **Excel-eksport**: Konsistent rapportering mellem UI og analysefil

## Test plan

- [x] 4 nye regression-tests:
  - \`resolve_analysis_centerline()\` prefers raw over rounded summary
  - \`at_target\` boundary-case 0.9005 vs 0.9000
  - Fallback til summary når qic_data mangler
  - Variabel cl returnerer sidste række (freeze/part)
- [x] Eksisterende 3 tests passerer stadig
- [x] Bredere relateret suite grøn (test-utils-export-analysis-metadata, fct_spc_excel_analysis)
- [ ] CI verificeres efter push
- [ ] Manuel verifikation af Excel-eksport viser konsistent målvurdering med UI

## Reference

- Issue: #470
- Codex-rescue verifikation 2026-05-03
- Same root-cause som #468 (forkert brug af BFHcharts' rapporteringslag som beregningskilde)
- BFHcharts-side: BFHcharts#290 (summary-rounding scope-item)