### PR TITLE
fix(security): udvid escape_typst_metadata med 11 markup-tegn (fixes #486)

### DIFF
--- a/R/utils_export_validation.R
+++ b/R/utils_export_validation.R
@@ -319,9 +319,24 @@ validate_aspect_ratio <- function(width, height, warn_only = TRUE) {
 
 #' Escape user-input for Typst-template
 #'
-#' Escapes Typst-markup characters: #, $, backtick, backslash.
-#' Defense-in-depth -- BFHcharts forventes ogsaa at escape, men app-laget
-#' tilfoejer ekstra beskyttelse mod markup-injection.
+#' Escapes Typst-markup characters for at undgaa at user-input fortolkes som
+#' Typst-markup ved indsaettelse i template. Defense-in-depth -- BFHcharts
+#' forventes ogsaa at escape, men app-laget tilfoejer ekstra beskyttelse
+#' mod markup-injection.
+#'
+#' Escaped tegn (jf. Typst-syntaks):
+#' \itemize{
+#'   \item Backslash (\\) -- escape-prefiks selv
+#'   \item Hash (#) -- function-call/raw-block
+#'   \item Dollar ($) -- math-mode
+#'   \item Backtick (\code{`}) -- raw-text
+#'   \item Asterisk (*) -- bold (#486)
+#'   \item Underscore (_) -- emphasis/italic (#486)
+#'   \item Square brackets (\code{[}, \code{]}) -- content-block (#486)
+#'   \item Angle brackets (\code{<}, \code{>}) -- label/syntax (#486)
+#'   \item At-sign (@) -- reference (#486)
+#'   \item Line-leading =, -, +, / -- heading/list-markers (#486)
+#' }
 #'
 #' @param value Character or NULL/non-character (returneres uaendret).
 #'   Vectors behandles per element.
@@ -342,6 +357,23 @@ escape_typst_metadata <- function(value) {
   value <- gsub("#", "\\\\#", value)
   value <- gsub("\\$", "\\\\$", value)
   value <- gsub("`", "\\\\`", value)
+
+  # #486: Markup-tegn der inden for tekst kan inducere format-aendring.
+  value <- gsub("\\*", "\\\\*", value)
+  value <- gsub("_", "\\\\_", value)
+  value <- gsub("\\[", "\\\\[", value)
+  value <- gsub("\\]", "\\\\]", value)
+  value <- gsub("<", "\\\\<", value)
+  value <- gsub(">", "\\\\>", value)
+  value <- gsub("@", "\\\\@", value)
+
+  # #486: Line-leading markup (heading/list). Brug multi-line-mode (?m) saa
+  # ^ matcher start-af-linje, ej kun start-af-streng.
+  value <- gsub("(?m)^=", "\\\\=", value, perl = TRUE)
+  value <- gsub("(?m)^-", "\\\\-", value, perl = TRUE)
+  value <- gsub("(?m)^\\+", "\\\\+", value, perl = TRUE)
+  value <- gsub("(?m)^/", "\\\\/", value, perl = TRUE)
+
   value
 }
 

--- a/tests/testthat/test-escape-typst-metadata.R
+++ b/tests/testthat/test-escape-typst-metadata.R
@@ -129,3 +129,70 @@ test_that("escape_typst_metadata haandterer tom streng", {
   result <- escape_typst_metadata("")
   expect_equal(result, "")
 })
+
+# TEST: #486 — udvidet markup-coverage =========================================
+# Sikrer escape af markup-tegn der tidligere blev render'd som format
+# (bold, emphasis, label, reference, list, heading) i Typst-PDF.
+
+test_that("escape_typst_metadata escaper asterisk (*) — bold", {
+  result <- escape_typst_metadata("Geriatri *G16*")
+  # Forventet: "Geriatri \*G16\*" (R-streng = "Geriatri \\*G16\\*")
+  expect_equal(result, "Geriatri \\*G16\\*")
+})
+
+test_that("escape_typst_metadata escaper underscore (_) — emphasis", {
+  result <- escape_typst_metadata("kategori_a_b")
+  expect_equal(result, "kategori\\_a\\_b")
+})
+
+test_that("escape_typst_metadata escaper square brackets ([ ]) — content-block", {
+  result <- escape_typst_metadata("[indhold]")
+  expect_equal(result, "\\[indhold\\]")
+})
+
+test_that("escape_typst_metadata escaper angle brackets (< >) — label/syntax", {
+  result <- escape_typst_metadata("<test>")
+  expect_equal(result, "\\<test\\>")
+})
+
+test_that("escape_typst_metadata escaper at-sign (@) — reference", {
+  result <- escape_typst_metadata("test@host")
+  expect_equal(result, "test\\@host")
+})
+
+test_that("escape_typst_metadata escaper line-leading = (heading)", {
+  result <- escape_typst_metadata("=Heading")
+  expect_equal(result, "\\=Heading")
+
+  # Multi-line: kun line-leading skal escapes
+  multi <- escape_typst_metadata("normal\n=second-line")
+  expect_equal(multi, "normal\n\\=second-line")
+})
+
+test_that("escape_typst_metadata escaper line-leading - (list)", {
+  result <- escape_typst_metadata("-list item")
+  expect_equal(result, "\\-list item")
+})
+
+test_that("escape_typst_metadata escaper line-leading + (list)", {
+  result <- escape_typst_metadata("+list item")
+  expect_equal(result, "\\+list item")
+})
+
+test_that("escape_typst_metadata escaper line-leading / (list)", {
+  result <- escape_typst_metadata("/term: definition")
+  expect_equal(result, "\\/term: definition")
+})
+
+test_that("escape_typst_metadata bevarer ikke-leading -, +, / (kun line-leading escapes)", {
+  # Inde i tekst skal disse ej escapes (kun line-leading er markup-trigger)
+  result <- escape_typst_metadata("a-b+c/d")
+  expect_equal(result, "a-b+c/d")
+})
+
+test_that("escape_typst_metadata kombinerer alle markup-tegn (#486)", {
+  # Realistisk klinisk bruger-input med flere markup-trigger
+  input <- "<test@host>"
+  result <- escape_typst_metadata(input)
+  expect_equal(result, "\\<test\\@host\\>")
+})


### PR DESCRIPTION
## Problem

\`escape_typst_metadata()\` (\`R/utils_export_validation.R:330\`) escapede kun \`#\`, \`\$\`, backtick og backslash. Manglede:

| Tegn | Typst-betydning | Eksempel |
|------|----------------|----------|
| \`*\` | Bold | \"Geriatri *G16*\" → bold |
| \`_\` | Emphasis | \"kategori_a_b\" → italic |
| \`[\` \`]\` | Content-block | \"[indhold]\" → block |
| \`<\` \`>\` | Label/syntax | \"<test>\" → label |
| \`@\` | Reference | \"test@host\" → ref-attempt |
| Line-leading \`=\` | Heading | \"=Heading\" → h1 |
| Line-leading \`-\`, \`+\`, \`/\` | List/term | \"-list\" → list-item |

## Risiko

Department/title/baseline rendrede som format i Typst-PDF (silent korruption). Klinisk personale forventer plain-text-render.

## Fix

Udvid escape-rules. Line-leading regex bruger \`(?m)\`-multi-line mode så \`^\` matcher start-af-linje, ikke kun start-af-streng. Ikke-leading tegn (\`a-b+c/d\`) bevares.

## Tests

11 nye unit-tests:
- Per markup-trigger (5 single-char + 4 line-leading)
- Multi-line (kun line-leading escape)
- Kombinations-test (\`<test@host>\`)
- Ikke-leading bevares (\`a-b+c/d\`)

37 escape/typst tests passerer (0 FAIL).

Fixes #486