### PR TITLE
ui(export): forenkl footnote-felt + omarrangér metadata-rækkefølge

### DIFF
--- a/R/mod_export_ui.R
+++ b/R/mod_export_ui.R
@@ -135,23 +135,6 @@ mod_export_ui <- function(id) {
           ),
 
           # Metadata fields (alle formater) ----
-          shiny::div(
-            style = "margin-bottom: 15px;",
-            shiny::textAreaInput(
-              ns("export_title"),
-              "Titel:",
-              value = "",
-              # placeholder = "Skriv en kort og sigende titel,\n**eller konkluder, hvad grafen viser**",
-              placeholder = "Skriv en kort titel, eller tilf\u00f8j en konklusion,\n**der tydeligt opsummerer, hvad grafen fort\u00e6ller**",
-              width = "100%",
-              rows = 2,
-              resize = "vertical"
-            ),
-            shiny::tags$small(
-              class = "text-muted",
-              sprintf("Maksimalt %d karakterer", EXPORT_TITLE_MAX_LENGTH)
-            )
-          ),
           shiny::conditionalPanel(
             condition = sprintf("input['%s'] != 'png'", ns("export_format")),
             shiny::div(
@@ -175,33 +158,20 @@ mod_export_ui <- function(id) {
               width = "100%"
             )
           ),
-          ## Fodnote / Datakilde: rendres som footer-tekst paa baade PDF og PNG (#485)
           shiny::div(
             style = "margin-bottom: 15px;",
-            shiny::tagList(
-              shiny::textAreaInput(
-                ns("export_footnote"),
-                shiny::tagList(
-                  "Fodnote / Datakilde (vises under chart):",
-                  shiny::icon("circle-info", style = "font-size: 0.8em; opacity: 0.6; margin-left: 4px;") |>
-                    bslib::tooltip(sprintf(
-                      "Klinisk attribution vist nederst paa eksporten. Maks %d tegn. Renderes som UPPERCASE-tekst i PDF (BFHcharts footer_content).",
-                      EXPORT_FOOTNOTE_MAX_LENGTH
-                    ))
-                ),
-                value = "",
-                placeholder = "Eksempel: Datakilde: KvalDB udtræk 2026-04-29",
-                width = "100%",
-                rows = 2,
-                resize = "vertical"
-              ),
-              # HTML5 maxlength (klient-side hard cap; server validerer ogsaa)
-              shiny::tags$script(sprintf(
-                "$('#%s').attr('maxlength', %d);",
-                ns("export_footnote"),
-                EXPORT_FOOTNOTE_MAX_LENGTH
-              )),
-              shiny::helpText(sprintf("Maks. %d tegn.", EXPORT_FOOTNOTE_MAX_LENGTH))
+            shiny::textAreaInput(
+              ns("export_title"),
+              "Indikatortitel:",
+              value = "",
+              placeholder = "Skriv en kort titel, eller tilføj en konklusion,\n**der tydeligt opsummerer, hvad grafen fortæller**",
+              width = "100%",
+              rows = 2,
+              resize = "vertical"
+            ),
+            shiny::tags$small(
+              class = "text-muted",
+              sprintf("Maksimalt %d karakterer", EXPORT_TITLE_MAX_LENGTH)
             )
           ),
 
@@ -336,6 +306,24 @@ mod_export_ui <- function(id) {
                 )
               )
             ),
+          ),
+
+          ## Datakilde / fodnote: nederste felt; sendes til BFHcharts footer_content (#485)
+          shiny::div(
+            style = "margin-bottom: 15px;",
+            shiny::textInput(
+              ns("export_footnote"),
+              "Datakilde ell. fodnote:",
+              value = "",
+              placeholder = "Eksempel: Datakilde: KvalDB udtræk 2026-04-29",
+              width = "100%"
+            ),
+            # HTML5 maxlength (klient-side hard cap; server validerer ogsaa)
+            shiny::tags$script(sprintf(
+              "$('#%s').attr('maxlength', %d);",
+              ns("export_footnote"),
+              EXPORT_FOOTNOTE_MAX_LENGTH
+            ))
           ),
         )
       ),


### PR DESCRIPTION
- Footnote: textInput single-line (ikke textAreaInput); fjern tooltip + helpText; label "Datakilde ell. fodnote"; placeret som nederste felt efter analyse-tekst
- Indikatortitel: omdøbt fra "Titel"; flyttet under "Afdeling eller afsnit"
- Behold maxlength-script (silent client-side cap; server-validator uændret)

Bevarer wiring: input$export_footnote -> metadata$footer_content. Tests urørt (UI-only ændring).

<!-- Behold relevante sektioner; slet dem der ikke passer. -->

## Beskrivelse

<!-- Kort beskrivelse af hvad denne PR ændrer og hvorfor. -->

## Type

- [ ] Bug fix
- [ ] Ny feature
- [ ] Refactor (ingen adfærdsændring)
- [ ] Docs/test/chore
- [ ] Breaking change (kræver MAJOR bump + NEWS.md-entry)

## Relaterede issues

<!-- fx: Closes #123, Relateret til #456 -->

## Test plan

- [ ] Unit tests bestået (`devtools::test()` eller `testthat::test_file(...)`)
- [ ] Manual functionality test gennemført
- [ ] Ingen regressioner i relaterede tests
- [ ] NEWS.md opdateret (hvis bruger-synlig ændring)

## Security review — kræves for ændringer i supply-chain-følsomme filer

Hvis denne PR ændrer **en eller flere** af følgende filer, skal reviewer
eksplicit verificere security-impact inden approval:

- [ ] `.Rprofile` (auto-executing ved R session-start)
- [ ] `.Renviron` eller anden secrets-håndtering
- [ ] `dev/git-hooks/*` (kører automatisk ved git-operationer)
- [ ] `dev/install_git_hooks.R` (symlink-creation)
- [ ] `.github/workflows/*` (CI/CD-pipelines med repo-adgang)
- [ ] `tests/e2e/setup.R` eller andre test-bootstrap-filer
- [ ] `DESCRIPTION` (nye dependencies eller `Remotes:`-entries)
- [ ] `renv.lock` (bundlede afhængigheder)

**Review-checklist ved supply-chain-filer:**
1. Ingen netværkskald (`curl`, `download.file`, `httr::GET` uden explicit purpose)
2. Ingen fil-skrivning uden for logs/temp
3. Ingen `system()`/`system2()`-kald uden sanitiseret input
4. Ingen code fra eksterne kilder uden pinned hash/version
5. Ændringer matcher PR-beskrivelsen (ingen "incidental" additions)

Se `.Rprofile`-header for baggrund (#247 M5).

## Danish-language checklist

- [ ] UI-tekst og fejlbeskeder på dansk
- [ ] NEWS.md-entry på dansk
- [ ] Commit-message format: `type(scope): beskrivelse`
- [ ] Ingen Claude attribution footers
