### PR TITLE
ci: pre-install chromium (workaround xtradeb PPA flake — #436)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -47,6 +47,12 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck
@@ -85,6 +91,12 @@ jobs:
         with:
           r-version: 'release'
           use-public-rspm: true
+
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -127,6 +139,12 @@ jobs:
         with:
           r-version: 'release'
           use-public-rspm: true
+
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -94,6 +94,12 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        if: steps.check.outputs.deps_changed == 'true'
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - name: Install R dependencies
         if: steps.check.outputs.deps_changed == 'true'
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -31,6 +31,12 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::covr, any::testthat, any::mockery

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -39,6 +39,12 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::shinytest2, any::testthat

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -61,6 +61,11 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -32,6 +32,12 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::testthat, any::mockery


### PR DESCRIPTION
## Summary

CI fejler intermittent med **HTTP 504 Gateway Timeout** fra `launchpad.net` REST API når pak's sysreqs-handler kalder `add-apt-repository ppa:xtradeb/apps` for at installere chromium (sysreq for chromote i biSPCharts Suggests).

Canonical DDoS-recovery (#436) er delvis: `ppa.launchpad.net` (apt-repo) er oppe ifølge [Canonical status](https://status.canonical.com/), men `launchpad.net` REST API der returnerer signing keys for PPAs er stadig ramt.

## Workaround

Pre-install chromium-browser via standard Ubuntu apt (eller snap fallback) **før** `setup-r-dependencies` kører. pak's sysreqs-handler skipper xtradeb-PPA-add når chromium allerede er installeret.

```yaml
- name: Pre-install chromium (workaround xtradeb PPA flake)
  run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
```

## Filer ændret

| Fil | Antal jobs |
|-----|------------|
| `R-CMD-check.yaml` | 3 (smoke, gate, release-gate) |
| `testthat.yaml` | 1 |
| `coverage.yaml` | 1 |
| `shinytest2.yaml` | 1 |
| `auto-regen-manifest.yaml` | 1 (med if-betingelse) |
| `sibling-bump-poller.yaml` | 1 |

## Påvirkning

- **Positiv**: CI passerer trods xtradeb PPA-flake
- **Negativ**: ~10-30s ekstra setup-tid per job (chromium-browser install)
- **Risiko**: Lav — fallback til snap + `|| true` sikrer ingen step-fail

## Workaround er midlertidig

Fjern når:
- Canonical recovery er fuldt komplet (xtradeb PPA stabil), ELLER
- pkgdepends sysreqs-database opdaterer chromium-handler til at bruge officiel Ubuntu-repo i stedet for xtradeb PPA

## Test plan

- [x] YAML-syntax valideret (yaml::read_yaml på alle 6 filer)
- [ ] CI verificeres efter push (denne PR er selv-testen)
- [ ] Hvis grøn → merge → rebase #467, #469, #471, #472 oven på master

## Reference

- Issue: #436 (Canonical DDoS recovery tracker)
- Affected PRs: #467, #469, #471, #472 (alle blokkeret af samme PPA-flake)
- Codex DDoS-side observation 2026-05-03