### PR TITLE
refactor(config): konsolidér resterende Sys.getenv via safe_getenv (#458)

### DIFF
--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -252,10 +252,7 @@ app_sys <- function(...) {
 #' @noRd
 get_golem_config <- function(
   value,
-  config = Sys.getenv(
-    "GOLEM_CONFIG_ACTIVE",
-    "default"
-  ),
+  config = safe_getenv("GOLEM_CONFIG_ACTIVE", default = "default"),
   use_parent = TRUE
 ) {
   # Avoid app_sys during package loading to prevent freeze

--- a/R/utils_analytics_github.R
+++ b/R/utils_analytics_github.R
@@ -73,9 +73,9 @@ build_session_filename <- function(session_id = NULL, timestamp = Sys.time()) {
 sync_logs_to_github <- function(all_data,
                                 session_id = NULL,
                                 max_retries = 3L) {
-  pat <- Sys.getenv("GITHUB_PAT")
-  repo_url <- Sys.getenv("PIN_REPO_URL")
-  branch <- Sys.getenv("PIN_REPO_BRANCH")
+  pat <- safe_getenv("GITHUB_PAT")
+  repo_url <- safe_getenv("PIN_REPO_URL")
+  branch <- safe_getenv("PIN_REPO_BRANCH")
   if (nchar(branch) == 0) branch <- "main"
 
   if (nchar(pat) == 0 || nchar(repo_url) == 0) {

--- a/R/utils_analytics_pins.R
+++ b/R/utils_analytics_pins.R
@@ -294,8 +294,8 @@ aggregate_and_pin_logs <- function(log_directory = "logs/",
     code = {
       github_sync_enabled <- isTRUE(golem::get_golem_options("analytics.github_sync_enabled"))
       if (github_sync_enabled &&
-        nchar(Sys.getenv("GITHUB_PAT")) > 0 &&
-        nchar(Sys.getenv("PIN_REPO_URL")) > 0) {
+        nchar(safe_getenv("GITHUB_PAT")) > 0 &&
+        nchar(safe_getenv("PIN_REPO_URL")) > 0) {
         result <- sync_logs_to_github(all_data, session_id = session_id)
         if (isTRUE(result$success)) {
           log_info(
@@ -315,7 +315,7 @@ aggregate_and_pin_logs <- function(log_directory = "logs/",
           )
         }
       } else if (requireNamespace("pins", quietly = TRUE) &&
-        nchar(Sys.getenv("CONNECT_SERVER")) > 0) {
+        nchar(safe_getenv("CONNECT_SERVER")) > 0) {
         board <- pins::board_connect()
         safe_pin_data <- filter_shinylogs_allowlist(all_data)
         pins::pin_write(board, safe_pin_data, config$pin_name,


### PR DESCRIPTION
## Summary

- Konverterer 7 resterende `Sys.getenv()`-sites til `safe_getenv()` (Fase 2 af #458)
- Bringer total adoption fra 12/27 op til komplet (på nær 1 NA_character_-special-case + 2 explicit \"Bevidst raw\")
- Bevarer existence-check-semantik (`nchar > 0`) og unset-vs-empty-string-semantik

## Sites

- `R/utils_analytics_pins.R`: GITHUB_PAT, PIN_REPO_URL, CONNECT_SERVER (3)
- `R/utils_analytics_github.R`: GITHUB_PAT, PIN_REPO_URL, PIN_REPO_BRANCH (3)
- `R/app_ui.R`: GOLEM_CONFIG_ACTIVE (1)

## Bevidst raw kept

- `R/zzz.R:205` — `unset = NA_character_` for on.exit-detection (særlig semantik)
- `R/utils_cache_generators.R:199-200` — explicit comment \"Bevidst raw\" (ENV-key existence vs value)

## Test plan

- [x] Eksisterende analytics-tests passerer (20+46 PASS)
- [x] Package loads (`devtools::load_all`)

Closes #458