### PR TITLE
fix(deploy): qualify app_ui/app_server med ::: i app.R (fixes #481)

### DIFF
--- a/app.R
+++ b/app.R
@@ -17,7 +17,9 @@ pkgload::load_all(export_all = FALSE, helpers = FALSE, attach_testthat = FALSE)
 options("golem.app.prod" = TRUE)
 
 # Returner shinyApp objekt - Connect Cloud styrer livscyklus
+# Bruger ::: fordi app_ui/app_server er @keywords internal og dermed ej i
+# package-search-path efter pkgload::load_all(export_all = FALSE). Ref #481.
 shiny::shinyApp(
-  ui = app_ui,
-  server = app_server
+  ui = biSPCharts:::app_ui,
+  server = biSPCharts:::app_server
 )


### PR DESCRIPTION
## Problem

Production-entrypoint `app.R` kaldte bare `app_ui`/`app_server` efter `pkgload::load_all(export_all = FALSE)`. Begge er `@keywords internal` og dermed ej i søgesti — `shiny::shinyApp()` fejlede med:

```
Fejl: objekt 'app_server' blev ikke fundet
```

Verificeret lokalt med `Rscript app.R`-emulering. ADR-019 påstand om at flow var verificeret på Connect Cloud kunne ej genskabes.

## Fix

Qualify referencer med `:::` (pakke-intern):

```r
shiny::shinyApp(
  ui = biSPCharts:::app_ui,
  server = biSPCharts:::app_server
)
```

Holder NAMESPACE-kontrakt: `app_ui`/`app_server` forbliver internal. ADR-019 intent (kun exports public) bevaret.

## Verifikation

```bash
Rscript -e 'options(shiny.autoload.r=FALSE); pkgload::load_all(export_all=FALSE, helpers=FALSE, attach_testthat=FALSE); shiny::shinyApp(ui=biSPCharts:::app_ui, server=biSPCharts:::app_server)'
# → OK: shinyApp object created, class: shiny.appobj
```

## Test plan
- [x] Rscript-emulering bekræfter shinyApp construction
- [x] testthat: `package-initialization` + `no-file-dependencies` tests passerer
- [x] Pre-push gate (fast mode) passerer
- [ ] **MANUELT TRIN:** Pilot-deploy til Connect Cloud staging før master-merge

## Følge-arbejde

ADR-019 bør revideres til at reflektere `:::`-pattern (separat PR/commit hvis ønsket).

Fixes #481