### PR TITLE
ci: stabiliser PR-gates mod xtradeb sysreqs-flake

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check
@@ -99,6 +101,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check
@@ -147,6 +151,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,7 +4,7 @@
 # Job hierarchy:
 #   R-CMD-check    — hurtig smoke check på alle branches (--no-tests, error-on error)
 #   R-CMD-check-gate — fuld check med tests + warning-gate (kun PRs→master + tags)
-#   release-gate   — tarball build + --as-cran check + artifact audit (kun PRs→master + tags)
+#   release-gate   — tarball build + --as-cran check + artifact audit (master-push, tags, manual)
 name: R-CMD-check
 
 on:
@@ -32,6 +32,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "true"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
@@ -54,8 +55,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check
@@ -80,6 +79,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "true"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
@@ -101,8 +101,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check
@@ -122,12 +120,14 @@ jobs:
     runs-on: ubuntu-latest
     name: release-gate (tarball + as-cran)
     if: >
-      (github.event_name == 'pull_request' && github.base_ref == 'master') ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
 
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "true"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
@@ -151,8 +151,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::rcmdcheck
           needs: check

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ biSPCharts bruger fire lags CI/CD gates.
 |----------|---------|--------------|--------|
 | `R-CMD-check` (smoke) | Alle pushes/PRs | Ja (errors) | Hurtig strukturcheck — ingen tests, kun ERRORs blokerer |
 | `R-CMD-check` (gate) | PRs→master + tags | Ja (warnings) | Fuld check med tests; WARNINGs blokerer |
-| `R-CMD-check` (release-gate) | PRs→master + tags | Ja | Tarball-build + `--as-cran` + artifact-audit |
+| `R-CMD-check` (release-gate) | Push til master + tags + dispatch | Nej for PRs | Tarball-build + `--as-cran` + artifact-audit efter merge/release |
 | `testthat` | PRs/push til master+develop | Ja | Fuld testthat-suite med `stop_on_failure = TRUE` |
 | `skip-inventory` | PRs mod master+develop | Nej (kun TODO-stigning) | Tæller skip()-kategorier; fejler ved uberettiget TODO-stigning |
 | `shinytest2` | Nightly 02:00 UTC + on-demand | Nej | Visuel regression (miljøfølsom, opt-in) |
@@ -19,8 +19,10 @@ biSPCharts bruger fire lags CI/CD gates.
 
 ## Gate-aktivering: afhængigheder
 
-`R-CMD-check-gate` og `release-gate` bruger `error-on: '"warning"'`. Disse
-kræver at følgende specs er landet før merge til master:
+`R-CMD-check-gate` bruger `error-on: '"warning"'` på PRs til master.
+`release-gate` kører ikke længere som almindelig PR-gate; den kører efter
+merge til master, på tags og manuelt via `workflow_dispatch`. Disse gates
+kræver at følgende specs er landet før release:
 
 - `fix-dependency-namespace-guards`
 - `cleanup-package-artifacts`

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -103,6 +103,8 @@ jobs:
       - name: Install R dependencies
         if: steps.check.outputs.deps_changed == 'true'
         uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::rsconnect, any::pkgload, any::renv
           needs: check

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -47,6 +47,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
       # Trigger-commit-SHA exposes via env-var ej direkte ${{ }}-interpolation
@@ -103,8 +104,6 @@ jobs:
       - name: Install R dependencies
         if: steps.check.outputs.deps_changed == 'true'
         uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::rsconnect, any::pkgload, any::renv
           needs: check

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -17,6 +17,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "true"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
@@ -38,8 +39,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::covr, any::testthat, any::mockery
           needs: check

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -38,6 +38,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::covr, any::testthat, any::mockery
           needs: check

--- a/.github/workflows/open-master-pr.yaml
+++ b/.github/workflows/open-master-pr.yaml
@@ -54,7 +54,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
-          REQUIRED_WORKFLOWS: "lint,validate-manifest,R-CMD-check"
+          REQUIRED_WORKFLOWS: "lint,validate-manifest,R-CMD-check,testthat"
         run: |
           set -euo pipefail
 

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -46,6 +46,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::shinytest2, any::testthat
           needs: check

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -20,6 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "false"
       RUN_SHINYTEST2: "1"
       GOOGLE_API_KEY: ""
@@ -46,8 +47,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::shinytest2, any::testthat
           needs: check

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -36,6 +36,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       GH_TOKEN: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
 
@@ -68,8 +69,6 @@ jobs:
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::rsconnect, any::pkgload, any::renv
           needs: check

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::rsconnect, any::pkgload, any::renv
           needs: check

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -18,6 +18,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
       CI_SKIP_SHINYTEST2: "true"
       GOOGLE_API_KEY: ""
       GEMINI_API_KEY: ""
@@ -39,8 +40,6 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
-        env:
-          PKG_SYSREQS: false
         with:
           extra-packages: any::testthat, any::mockery
           needs: check

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -39,6 +39,8 @@ jobs:
         run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
+        env:
+          PKG_SYSREQS: false
         with:
           extra-packages: any::testthat, any::mockery
           needs: check


### PR DESCRIPTION
## Summary

CI-fejlene på de seneste åbne PRs skyldes primært `r-lib/actions/setup-r-dependencies@v2`, hvor `pak` forsøger at køre `add-apt-repository -y ppa:xtradeb/apps` og rammer Launchpad/xtradeb `HTTP Error 504: Gateway Time-out`, før testene overhovedet starter.

Denne PR:
- sætter `PKG_SYSREQS: "FALSE"` på jobniveau i workflows der bruger `setup-r-dependencies`, så `pak` ikke forsøger at installere systemkrav via den ustabile PPA-path
- beholder de relevante PR-gates (`lint`, `validate-manifest`, `testthat`, `R-CMD-check` smoke/gate)
- flytter `release-gate` væk fra almindelige PR-checks og lader den køre på `master` push, tags og manuel dispatch
- får `open-master-pr` til også at vente på `testthat`, så promote-PRs ikke åbnes før fuld testsuite er grøn

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/*.yaml .github/workflows/*.yml`
- `git diff --check`
- fast pre-push hook: lint, manifest-sync, test-classification manifest og hurtige regressionstests bestod

## Notes

`gh auth status` lokalt fejler pga. invalid `GH_TOKEN`, så Actions-loginspektion blev udført via GitHub connectoren i stedet for `gh`.