### PR TITLE
fix(ci): repariér export-smoke-test workflow

### DIFF
--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -8,19 +8,41 @@ on:
     - cron: "0 3 * * *"
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   export-smoke-test:
     runs-on: ubuntu-latest
     name: Quarto capability check
 
+    env:
+      GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
+      CI_SKIP_SHINYTEST2: "true"
+      GOOGLE_API_KEY: ""
+      GEMINI_API_KEY: ""
+
     steps:
       - uses: actions/checkout@v4
 
+      - uses: r-lib/actions/setup-pandoc@v2
+
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.3"
+          r-version: "release"
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v2
+      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
+      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
+      - name: Pre-install chromium (workaround xtradeb PPA flake)
+        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::testthat, any::mockery
+          needs: check
 
       - name: Installer Quarto CLI
         uses: quarto-dev/quarto-actions/setup@v2
@@ -31,6 +53,10 @@ jobs:
         run: |
           quarto --version
           quarto typst --version
+        shell: bash
+
+      - name: Install local package
+        run: R CMD INSTALL .
         shell: bash
 
       - name: Kor export capability tests


### PR DESCRIPTION
## Problem

Nightly export-smoke-test fejler på master:

```
Error in contrib.url(repos, type) : trying to use CRAN without setting a mirror
Calls: install.packages -> startsWith -> contrib.url
```

Workflow brugte `setup-renv@v2` men repo har intet `renv.lock`, så action triggede `install.packages("renv")` uden CRAN-mirror sat.

Run: https://github.com/johanreventlow/biSPCharts/actions/runs/25303375458

## Ændringer

- Drop `setup-renv@v2` (intet lockfile i repo)
- `setup-r` med `use-public-rspm: true`
- `setup-r-dependencies@v2` med `testthat`+`mockery`
- Pre-install chromium (xtradeb PPA workaround, parity med øvrige workflows, ref. #436)
- `R CMD INSTALL .` før test (action havde ikke pkg loaded)
- Tilføj env-vars (`GITHUB_PAT`, `PKG_SYSREQS`, `CI_SKIP_SHINYTEST2`, tom GOOGLE/GEMINI keys)
- `r-version: release` (parity med testthat.yaml + R-CMD-check.yaml; var pinnet til 4.3)

## Bonus

Oprettet manglende label `shinytest2-failure` i repo (workflow forsøgte `gh issue create --label shinytest2-failure` men fejlede 'label not found').

## Test plan

- [x] Lokalt: workflow YAML valideret syntaktisk
- [ ] Trigger via `workflow_dispatch` efter merge for at bekræfte grøn run
- [ ] Verificer label-applied når næste shinytest2-fejl rammer