### PR TITLE
fix(export): cap pdf_description og LLM-context-fields til max 2000 tegn (fixes #489)

### DIFF
--- a/R/fct_ai_improvement_suggestions.R
+++ b/R/fct_ai_improvement_suggestions.R
@@ -71,6 +71,14 @@ generate_improvement_suggestion <- function(spc_result, context, session, max_ch
         return(NULL)
       }
 
+      # #489: Server-side cap paa free-text-felter foer LLM-kald for at undgaa
+      # cost-amplification + Gemini rate-limit ved meget store inputs.
+      # Bruger samme limit som EXPORT_DESCRIPTION_MAX_LENGTH (2000) for
+      # konsistens med PDF-eksport-validering. Truncation logges; ingen
+      # user-warning i denne sti (UI-laget validerer separat via
+      # validate_export_inputs).
+      context <- truncate_llm_context_fields(context)
+
       # PHI-check: CPR-moenstre i data_definition -> modal advarsel foer afsendelse.
       # Pattern matcher dansk CPR-format: 6 cifre + valgfri bindestreg + 4 cifre.
       data_def_text <- context$data_definition %||% ""
@@ -133,4 +141,40 @@ generate_improvement_suggestion <- function(spc_result, context, session, max_ch
     fallback = NULL,
     show_user = TRUE
   )
+}
+
+# Truncate free-text-felter i LLM-context til EXPORT_DESCRIPTION_MAX_LENGTH
+# (#489). Beskytter mod cost-amplification og Gemini rate-limit ved meget
+# lange inputs. Truncation logges paa info-niveau saa server-operatør kan
+# spore mønstre. Returnerer modificeret context med samme keys.
+truncate_llm_context_fields <- function(context,
+                                        max_length = EXPORT_DESCRIPTION_MAX_LENGTH) {
+  if (!is.list(context) || length(context) == 0) {
+    return(context)
+  }
+
+  # Felter der kan rumme bruger-skrevet free-text. y_axis_unit og target er
+  # korte enum/numeric — udelades.
+  freetext_fields <- c(
+    "data_definition", "chart_title", "department",
+    "baseline_analysis", "signal_examples", "target_text",
+    "target_display", "action_text", "y_axis_unit"
+  )
+
+  for (field in freetext_fields) {
+    val <- context[[field]]
+    if (!is.null(val) && is.character(val) && length(val) == 1L &&
+      !is.na(val) && nchar(val) > max_length) {
+      log_info(
+        message = sprintf(
+          "LLM-context: truncating %s fra %d til %d tegn (#489)",
+          field, nchar(val), max_length
+        ),
+        .context = "AI_SUGGESTION"
+      )
+      context[[field]] <- substr(val, 1L, max_length)
+    }
+  }
+
+  context
 }

--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -100,7 +100,8 @@ generate_pdf_export <- function(input, app_state, file) {
     format = "pdf",
     title = input$export_title,
     department = input$export_department,
-    hospital = input$export_hospital
+    hospital = input$export_hospital,
+    description = input$pdf_description
   )
 
   # Generer SPC plot via faelles helper

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1026,6 +1026,14 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-03'
   rationale: Tilfoejet manuelt — fil oprettet efter audit-baseline 2026-04-26.
+- file: test-llm-context-truncation-489.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-04'
+  rationale: Regression-test for #489 LLM-context-cap — tilfoejet manuelt.
 - file: test-cache-session-scope.R
   audit_category: post-audit
   type: unit

