### PR TITLE
test(mocks): refactor mock_bfh_qic til BFHcharts 0.15.0 contract (fixes #490)

### DIFF
--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -44,6 +44,18 @@ mock_bfhllm_spc_suggestion <- function(spc_result, context, min_chars = 300,
 #'
 #' Returnerer minimal bfh_qic_result-struktur uden ggplot-rendering.
 #' formals() matcher den installerede BFHcharts::bfh_qic-version.
+#'
+#' Kontrakt-paritet med BFHcharts >= 0.15.0 (#490):
+#' - $qic_data (ej $data) — laesest af `transform_bfh_output()`
+#' - $summary med decomposed signal-kolonner (anhoej_signal, runs_signal,
+#'   crossings_signal, centerlinje) — erstatter legacy
+#'   summary$loebelaengde_signal
+#' - $config med y_axis_unit
+#' - S3-class "bfh_qic_result" saa S3-dispatch virker
+#' - Anhoej-rule-kolonner i qic_data (anhoej.signal, runs.signal,
+#'   sigma.signal, n.crossings, n.crossings.min, longest.run,
+#'   longest.run.max) — alle NA-defaults; tests kan overrides via
+#'   constructor-parametre.
 mock_bfh_qic <- function(data, x, y, n = NULL, chart_type = "run",
                          y_axis_unit = NULL, chart_title = NULL,
                          target_value = NULL, target_text = NULL,
@@ -56,21 +68,62 @@ mock_bfh_qic <- function(data, x, y, n = NULL, chart_type = "run",
                          subtitle = NULL, caption = NULL,
                          return.data = FALSE, print.summary = FALSE,
                          language = "da") {
-  # Minimal struktur matchende real bfh_qic_result
-  list(
+  n_rows <- nrow(data)
+  cl_value <- if (!is.null(cl)) {
+    cl
+  } else {
+    mean(as.numeric(data[[y]]), na.rm = TRUE)
+  }
+
+  qic_data <- data.frame(
+    x = seq_len(n_rows),
+    y = as.numeric(data[[y]]),
+    cl = rep(cl_value, n_rows),
+    lcl = rep(NA_real_, n_rows),
+    ucl = rep(NA_real_, n_rows),
+    # Anhoej-rule-kolonner (BFHcharts 0.15.0 contract)
+    anhoej.signal = rep(FALSE, n_rows),
+    runs.signal = rep(FALSE, n_rows),
+    sigma.signal = rep(FALSE, n_rows),
+    n.crossings = rep(NA_real_, n_rows),
+    n.crossings.min = rep(NA_real_, n_rows),
+    longest.run = rep(NA_real_, n_rows),
+    longest.run.max = rep(NA_real_, n_rows),
+    part = if (!is.null(part) && part %in% names(data)) {
+      as.factor(data[[part]])
+    } else {
+      factor(rep(1L, n_rows))
+    }
+  )
+
+  # signal-kolonne aliaserer anhoej.signal saa downstream-kald
+  # (transform_bfh_output) er glade ved enten `signal` eller `anhoej.signal`.
+  qic_data$signal <- qic_data$anhoej.signal
+
+  # Summary per part — decomposed signaler matcher BFHcharts 0.15.0
+  parts_levels <- levels(qic_data$part)
+  summary_df <- data.frame(
+    part = parts_levels,
+    centerlinje = rep(cl_value, length(parts_levels)),
+    runs_signal = rep(FALSE, length(parts_levels)),
+    crossings_signal = rep(FALSE, length(parts_levels)),
+    anhoej_signal = rep(FALSE, length(parts_levels))
+  )
+
+  result <- list(
     plot = ggplot2::ggplot(data.frame(x = 1:3, y = 1:3)) +
       ggplot2::geom_point(ggplot2::aes(x = x, y = y)) +
       ggplot2::labs(title = chart_title %||% "Mock SPC Chart"),
-    data = data.frame(
-      x = seq_len(nrow(data)),
-      y = rep(mean(as.numeric(data[[y]]), na.rm = TRUE), nrow(data)),
-      cl = rep(mean(as.numeric(data[[y]]), na.rm = TRUE), nrow(data)),
-      lcl = rep(NA_real_, nrow(data)),
-      ucl = rep(NA_real_, nrow(data)),
-      signal = rep(FALSE, nrow(data))
-    ),
-    chart_type = chart_type
+    qic_data = qic_data,
+    summary = summary_df,
+    config = list(
+      y_axis_unit = y_axis_unit,
+      chart_type = chart_type,
+      chart_title = chart_title
+    )
   )
+  class(result) <- "bfh_qic_result"
+  result
 }
 
 if (requireNamespace("BFHcharts", quietly = TRUE)) {

--- a/tests/testthat/test-helper-mocks-contracts.R
+++ b/tests/testthat/test-helper-mocks-contracts.R
@@ -39,6 +39,84 @@ test_that("mock_bfh_qic matches BFHcharts::bfh_qic signature", {
   expect_setequal(mock_args, real_args)
 })
 
+# Body-kontrakt for #490: mock_bfh_qic skal returnere shape kompatibel med
+# BFHcharts 0.15.0 + transform_bfh_output. Fanger drift hvis nogen ved en fejl
+# bytter $qic_data tilbage til $data eller dropper Anhoej-kolonner.
+
+test_that("mock_bfh_qic returnerer bfh_qic_result-struktur (#490)", {
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "day", length.out = 10),
+    value = 1:10
+  )
+  result <- mock_bfh_qic(data = data, x = "date", y = "value", chart_type = "i")
+
+  expect_s3_class(result, "bfh_qic_result")
+  expect_true("qic_data" %in% names(result))
+  expect_false("data" %in% names(result),
+    info = "Mock skal eksponere $qic_data, ej $data — transform_bfh_output laeser $qic_data"
+  )
+  expect_true("summary" %in% names(result))
+  expect_true("config" %in% names(result))
+})
+
+test_that("mock_bfh_qic$qic_data inkluderer Anhoej-rule-kolonner (#490)", {
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "day", length.out = 5),
+    value = 1:5
+  )
+  result <- mock_bfh_qic(data = data, x = "date", y = "value")
+
+  required_cols <- c(
+    "x", "y", "cl", "anhoej.signal", "runs.signal",
+    "sigma.signal", "n.crossings", "n.crossings.min",
+    "longest.run", "longest.run.max", "part"
+  )
+  expect_true(all(required_cols %in% names(result$qic_data)),
+    info = "qic_data skal eksponere alle Anhoej/sigma-kolonner per BFHcharts 0.15.0-kontrakt"
+  )
+})
+
+test_that("mock_bfh_qic$summary har decomposed signal-kolonner (#490)", {
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "day", length.out = 5),
+    value = 1:5
+  )
+  result <- mock_bfh_qic(data = data, x = "date", y = "value")
+
+  required_summary_cols <- c(
+    "part", "centerlinje", "runs_signal",
+    "crossings_signal", "anhoej_signal"
+  )
+  expect_true(all(required_summary_cols %in% names(result$summary)),
+    info = "summary skal eksponere decomposed signal-kolonner (ej legacy loebelaengde_signal)"
+  )
+  expect_false("loebelaengde_signal" %in% names(result$summary),
+    info = "Legacy summary-kolonne fjernet i BFHcharts 0.15.0"
+  )
+})
+
+test_that("mock_bfh_qic kan rutes gennem transform_bfh_output uden fejl (#490)", {
+  skip_if(
+    !exists("transform_bfh_output", mode = "function"),
+    "transform_bfh_output ikke tilgængelig"
+  )
+  data <- data.frame(
+    date = seq.Date(as.Date("2024-01-01"), by = "day", length.out = 8),
+    value = c(10, 12, 11, 14, 13, 15, 11, 12)
+  )
+  bfh_result <- mock_bfh_qic(data = data, x = "date", y = "value", chart_type = "i")
+
+  out <- transform_bfh_output(bfh_result,
+    chart_type = "i",
+    multiply = 1,
+    freeze_applied = FALSE
+  )
+
+  expect_true(is.list(out))
+  expect_true("qic_data" %in% names(out))
+  expect_equal(nrow(out$qic_data), 8L)
+})
+
 # ------------------------------------------------------------------------------
 # pins mock contracts
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

