### PR TITLE
fix(export): inject logo_path før typst-write i PDF-preview

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,19 @@
 
 ## Bug fixes
 
+* **PDF-preview: hospital-logo manglede i preview (men ikke i download).**
+  `generate_pdf_preview()` (`R/utils_server_export.R`) kaldte
+  `BFHcharts::bfh_create_typst_document()` FØR `inject_template_assets()`.
+  Konsekvens: `.typ`-filen skrev `logo_path: none` (default i template) før
+  `Hospital_Maerke_RGB_A1_str.png` blev kopieret ind, og Typst-render
+  skipede foreground-blokken. PDF-download (`generate_pdf_export()`) var ej
+  ramt — den bruger `bfh_export_pdf()`-pipelinen der orkestrerer
+  inject-then-write korrekt internt. Fix: sæt
+  `metadata$logo_path = "images/Hospital_Maerke_RGB_A1_str.png"` eksplicit
+  før `bfh_create_typst_document()`-kaldet (matcher
+  `.detect_packaged_logo()`-konventionen i BFHcharts). Logo-filen kopieres
+  ind via `inject_template_assets()` umiddelbart efter, før Typst kompilerer.
+
 * **Klinisk kritisk:** `resolve_analysis_centerline()` bruger nu rå
   `qic_data$cl` (uafrundet qicharts2-værdi) primært i stedet for
   BFHcharts' afrundede `summary$centerlinje`. Tidligere kunne

--- a/R/utils_server_export.R
+++ b/R/utils_server_export.R
@@ -311,6 +311,19 @@ generate_pdf_preview <- function(bfh_qic_result,
           # 3. Merge metadata with chart title
           metadata_full <- BFHcharts::bfh_merge_metadata(metadata, chart_title)
 
+          # 3b. Sæt logo_path manuelt (preview-fix #485-followup).
+          #     bfh_create_typst_document() accepterer ikke inject_assets-callback
+          #     (kun bfh_export_pdf gør). Uden manuel logo_path skriver template
+          #     .typ-fil med default `logo_path: none` -> intet logo i preview
+          #     selv om inject_template_assets() bagefter kopierer logo-filen.
+          #     Stien er relativ til typst-document-mappen og matcher
+          #     .detect_packaged_logo() i BFHcharts/R/utils_export_helpers.R
+          #     (autodetekt-mønster brugt af bfh_export_pdf-pipelinen).
+          if (is.null(metadata_full$logo_path) &&
+            requireNamespace("BFHchartsAssets", quietly = TRUE)) {
+            metadata_full$logo_path <- "images/Hospital_Maerke_RGB_A1_str.png"
+          }
+
           # 4. Create Typst document via BFHcharts public API (>= 0.14.0).
           typst_file <- file.path(temp_dir, "document.typ")
           BFHcharts::bfh_create_typst_document(


### PR DESCRIPTION
## Summary

PDF-preview viste manglende hospital-logo (men PDF-download virkede). Fix: sæt `metadata\$logo_path` eksplicit før `bfh_create_typst_document()`-kaldet.

## Why

`generate_pdf_preview()` (`R/utils_server_export.R:316-322`) kaldte `BFHcharts::bfh_create_typst_document()` FØR `inject_template_assets()` (line 330). Konsekvens: `.typ`-filen skrev `logo_path: none` (template-default) FØR `Hospital_Maerke_RGB_A1_str.png` blev kopieret ind, og Typst skipede foreground-blokken.

PDF-download (`generate_pdf_export()` → `BFHcharts::bfh_export_pdf()`) var ej ramt — `bfh_export_pdf` orkestrerer inject-then-write korrekt internt via `compose_typst_document()`. BFHcharts advarer eksplicit om denne regression-fælde for callers der arbejder med `bfh_create_typst_document` direkte:

> Order matters: template-staging og inject_assets SKAL koere FOER bfh_create_typst_document(), saa logo_path-auto-detect kan se de injicerede filer og populere metadata\$logo_path inden Typst-content genereres. Hvis .typ skrives foer inject, ser den hard-coded `logo_path: none` selv naar companion-pakker har droppet et logo (regression mod design-malet).

— `BFHcharts/R/utils_export_helpers.R:401-405`

## Verifikation

**Før fix:**
```
.typ indhold: ingen logo_path-linje (template-default = none)
PDF-preview: intet logo
PDF-download: logo til stede (992×992 image embedded — bekræftet via pdfimages -list)
```

**Efter fix:**
```
.typ indhold: 'logo_path: "images/Hospital_Maerke_RGB_A1_str.png"'
staged logo eksisterer ved Typst-compile-tid
PDF-preview: logo synligt (samme path som download)
```

## Changes

- `R/utils_server_export.R:312` — set `metadata_full\$logo_path` til `"images/Hospital_Maerke_RGB_A1_str.png"` (relative path, matcher `.detect_packaged_logo()`-konventionen i `BFHcharts/R/utils_typst.R:246`) før `bfh_create_typst_document()`-kaldet
- Guard: kun aktiv hvis `BFHchartsAssets` er tilgængelig
- Hvis caller eksplicit har sat `logo_path` allerede, respekteres det (`is.null(metadata_full\$logo_path)`-check)

## Test plan

- [ ] Manuel: kør `source('dev/run_dev.R')` → PDF-preview-pane viser hospital-logo
- [ ] Manuel: PDF-download viser fortsat logo (ingen regression)
- [ ] Manuel: BFHchartsAssets ej installeret → graceful skip (preview kompilerer uden logo, ingen error)

## Branch tree

- `develop` ← `fix/pdf-preview-logo-injection` (denne PR)
- Orthogonal til #512 (UI tweaks) og #514 (`_brand.yml` cleanup)

## Related

- #485 (production-readiness review fund 1.6)
- BFHcharts `add-conditional-template-image` OpenSpec (introducerede `logo_path`-parameter)
- `BFHcharts/R/utils_export_helpers.R:401-405` (advarsel mod denne regression-fælde)