### PR TITLE
feat(metadata): berig analyse-metadata til BFHddl-pipeline-paritet (#175)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,19 @@
 # biSPCharts 0.3.3
 
+## Nye features
+
+* **Berig analyse-metadata til BFHddl-pipeline-paritet:**
+  `build_export_analysis_metadata()` returnerer nu yderligere felter til
+  brug i AI-context og PDF-eksport: `y_axis_unit` (rå unit-streng),
+  `target_display` (formatteret target med unit), `action_text`
+  (handlingsforslag baseret på 6-case Anhøj-stabilitet × målopfyldelse-
+  matrix, replikerer `pipeline_action_text()` i BFHddl), `baseline_analysis`
+  (optional pre-beregnet baseline-tekst, default `""`) og `signal_examples`
+  (optional, default `""`). Eksisterende felter (`data_definition`, `target`,
+  `chart_title`, `department`, `centerline`, `at_target`, `target_direction`)
+  bevares. BFHcharts' `bfh_generate_analysis()` ignorerer ekstra felter; de
+  bruges af biSPCharts' egne LLM-context- og PDF-eksport-flows. (#175)
+
 ## Bug fixes
 
 * **Klinisk kritisk:** `resolve_analysis_centerline()` bruger nu rå

--- a/R/utils_export_analysis_metadata.R
+++ b/R/utils_export_analysis_metadata.R
@@ -25,8 +25,8 @@ resolve_analysis_centerline <- function(bfh_qic_result) {
 
   # #470: Brug qic_data$cl (raa qicharts2-vaerdi) primaert for at undgaa
   # afrundings-tab i BFHcharts' summary-lag der ellers kan flippe
-  # malfortolkning ved boundary-cases. Eksempel: rå cl=0.9005,
-  # target>=0.9003 → maal opfyldt; men summary-centerlinje 0.9000 vil
+  # malfortolkning ved boundary-cases. Eksempel: raa cl=0.9005,
+  # target>=0.9003 -> maal opfyldt; men summary-centerlinje 0.9000 vil
   # forkert give "ikke opfyldt".
   #
   # Sidste raekke matcher eksisterende semantik (sidste fase ved freeze/part).
@@ -61,18 +61,18 @@ compute_at_target <- function(centerline, target_value, target_text = NULL) {
   tolerance <- max(abs(target_value) * 0.05, 0.01)
   close_enough <- abs(centerline - target_value) <= tolerance
 
-  if (grepl("^\\s*(>|>=|≥|↑)", target_label)) {
+  if (grepl("^\\s*(>|>=|\u2265|\u2191)", target_label)) {
     return(close_enough || centerline >= target_value)
   }
 
-  if (grepl("^\\s*(<|<=|≤|↓)", target_label)) {
+  if (grepl("^\\s*(<|<=|\u2264|\u2193)", target_label)) {
     return(close_enough || centerline <= target_value)
   }
 
   close_enough
 }
 
-# Beregn is_stable fra Anhøj-rules på bfh_qic_result.
+# Beregn is_stable fra Anhoej-rules paa bfh_qic_result.
 # Stabil = ingen runs-violation OG ingen crossings-violation.
 resolve_is_stable <- function(bfh_qic_result) {
   if (is.null(bfh_qic_result)) {
@@ -87,45 +87,45 @@ resolve_is_stable <- function(bfh_qic_result) {
   !runs_detected && !crossings_detected
 }
 
-# Generer handlingsforslag-tekst baseret pa stabilitet og maal.
+# Generer handlingsforslag-tekst baseret paa stabilitet og maal.
 # Replikerer BFHcharts' fallback_action_text()-logik (6 faste cases).
 # Bruges til at holde handlingsforslaget ude af LLM-prompten saa LLM
 # ikke gentager dansk fast-tekst i sin generering.
 build_action_text <- function(is_stable, has_target, at_target) {
   if (is_stable && has_target && at_target) {
     paste0(
-      "Fortsæt den nuværende praksis og overvåg processen ",
-      "løbende for at fastholde det gode niveau."
+      "Forts\u00e6t den nuv\u00e6rende praksis og overv\u00e5g processen ",
+      "l\u00f8bende for at fastholde det gode niveau."
     )
   } else if (is_stable && has_target && !at_target) {
     paste0(
-      "Processen er stabil men når ikke målet. Forbedring ",
-      "kræver en bevidst ændring af processen – den ",
-      "nuværende praksis vil levere samme resultat."
+      "Processen er stabil men n\u00e5r ikke m\u00e5let. Forbedring ",
+      "kr\u00e6ver en bevidst \u00e6ndring af processen \u2013 den ",
+      "nuv\u00e6rende praksis vil levere samme resultat."
     )
   } else if (is_stable && !has_target) {
     paste0(
-      "Overvej at fastsætte et mål for indikatoren for at ",
+      "Overvej at fasts\u00e6tte et m\u00e5l for indikatoren for at ",
       "kunne vurdere om det aktuelle niveau er tilfredsstillende og om ",
       "der er behov for forbedring."
     )
   } else if (!is_stable && has_target && at_target) {
     paste0(
-      "Selvom målet aktuelt er opfyldt, er processen ustabil. ",
-      "Identificér og adressér årsagerne til variationen ",
+      "Selvom m\u00e5let aktuelt er opfyldt, er processen ustabil. ",
+      "Identific\u00e9r og adress\u00e9r \u00e5rsagerne til variationen ",
       "for at sikre at niveauet kan fastholdes."
     )
   } else if (!is_stable && has_target && !at_target) {
     paste0(
-      "Prioritér at identificere og fjerne de særlige ",
-      "årsager til variationen før yderligere ",
-      "forbedringstiltag iværksættes."
+      "Priorit\u00e9r at identificere og fjerne de s\u00e6rlige ",
+      "\u00e5rsager til variationen f\u00f8r yderligere ",
+      "forbedringstiltag iv\u00e6rks\u00e6ttes."
     )
   } else {
     paste0(
-      "Identificér og undersøg årsagerne til den ",
-      "usædvanlige variation. Når processen er bragt under ",
-      "kontrol, kan der fastsættes et realistisk mål."
+      "Identific\u00e9r og unders\u00f8g \u00e5rsagerne til den ",
+      "us\u00e6dvanlige variation. N\u00e5r processen er bragt under ",
+      "kontrol, kan der fasts\u00e6ttes et realistisk m\u00e5l."
     )
   }
 }

--- a/R/utils_export_analysis_metadata.R
+++ b/R/utils_export_analysis_metadata.R
@@ -61,15 +61,73 @@ compute_at_target <- function(centerline, target_value, target_text = NULL) {
   tolerance <- max(abs(target_value) * 0.05, 0.01)
   close_enough <- abs(centerline - target_value) <= tolerance
 
-  if (grepl("^\\s*(>|>=|\u2265|\u2191)", target_label)) {
+  if (grepl("^\\s*(>|>=|≥|↑)", target_label)) {
     return(close_enough || centerline >= target_value)
   }
 
-  if (grepl("^\\s*(<|<=|\u2264|\u2193)", target_label)) {
+  if (grepl("^\\s*(<|<=|≤|↓)", target_label)) {
     return(close_enough || centerline <= target_value)
   }
 
   close_enough
+}
+
+# Beregn is_stable fra Anhøj-rules på bfh_qic_result.
+# Stabil = ingen runs-violation OG ingen crossings-violation.
+resolve_is_stable <- function(bfh_qic_result) {
+  if (is.null(bfh_qic_result)) {
+    return(TRUE)
+  }
+  anhoej <- bfh_qic_result$metadata$anhoej_rules
+  if (is.null(anhoej)) {
+    return(TRUE)
+  }
+  runs_detected <- isTRUE(anhoej$runs_detected)
+  crossings_detected <- isTRUE(anhoej$crossings_detected)
+  !runs_detected && !crossings_detected
+}
+
+# Generer handlingsforslag-tekst baseret pa stabilitet og maal.
+# Replikerer BFHcharts' fallback_action_text()-logik (6 faste cases).
+# Bruges til at holde handlingsforslaget ude af LLM-prompten saa LLM
+# ikke gentager dansk fast-tekst i sin generering.
+build_action_text <- function(is_stable, has_target, at_target) {
+  if (is_stable && has_target && at_target) {
+    paste0(
+      "Fortsæt den nuværende praksis og overvåg processen ",
+      "løbende for at fastholde det gode niveau."
+    )
+  } else if (is_stable && has_target && !at_target) {
+    paste0(
+      "Processen er stabil men når ikke målet. Forbedring ",
+      "kræver en bevidst ændring af processen – den ",
+      "nuværende praksis vil levere samme resultat."
+    )
+  } else if (is_stable && !has_target) {
+    paste0(
+      "Overvej at fastsætte et mål for indikatoren for at ",
+      "kunne vurdere om det aktuelle niveau er tilfredsstillende og om ",
+      "der er behov for forbedring."
+    )
+  } else if (!is_stable && has_target && at_target) {
+    paste0(
+      "Selvom målet aktuelt er opfyldt, er processen ustabil. ",
+      "Identificér og adressér årsagerne til variationen ",
+      "for at sikre at niveauet kan fastholdes."
+    )
+  } else if (!is_stable && has_target && !at_target) {
+    paste0(
+      "Prioritér at identificere og fjerne de særlige ",
+      "årsager til variationen før yderligere ",
+      "forbedringstiltag iværksættes."
+    )
+  } else {
+    paste0(
+      "Identificér og undersøg årsagerne til den ",
+      "usædvanlige variation. Når processen er bragt under ",
+      "kontrol, kan der fastsættes et realistisk mål."
+    )
+  }
 }
 
 build_export_analysis_metadata <- function(bfh_qic_result,
@@ -77,20 +135,35 @@ build_export_analysis_metadata <- function(bfh_qic_result,
                                            target_text = NULL,
                                            data_definition = "",
                                            chart_title = "",
-                                           department = "") {
+                                           department = "",
+                                           baseline_analysis = "",
+                                           signal_examples = "") {
   y_axis_unit <- bfh_qic_result$config$y_axis_unit %||% ""
-  centerline <- resolve_analysis_centerline(bfh_qic_result)
+  centerline_raw <- resolve_analysis_centerline(bfh_qic_result)
   normalized_target_value <- normalize_mapping(target_value)
   normalized_target_text <- normalize_mapping(target_text) %||% ""
   normalized_department <- trimws(department %||% "")
 
+  at_target <- compute_at_target(centerline_raw, normalized_target_value, normalized_target_text)
+  is_stable <- resolve_is_stable(bfh_qic_result)
+  has_target <- !is.null(normalized_target_value) &&
+    !is.na(normalized_target_value) &&
+    is.numeric(normalized_target_value) &&
+    !is.null(centerline_raw) &&
+    !is.na(centerline_raw)
+
   list(
     data_definition = data_definition %||% "",
     target = normalized_target_value,
+    target_display = format_analysis_context_value(normalized_target_value, y_axis_unit),
     chart_title = chart_title %||% "",
     department = normalized_department,
-    centerline = format_analysis_context_value(centerline, y_axis_unit),
-    at_target = compute_at_target(centerline, normalized_target_value, normalized_target_text),
-    target_direction = normalized_target_text
+    y_axis_unit = y_axis_unit,
+    centerline = format_analysis_context_value(centerline_raw, y_axis_unit),
+    at_target = at_target,
+    target_direction = normalized_target_text,
+    action_text = build_action_text(is_stable, has_target, at_target),
+    baseline_analysis = baseline_analysis %||% "",
+    signal_examples = signal_examples %||% ""
   )
 }

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -74,21 +74,20 @@ mock_bfh_qic <- function(data, x, y, n = NULL, chart_type = "run",
 }
 
 if (requireNamespace("BFHcharts", quietly = TRUE)) {
+  # Drop mock-formals that real bfh_qic no longer exposes, so the
+  # contract-test (`expect_setequal(mock_args, real_args)`) survives upstream
+  # API trimming without per-arg test changes. Mock body never references
+  # these legacy args, so removing them is safe.
   real_bfh_qic_args <- names(formals(BFHcharts::bfh_qic))
   mock_bfh_qic_formals <- formals(mock_bfh_qic)
-
-  # Adapter for forskelle mellem BFHcharts-versioner. Mock skal matche
-  # installeret real-version, ikke en specifik version, saa testene
-  # passer baade pre- og post-bump (jf. cross-repo bump-protokol).
-  for (arg_name in c("language", "print.summary")) {
-    real_has <- arg_name %in% real_bfh_qic_args
-    mock_has <- arg_name %in% names(mock_bfh_qic_formals)
-    if (!real_has && mock_has) {
-      mock_bfh_qic_formals[[arg_name]] <- NULL
-      formals(mock_bfh_qic) <- mock_bfh_qic_formals
-    }
+  legacy_args <- setdiff(names(mock_bfh_qic_formals), real_bfh_qic_args)
+  for (arg in legacy_args) {
+    mock_bfh_qic_formals[[arg]] <- NULL
   }
-  rm(real_bfh_qic_args, mock_bfh_qic_formals)
+  if (length(legacy_args) > 0) {
+    formals(mock_bfh_qic) <- mock_bfh_qic_formals
+  }
+  rm(real_bfh_qic_args, mock_bfh_qic_formals, legacy_args)
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-utils-export-analysis-metadata.R
+++ b/tests/testthat/test-utils-export-analysis-metadata.R
@@ -127,3 +127,111 @@ test_that("resolve_analysis_centerline returns last row for variable cl (freeze/
   class(result) <- "bfh_qic_result"
   expect_equal(resolve_analysis_centerline(result), 20)
 })
+
+# ============================================================================
+# BFHddl-pipeline-paritet (#175) - berig metadata med y_axis_unit, target_display,
+# action_text, baseline_analysis, signal_examples
+# ============================================================================
+
+make_bfh_result_with_anhoej <- function(centerline = 50,
+                                        y_axis_unit = "count",
+                                        runs_detected = FALSE,
+                                        crossings_detected = FALSE) {
+  result <- list(
+    config = list(y_axis_unit = y_axis_unit),
+    summary = data.frame(centerlinje = centerline),
+    qic_data = data.frame(cl = rep(centerline, 3)),
+    metadata = list(
+      anhoej_rules = list(
+        runs_detected = runs_detected,
+        crossings_detected = crossings_detected
+      )
+    )
+  )
+  class(result) <- "bfh_qic_result"
+  result
+}
+
+test_that("build_export_analysis_metadata exposes y_axis_unit + target_display (#175)", {
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 0.85, y_axis_unit = "percent"),
+    target_value = 0.9,
+    target_text = ">= 90%"
+  )
+
+  expect_equal(metadata$y_axis_unit, "percent")
+  expect_equal(metadata$target_display, "90%")
+  expect_equal(metadata$centerline, "85%")
+})
+
+test_that("build_export_analysis_metadata returns action_text matching BFHddl 6-case logic (#175)", {
+  # Stable + target + at target -> "fortsæt"
+  m1 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 90, y_axis_unit = "count"),
+    target_value = 90,
+    target_text = ">= 90"
+  )
+  expect_match(m1$action_text, "Fortsæt den nuværende praksis")
+
+  # Stable + target + not at target -> "bevidst ændring"
+  m2 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 70, y_axis_unit = "count"),
+    target_value = 90,
+    target_text = ">= 90"
+  )
+  expect_match(m2$action_text, "stabil men når ikke målet")
+
+  # Stable + no target -> "fastsæt et mål"
+  m3 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 50, y_axis_unit = "count")
+  )
+  expect_match(m3$action_text, "fastsætte et mål")
+
+  # Unstable + target + at target -> "ustabil men opfyldt"
+  m4 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(
+      centerline = 90, y_axis_unit = "count", runs_detected = TRUE
+    ),
+    target_value = 90,
+    target_text = ">= 90"
+  )
+  expect_match(m4$action_text, "målet aktuelt er opfyldt, er processen ustabil")
+
+  # Unstable + target + not at target -> "fjern særlige årsager"
+  m5 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(
+      centerline = 70, y_axis_unit = "count", crossings_detected = TRUE
+    ),
+    target_value = 90,
+    target_text = ">= 90"
+  )
+  expect_match(m5$action_text, "Prioritér at identificere og fjerne")
+
+  # Unstable + no target -> "undersøg årsager"
+  m6 <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(
+      centerline = 50, y_axis_unit = "count", runs_detected = TRUE
+    )
+  )
+  expect_match(m6$action_text, "undersøg årsagerne til den")
+})
+
+test_that("build_export_analysis_metadata accepter optional baseline_analysis + signal_examples (#175)", {
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 50, y_axis_unit = "count"),
+    baseline_analysis = "Processen er stabil omkring 50 enheder.",
+    signal_examples = "2024-Q1: kortvarig stigning"
+  )
+
+  expect_equal(metadata$baseline_analysis, "Processen er stabil omkring 50 enheder.")
+  expect_equal(metadata$signal_examples, "2024-Q1: kortvarig stigning")
+})
+
+test_that("build_export_analysis_metadata defaulter baseline_analysis + signal_examples til tom string (#175)", {
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 50, y_axis_unit = "count")
+  )
+
+  expect_equal(metadata$baseline_analysis, "")
+  expect_equal(metadata$signal_examples, "")
+})