\`tests/testthat/helper-mocks.R::mock_bfh_qic()\` returnerede:
\`\`\`r
list(plot, data, chart_type)
\`\`\`

\`R/fct_spc_bfh_output.R::transform_bfh_output()\` læser \`bfh_result\$qic_data\` (ej \`\$data\`) og forventer Anhoej-rule-kolonner. Mocken var derfor irrelevant for end-to-end-test af pipeline-pathen — regressioner fra BFHcharts 0.15.0 ville ikke blive fanget.

## Fix

Refactor mock-body til at matche BFHcharts 0.15.0-kontrakt:

- Returnér \`bfh_qic_result\` S3-objekt med korrekt navngivet \`\$qic_data\`
- Anhoej-rule-kolonner: \`anhoej.signal\`, \`runs.signal\`, \`sigma.signal\`, \`n.crossings\`, \`n.crossings.min\`, \`longest.run\`, \`longest.run.max\`
- \`\$summary\` med decomposed signal-kolonner: \`centerlinje\`, \`runs_signal\`, \`crossings_signal\`, \`anhoej_signal\` (legacy \`loebelaengde_signal\` fjernet)
- \`\$config\` med \`y_axis_unit\`/\`chart_type\`/\`chart_title\`
- Bevar \`formals()\`-kontrakt med \`BFHcharts::bfh_qic\`
- \`qic_data\$signal\` aliaserer \`anhoej.signal\` for downstream-kompatibilitet

## Tests

4 nye contract-tests:
- S3-class \`bfh_qic_result\`, korrekt \`\$qic_data\` (ej \`\$data\`)
- Alle Anhoej/sigma-kolonner i \`qic_data\`
- Decomposed summary uden legacy \`loebelaengde_signal\`
- End-to-end \`transform_bfh_output\` succesfuld pipeline-routing

293 mock/bfh-related tests passerer (0 FAIL).

## Note

Eksisterende tests bruger \`make_mock_bfh_qic_result\` (separat helper i \`test-utils-export-analysis-metadata.R\`) som allerede har korrekt shape — derfor ingen blast radius på eksisterende tests fra denne refactor.

Fixes #490