### PR TITLE
fix(deps): flyt openxlsx Suggests → Imports (fixes #483)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,8 @@ Imports:
     config (>= 0.3.0),
     systemfonts (>= 1.0.0),
     pkgload (>= 1.3.0),
-    svglite (>= 2.1.0)
+    svglite (>= 2.1.0),
+    openxlsx (>= 4.2.0)
 Suggests:
     chromote,
     httr2,
@@ -59,7 +60,6 @@ Suggests:
     rmarkdown,
     rprojroot,
     writexl (>= 1.4.0),
-    openxlsx (>= 4.2.0),
     microbenchmark (>= 1.4.0),
     covr (>= 3.6.0),
     qicharts2 (>= 0.7.0),


### PR DESCRIPTION
## Problem

\`R/fct_spc_file_save_load.R:45-138\` kaldte \`openxlsx::createWorkbook()\`, \`addWorksheet()\`, \`writeData()\`, \`saveWorkbook()\` unconditionally — uden \`requireNamespace(\"openxlsx\", quietly = TRUE)\`-guard. \`openxlsx\` var deklareret i Suggests.

Konsekvens: fresh Connect Cloud-deploy, Docker-image eller CI uden openxlsx → Excel-export crash med:
\`\`\`
there is no package called 'openxlsx'
\`\`\`

## Fix

Flyt openxlsx fra Suggests til Imports. Excel save/load er kerne klinisk-flow — ej optional feature.

## Manifest

\`manifest.json\` indeholdt allerede openxlsx (renv resolverede det som transitive dep). DESCRIPTION-ændring er kontrakt-fix uden behov for manifest-regen. \`Rscript dev/validate_connect_manifest.R\` passerer.

## Test plan

- [x] Manifest-validator passerer (BFH*-pakker stadig synced)
- [x] Pre-push gate (fast mode) passerer
- [ ] **Anbefalet:** verify-fix lokalt — \`remove.packages(\"openxlsx\")\` + reinstall + run E2E excel-export-test

Fixes #483