--- a/tests/testthat/test-llm-context-truncation-489.R
+++ b/tests/testthat/test-llm-context-truncation-489.R
@@ -1,0 +1,87 @@
+# test-llm-context-truncation-489.R
+# Regression-test for #489: truncate_llm_context_fields begraenser free-text
+# i LLM-context til EXPORT_DESCRIPTION_MAX_LENGTH foer Gemini-kald. Beskytter
+# mod cost-amplification og rate-limit.
+
+test_that("truncate_llm_context_fields begraenser data_definition til max_length", {
+  long_text <- strrep("a", EXPORT_DESCRIPTION_MAX_LENGTH + 500)
+  context <- list(data_definition = long_text)
+
+  result <- truncate_llm_context_fields(context)
+  expect_equal(nchar(result$data_definition), EXPORT_DESCRIPTION_MAX_LENGTH)
+})
+
+test_that("truncate_llm_context_fields lader korte vaerdier vaere urort", {
+  short_text <- "Ventetid til operation"
+  context <- list(
+    data_definition = short_text,
+    chart_title = "Q1 2024",
+    department = "Ortopædkirurgi"
+  )
+
+  result <- truncate_llm_context_fields(context)
+  expect_equal(result$data_definition, short_text)
+  expect_equal(result$chart_title, "Q1 2024")
+  expect_equal(result$department, "Ortopædkirurgi")
+})
+
+test_that("truncate_llm_context_fields handler NULL og NA gracefully", {
+  context <- list(
+    data_definition = NULL,
+    chart_title = NA_character_,
+    department = "Akut"
+  )
+
+  result <- truncate_llm_context_fields(context)
+  expect_null(result$data_definition)
+  expect_true(is.na(result$chart_title))
+  expect_equal(result$department, "Akut")
+})
+
+test_that("truncate_llm_context_fields truncater alle freetext-felter ved long input", {
+  too_long <- strrep("x", EXPORT_DESCRIPTION_MAX_LENGTH + 1L)
+  context <- list(
+    data_definition = too_long,
+    chart_title = too_long,
+    baseline_analysis = too_long,
+    signal_examples = too_long
+  )
+
+  result <- truncate_llm_context_fields(context)
+  expect_true(all(vapply(
+    result[c("data_definition", "chart_title", "baseline_analysis", "signal_examples")],
+    nchar, integer(1L)
+  ) == EXPORT_DESCRIPTION_MAX_LENGTH))
+})
+
+test_that("truncate_llm_context_fields lader non-freetext-felter (target_value) vaere", {
+  too_long <- strrep("x", EXPORT_DESCRIPTION_MAX_LENGTH + 1L)
+  context <- list(
+    data_definition = "kort",
+    target_value = 42, # numeric — ej med i freetext_fields
+    centerline = 50.5
+  )
+
+  result <- truncate_llm_context_fields(context)
+  expect_equal(result$target_value, 42)
+  expect_equal(result$centerline, 50.5)
+})
+
+test_that("truncate_llm_context_fields handler tom liste", {
+  expect_equal(truncate_llm_context_fields(list()), list())
+})
+
+test_that("truncate_llm_context_fields handler non-list input", {
+  # Defensiv check: returnerer input urort hvis ej list
+  expect_equal(truncate_llm_context_fields(NULL), NULL)
+  expect_equal(truncate_llm_context_fields("ikke list"), "ikke list")
+})
+
+test_that("truncate_llm_context_fields respekterer custom max_length", {
+  text <- strrep("a", 100L)
+  result <- truncate_llm_context_fields(
+    list(data_definition = text),
+    max_length = 50L
+  )
+  expect_equal(nchar(result$data_definition), 50L)
+})


### PR DESCRIPTION
## To-delt fix

### A) pdf_description bypasser længde-validering

\`R/mod_export_download.R::generate_pdf_export()\` passede ikke \`description=input\$pdf_description\` til \`validate_export_inputs()\`. \`EXPORT_DESCRIPTION_MAX_LENGTH\` (2000) blev derfor ignoreret. 50.000+ char input flydte direkte til \`metadata\$data_definition\` → Typst-compile slow/OOM på Connect worker.

**Fix:** tilføj \`description = input\$pdf_description\` til validator-kaldet.

### B) LLM-context-fields ucapped før Gemini

\`R/fct_ai_improvement_suggestions.R\` passede free-text-context direkte til BFHllm uden length-cap. Cost-amplification + rate-limit ved store inputs.

**Fix:** ny helper \`truncate_llm_context_fields()\` server-side begrænser \`data_definition\`, \`chart_title\`, \`department\`, \`baseline_analysis\`, \`signal_examples\`, \`target_text/display\`, \`action_text\`, \`y_axis_unit\` til \`EXPORT_DESCRIPTION_MAX_LENGTH\`. Truncation logges på info-niveau.

## Tests

\`tests/testthat/test-llm-context-truncation-489.R\` — 8 unit-tests:
- Truncation ved long input
- Korte værdier urort
- NULL/NA gracefully
- Tom liste / non-list input gracefully
- Custom \`max_length\` parameter
- Non-freetext felter (target_value, centerline) bevares

563 ai/export/llm tests passerer (0 FAIL).

Fixes #489