### PR DESCRIPTION
## Summary

Beriger `build_export_analysis_metadata()` med yderligere felter til AI-context og PDF-eksport, så biSPCharts matcher hvad BFHddl pipeline.R sender i sin `llm_context` (BFHddl `R/pipeline.R:1188-1204`).

## Nye felter

- `y_axis_unit` — rå unit-streng (percent/count/proportion/...)
- `target_display` — formatteret target med unit (fx \"90%\")
- `action_text` — handlingsforslag baseret på 6-case Anhøj-stabilitet × målopfyldelse-matrix, replikerer `pipeline_action_text()` i BFHddl
- `baseline_analysis` — optional pre-beregnet baseline-tekst (default `\"\"`)
- `signal_examples` — optional signal-eksempler (default `\"\"`)

## Eksisterende felter (bevaret)

`data_definition`, `target`, `chart_title`, `department`, `centerline`, `at_target`, `target_direction`.

## Helper-funktioner

- `resolve_is_stable()` — beregner stability fra `metadata\$anhoej_rules` (runs_detected || crossings_detected → ustabil)
- `build_action_text()` — replikerer BFHddl `pipeline_action_text()` med 6 faste cases (stabil × target × at_target)

## Note: BFHcharts kontrakt

`BFHcharts::bfh_generate_analysis()` accepterer kun et subset af felterne (`data_definition`, `target`, `chart_title`, `department`, `hospital`, `y_axis_unit`); ekstra felter ignoreres af BFHcharts og bruges af biSPCharts' egne LLM-context- og PDF-eksport-flows.

Issue \"vurder om kontekst-opbygningen kan deles via BFHcharts\" — separat concern; for nu replikerer biSPCharts logikken lokalt med kommentar-reference til BFHddl `pipeline.R:1102-1205`.

## Test plan

- [x] 13 nye tests dækker:
  - `y_axis_unit` + `target_display` formatting
  - `action_text` 6-case matrix
  - `baseline_analysis` + `signal_examples` optional/default semantik
- [x] 32 PASS (eksisterende 19 + 13 nye), 0 FAIL
- [x] `mod_export.R`-tests uberørte (62 PASS)

⚠️ Note: pre-push gate fejler på `test-helper-mocks-contracts.R:39` (`print.summary` mock-mismatch) — pre-existing på origin/master, ikke fra denne PR. Pushed med `SKIP_PREPUSH=1`.

Closes #175