### PR TITLE
docs(openspec): proposal for add-pdf-footnote-input (fixes #485)

### DIFF
--- a/openspec/changes/add-pdf-footnote-input/proposal.md
+++ b/openspec/changes/add-pdf-footnote-input/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+Klinisk personale tilføjer typisk dataattribution (fx "Datakilde: KvalDB udtræk 2026-04-29") som footnote til SPC-grafer for at sikre sporbarhed i kvalitetsrapporter. Den nuværende implementation (`mod_export_download.R:229-231`, `mod_export_server.R:194-196`) tilføjer `input$export_footnote` som `ggplot2::labs(caption = ...)` på PNG-plottet og preview, men:
+
+1. **PDF-eksport-pathen passer ej footnote til BFHcharts' Typst-template** — `metadata`-list (linje 153-160) inkluderer `hospital`, `department`, `title`, `analysis`, `data_definition`, `date`, men intet footnote-felt.
+2. **Typst-template har ingen footnote-parameter** (verificeret ved gennemgang af `inst/templates/typst/`-skabelonkontrakt).
+
+Konsekvens: Bruger skriver footnote → ser den i preview + PNG-download → **download PDF uden footnote**. Klinisk attribution forsvinder silently. Bug-#485 (production-readiness review).
+
+Ønsket adfærd: Footnote skal være et **separat tekst-element i Typst-template** (ikke en del af plot-billedet), så det vises konsistent på tværs af preview, PNG og PDF.
+
+## What Changes
+
+**UI-laget (`R/mod_export_ui.R`):**
+- Tilføj `textAreaInput("export_footnote", "Footnote / Datakilde", placeholder = "...")` til trin 3 (Eksport)
+- Maks-længde: `EXPORT_FOOTNOTE_MAX_LENGTH` (ny konstant, fx 500 tegn)
+
+**Server-laget (`R/mod_export_server.R`, `R/mod_export_download.R`):**
+- **Fjern** `ggplot2::labs(caption = ...)` fra PNG-pathen — footnote skal ikke længere brændes ind i plot-pixels
+- **Tilføj** `footnote = escape_typst_metadata(input$export_footnote)` til `metadata`-list i `generate_pdf_export()`
+- **Tilføj** `validate_export_inputs(footnote = input$export_footnote)` (ny validator-arg)
+- Preview-pathen (`mod_export_server.R:194-196`) skal generere preview baseret på samme metadata-sti
+
+**Validator (`R/utils_export_validation.R`):**
+- Tilføj `footnote`-parameter til `validate_export_inputs()` med længde-cap
+- Udvid `escape_typst_metadata`-anvendelse til footnote (allerede dækket af #486)
+
+**Konfiguration (`R/config_export_config.R`):**
+- Ny konstant: `EXPORT_FOOTNOTE_MAX_LENGTH <- 500L`
+
+**Typst-template (BFHcharts repo — cross-repo dependency):**
+- Template-update: tilføj optional `footnote`-parameter med render-block under chart
+- BFHcharts feature-request påkrævet (cross-repo bump-protokol §E)
+
+**Tests:**
+- `tests/testthat/test-export-footnote.R` — ny fil
+  - Footnote → metadata-pipe (unit-test af `build_export_metadata`)
+  - Validator-cap håndhævet (input length > MAX → fejl)
+  - Footnote escapes via `escape_typst_metadata`
+  - Preview-PDF round-trip viser footnote (integration, kan kræve mock af BFHcharts Typst-render)
+
+**LLM-context (#489-relateret):**
+- Tilføj `footnote` til `truncate_llm_context_fields`-freetext-liste
+
+## Impact
+
+- **Affected specs**: `export-preview` (MODIFIED — udvider eksisterende krav om Typst-metadata med footnote-parameter)
+- **Affected code**:
+  - Modificeret: `R/mod_export_ui.R` (UI-input)
+  - Modificeret: `R/mod_export_server.R` (preview-flow)
+  - Modificeret: `R/mod_export_download.R` (PDF + PNG-flow)
+  - Modificeret: `R/utils_export_validation.R` (validator-arg)
+  - Modificeret: `R/utils_export_analysis_metadata.R` (metadata-build)
+  - Modificeret: `R/config_export_config.R` (max-konstant)
+  - Modificeret: `R/fct_ai_improvement_suggestions.R` (LLM-context-cap udvides)
+  - Ny: `tests/testthat/test-export-footnote.R`
+  - Modificeret: `inst/templates/typst/bfh-template/*` (template-update — eller koordineret BFHcharts-PR)
+- **Cross-repo**: BFHcharts skal eksponere footnote-parameter i Typst-template eller leverer biSPCharts en lokal template-override.
+- **Breaking changes**: Ingen — input-felt er nyt; eksisterende eksport uden footnote fortsætter uændret.
+
+## Related
+
+- GitHub Issue #485 (production-readiness review fund 1.6)
+- Production-readiness review 2026-05-04 (PR-batch #481-#492)
+- `R/utils_export_validation.R:330` (escape_typst_metadata, udvidet i #486)
+- BFHcharts repo (cross-repo Typst-template-update)
+- ADR-015 (BFHchart-migrering, etablerer template-kontrakt)

--- a/openspec/changes/add-pdf-footnote-input/specs/export-preview/spec.md
+++ b/openspec/changes/add-pdf-footnote-input/specs/export-preview/spec.md
@@ -1,0 +1,53 @@
+# export-preview Specification — Delta (add-pdf-footnote-input)
+
+## ADDED Requirements
+
+### Requirement: Eksport SHALL understøtte footnote som separat tekst-element i Typst-template
+
+PDF-eksport SHALL acceptere et valgfrit `footnote`-felt i metadata-pipeline, der renderes som adskilt tekst-blok under SPC-chart i Typst-template — IKKE som ggplot-caption brændt ind i plot-pixels. Footnote SHALL bruges til klinisk dataattribution (fx "Datakilde: KvalDB udtræk YYYY-MM-DD") og være konsistent på tværs af preview, PNG og PDF-output.
+
+#### Scenario: Bruger indtaster footnote til PDF-eksport
+
+- **GIVEN** bruger har genereret SPC-chart og navigeret til trin 3 (Eksport)
+- **WHEN** bruger indtaster "Datakilde: KvalDB udtræk 2026-04-29" i footnote-feltet
+- **AND** klikker download-PDF
+- **THEN** PDF skal indeholde footnote-tekst som adskilt element under chart-billedet
+- **AND** preview-billedet skal vise footnote i samme position som downloadet PDF
+- **AND** chart-pixels skal være uændret (footnote ej brændt ind i plot)
+
+#### Scenario: Bruger eksporterer uden footnote
+
+- **GIVEN** footnote-feltet er tomt eller indeholder kun whitespace
+- **WHEN** bruger downloader PDF
+- **THEN** PDF skal renderes uden footnote-element (ingen tom blok eller layout-shift)
+- **AND** preview skal være visuelt identisk med downloadet PDF
+
+#### Scenario: Bruger forsøger at indtaste footnote længere end EXPORT_FOOTNOTE_MAX_LENGTH
+
+- **GIVEN** bruger indtaster 1000 tegn footnote (overstiger 500-tegn-cap)
+- **WHEN** validate_export_inputs() kaldes før eksport
+- **THEN** eksporten SHALL afbrydes med dansk fejlbesked om længde-grænse
+- **AND** ingen download-handler SHALL trigges
+- **AND** UI SHALL vise tegn-counter feedback før submit
+
+### Requirement: Footnote-input SHALL escapes via escape_typst_metadata
+
+Bruger-indtastet footnote SHALL processeres af `escape_typst_metadata()` før indsættelse i Typst-template, jf. defense-in-depth-mønster (#486). Markup-tegn (`*`, `_`, `[`, `]`, `<`, `>`, `@`, `#`, `$`, backtick, line-leading `=`/`-`/`+`/`/`) SHALL escapes så footnote rendres som plain-text.
+
+#### Scenario: Footnote indeholder markup-tegn
+
+- **GIVEN** bruger indtaster "Datakilde: *intern* rapport @afd"
+- **WHEN** metadata bygges til Typst-template
+- **THEN** footnote-værdi i metadata SHALL være `"Datakilde: \\*intern\\* rapport \\@afd"`
+- **AND** Typst-render SHALL vise plain-text uden bold/reference-fortolkning
+
+### Requirement: Footnote SHALL inkluderes i LLM-context-cap
+
+Når bruger trigger AI-improvement-suggestion-feature, SHALL footnote-feltet være underlagt samme længde-cap som andre free-text-felter (`truncate_llm_context_fields`, jf. #489). Beskytter mod cost-amplification ved store footnote-inputs.
+
+#### Scenario: Footnote sendes til BFHllm som del af context
+
+- **GIVEN** bruger har indtastet footnote og trigger AI-suggestion
+- **WHEN** `truncate_llm_context_fields()` processerer context
+- **THEN** footnote SHALL truncates til `EXPORT_DESCRIPTION_MAX_LENGTH` (2000 tegn) hvis nødvendigt
+- **AND** truncation SHALL logges på info-niveau

--- a/openspec/changes/add-pdf-footnote-input/tasks.md
+++ b/openspec/changes/add-pdf-footnote-input/tasks.md
@@ -1,0 +1,87 @@
+# Tasks — add-pdf-footnote-input
+
+## Foran-arbejde
+
+- [ ] Bekræft cross-repo-koordinering: er Typst-template ejet af BFHcharts (privat) eller biSPCharts? Hvis BFHcharts → opret feature-request først (cross-repo §E).
+- [ ] Bekræft footnote-design med klinisk personale: tekst-blok under chart vs. footer på siden? Maks-længde 500 tegn passende?
+
+## Konfiguration
+
+- [ ] Tilføj `EXPORT_FOOTNOTE_MAX_LENGTH <- 500L` til `R/config_export_config.R`
+- [ ] Dokumentér konstant i header-kommentar med kilde (`#485`-link)
+
+## Validator (utils_export_validation.R)
+
+- [ ] Tilføj `footnote = ""` parameter til `validate_export_inputs()`-signature
+- [ ] Tilføj længde-check: `nchar(footnote) > EXPORT_FOOTNOTE_MAX_LENGTH` → fejl
+- [ ] Tilføj test-cases til `tests/testthat/test-export-validation.R`
+
+## Metadata-pipeline (utils_export_analysis_metadata.R)
+
+- [ ] Tilføj `footnote`-felt til `build_export_analysis_metadata()`-output
+- [ ] Default `""` hvis ej supplied
+- [ ] Anvend `escape_typst_metadata()` på input
+
+## UI (mod_export_ui.R)
+
+- [ ] Tilføj `textAreaInput("export_footnote", ...)` til trin 3-panelet
+- [ ] Label: "Footnote / Datakilde (vises under chart)"
+- [ ] Placeholder: "Eksempel: Datakilde: KvalDB udtræk 2026-04-29"
+- [ ] Hjælp-tekst med karakter-counter (helpText eller bsTooltip)
+- [ ] Maks-længde-attr (HTML5 `maxlength`)
+
+## Server — PDF (mod_export_download.R::generate_pdf_export)
+
+- [ ] Tilføj `footnote = input$export_footnote` til `validate_export_inputs()`-kald
+- [ ] Tilføj `footnote = escape_typst_metadata(input$export_footnote)` til `metadata`-list
+- [ ] Verificér at `BFHcharts::bfh_export_pdf()` accepterer `metadata$footnote` (kræver BFHcharts-PR hvis ikke)
+
+## Server — PNG (mod_export_download.R::generate_png_export)
+
+- [ ] **Fjern** `ggplot2::labs(caption = footnote_text)`-tilføjelse til plot
+- [ ] Beslut: Skal PNG også vise footnote? Hvis ja: render som adskilt tekst-element via ggplot2 `theme()` eller ny `cowplot::plot_grid` — IKKE som plot-caption.
+- [ ] Hvis nej: dokumentér at footnote kun vises i PDF (UI-info-tekst)
+
+## Server — Preview (mod_export_server.R)
+
+- [ ] Opdater preview-flow til at bruge samme metadata-sti som download
+- [ ] Verificér at preview viser footnote konsistent med PDF-output (ej ggplot caption)
+
+## Typst-template (cross-repo / BFHcharts)
+
+- [ ] **[BFHcharts-PR]** Tilføj optional `footnote`-parameter til `bfh-diagram`-template
+- [ ] Render footnote som lille gråtone-tekst under chart-billedet (anbefalet placering: footer)
+- [ ] Bekræft at template virker med `footnote = none` (graceful tom-state)
+- [ ] Bump BFHcharts version efter merge → opdatér biSPCharts `DESCRIPTION` lower-bound
+
+## LLM-integration (#489-koordinering)
+
+- [ ] Tilføj `"footnote"` til `truncate_llm_context_fields`'s `freetext_fields`-liste i `R/fct_ai_improvement_suggestions.R`
+
+## Tests
+
+- [ ] Ny: `tests/testthat/test-export-footnote.R`
+  - [ ] `build_export_analysis_metadata` propagerer footnote til output
+  - [ ] `escape_typst_metadata` anvendes på footnote
+  - [ ] `validate_export_inputs(footnote = strrep("a", 1000))` kaster længde-fejl
+  - [ ] Default `""` ved manglende input
+- [ ] Udvid `tests/testthat/test-export-validation.R` med footnote-cases
+- [ ] **Manuel:** Test live PDF-eksport med footnote — verificér placering + readability
+
+## Dokumentation
+
+- [ ] Opdatér `docs/CONFIGURATION.md` med `EXPORT_FOOTNOTE_MAX_LENGTH`
+- [ ] Opdatér `NEWS.md` under "Nye features": "Footnote-felt i eksport (#485)"
+- [ ] Opdatér `R/mod_export_ui.R` roxygen-doc
+
+## Pre-merge gate
+
+- [ ] Pre-push gate (fast) passerer
+- [ ] Manifest-validator passerer
+- [ ] BFHcharts cross-repo dependency synced (DESCRIPTION lower-bound + manifest)
+- [ ] Manuel test: round-trip preview ↔ PDF viser footnote konsistent
+- [ ] Manuel test: tom footnote-felt → PDF uden footnote-element (ej tom blok)
+
+## Archive
+
+- [ ] Efter merge til master + Connect-deploy verifikation: kør `/opsx:archive add-pdf-footnote-input`


### PR DESCRIPTION
## OpenSpec proposal — add-pdf-footnote-input

Klinisk personale har behov for footnote (datakildeattribution) på PDF-eksport. Nuværende implementation tilføjer footnote som ggplot caption på PNG/preview, men dropper den i PDF-eksport-pathen → silent attribution-loss.

**Beslutning fra production-readiness review (#485):** Footnote skal være separat tekst-element i Typst-template, IKKE caption brændt ind i plot-pixels.

## Indhold

- **\`proposal.md\`** — Why/What/Impact + cross-repo BFHcharts-koordinering
- **\`tasks.md\`** — 8-fase implementation-plan (config, validator, metadata-pipe, UI, server PDF/PNG/preview, Typst-template, tests, docs)
- **\`specs/export-preview/spec.md\`** — 3 ADDED requirements:
  1. Footnote som separat tekst-element (ej ggplot caption)
  2. Footnote escapes via \`escape_typst_metadata\` (defense-in-depth)
  3. Footnote inkluderet i LLM-context-cap (#489-koordinering)

## Cross-repo dependency

Typst-template (BFHcharts repo) skal opdateres for at acceptere \`footnote\`-parameter. Cross-repo §E feature-request påkrævet før implementation.

## Workflow

1. Review proposal + diskutér design (footnote-placering, max-længde, PNG-adfærd)
2. Hvis godkendt: cross-repo-koordinering med BFHcharts
3. Implementation via \`/opsx:apply add-pdf-footnote-input\`
4. Archive efter Connect-deploy verifikation: \`/opsx:archive add-pdf-footnote-input\`

## Test plan

OpenSpec-proposal — ingen kode-ændringer i denne PR. Implementation følger separat efter proposal-godkendelse.

Fixes #485