### PR TITLE
fix(ui): brug Mari-Book.otf/Mari-Bold.otf med korrekt internal family

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,18 @@
 
 ## Bug fixes
 
+* **Mari-font: forkert variant (fed) i UI lokalt.** CSS `@font-face`
+  declarerer `font-family: 'Mari'` men pegede på `MariOffice-Book.ttf` +
+  `MariOffice-Bold.ttf` der internt har family `"Mari Office"` (med
+  mellemrum). Family-name-mismatch kombineret med name-collision mod
+  user-installeret system-Mari førte til at browser valgte forkert
+  variant (typisk Bold/Regular i stedet for Book) ved render af body-
+  tekst. Fix: skift til `Mari-Book.otf` + `Mari-Bold.otf` (samme
+  BFHchartsAssets v0.1.0-companion-pakke), der har korrekt internal
+  family `"Mari"` + matchende weight-metadata (Book=4, Bold=7).
+  `register_mari_font()` opdateret til samme filer for konsistens
+  mellem browser-CSS og R/ggplot/Typst-rendering.
+
 * **PDF-preview: hospital-logo manglede i preview (men ikke i download).**
   `generate_pdf_preview()` (`R/utils_server_export.R`) kaldte
   `BFHcharts::bfh_create_typst_document()` FØR `inject_template_assets()`.

--- a/R/ui_app_ui.R
+++ b/R/ui_app_ui.R
@@ -20,17 +20,22 @@ create_ui_header <- function() {
   # Fallback: ingen @font-face injiceres -- browser bruger naesteoverladte
   # system-font fra CSS font-family-stack (Arial, Helvetica, sans-serif).
   mari_fontface_css <- if (requireNamespace("BFHchartsAssets", quietly = TRUE)) {
+    # Brug Mari-Book.otf / Mari-Bold.otf (internal family = "Mari", weight=4/7).
+    # Tidligere brugte vi MariOffice-Book.ttf / MariOffice-Bold.ttf der internt
+    # hedder "Mari Office" (med mellemrum) -- mismatch mod CSS-deklarationen
+    # `font-family: 'Mari'` resulterede i forkert weight-rendering i browser.
+    # Mari-*.otf filerne er authoritative-navngivne (BFHchartsAssets v0.1.0).
     "
       /* Mari hospital font via BFHchartsAssets companion-pakke (@font-face) */
       @font-face {
         font-family: 'Mari';
-        src: url('bfh_assets/MariOffice-Book.ttf') format('truetype');
+        src: url('bfh_assets/Mari-Book.otf') format('opentype');
         font-weight: normal;
         font-style: normal;
       }
       @font-face {
         font-family: 'Mari';
-        src: url('bfh_assets/MariOffice-Bold.ttf') format('truetype');
+        src: url('bfh_assets/Mari-Bold.otf') format('opentype');
         font-weight: bold;
         font-style: normal;
       }

--- a/R/utils_font_registration.R
+++ b/R/utils_font_registration.R
@@ -220,14 +220,17 @@ register_mari_font <- function() {
     return(invisible(NULL))
   }
 
-  # Book-varianten matcher Mac system-default for "Mari" (lettere end Regular)
-  font_plain <- file.path(font_dir, "MariOffice-Book.ttf")
-  font_bold <- file.path(font_dir, "MariOffice-Bold.ttf")
+  # Brug Mari-*.otf (internal family = "Mari", weight=4/7) i stedet for
+  # MariOffice-*.ttf (internal family = "Mari Office" -- mismatch mod
+  # font-family: 'Mari'-deklarationen forvirrer browser/typst).
+  # Book-varianten matcher Mac system-default for "Mari" (lettere end Regular).
+  font_plain <- file.path(font_dir, "Mari-Book.otf")
+  font_bold <- file.path(font_dir, "Mari-Bold.otf")
 
   if (!file.exists(font_plain)) {
     log_warn(
       component = "[FONT_REGISTRATION]",
-      message = "MariOffice-Book.ttf ikke fundet i BFHchartsAssets \u2014 Mari font-registrering sprunget over",
+      message = "Mari-Book.otf ikke fundet i BFHchartsAssets \u2014 Mari font-registrering sprunget over",
       details = list(expected_path = font_plain)
     )
     return(invisible(NULL))


### PR DESCRIPTION
## Summary

Fixer "fed Mari-font" i lokal Shiny-app. CSS `@font-face` deklarerede `font-family: 'Mari'` men src pegede på `MariOffice-*.ttf`-filer der internt har family **"Mari Office"** (med mellemrum) — mismatch mod CSS-deklarationen og browser-konflikt med user-installeret system-Mari (`~/Library/Fonts/Mari*.otf`) → forkert variant rendret som body-tekst.

## Why

`BFHchartsAssets v0.1.0` indeholder BEGGE varianter af samme font-design:

| File | Internal family | Weight | Style |
|------|----------------|--------|-------|
| Mari-Book.otf | **Mari** | 4 | Book |
| Mari-Bold.otf | **Mari** | 7 | Bold |
| MariOffice-Book.ttf | Mari Office | 3 | Book |
| MariOffice-Bold.ttf | Mari Office | 7 | Bold |

CSS `@font-face` deklarerede `font-family: 'Mari'` med src=MariOffice-Book.ttf. Når browser loader filen, ser den interne family-name "Mari Office" der ikke matcher CSS-deklarationen. Kombineret med name-collision mod user-installeret system-Mari → forkert variant valgt ved render.

## Changes

- `R/ui_app_ui.R:22-37` — `@font-face src` skiftet fra `MariOffice-*.ttf` til `Mari-*.otf` + format `opentype` (.otf-format)
- `R/utils_font_registration.R::register_mari_font()` — samme skift for Connect Cloud-deploy hvor system-Mari ikke eksisterer (regression-beskyttelse + konsistens mellem browser-CSS og R/ggplot/Typst-rendering)

## Verifikation

Browser DevTools efter merge + cache-clear:

- Network-tab: `Mari-Book.otf` 200 OK fra `bfh_assets/`
- Computed → body element → font-family: `Mari` (rendret som Book-variant, ikke Bold)
- Visuelt: Body-tekst lighter weight (Mari Book ≈ Regular weight 400)

## Test plan

- [ ] Manuel: `source('dev/run_dev.R')` → body-tekst rendres som Mari Book (light/regular weight)
- [ ] Manuel: Bold-tekst (`<strong>` / headings) rendres som Mari Bold
- [ ] Manuel: PDF-eksport fortsat OK (Typst bruger samme assets via inject_template_assets)

## Related

- #485 (production-readiness review fund)
- PR #514 (slet stale _brand.yml — Lato-fix, prereq)
- PR #515 (PDF-preview logo-injection)