### PR TITLE
fix(export): prune Typst staged-fonts til Mari Book+Bold (PDF font-fix)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,19 @@
 
 ## Bug fixes
 
+* **PDF-eksport: forkert Mari-variant (Heavy) i body-tekst.** Typst's
+  font-matcher valgte `Mari-Heavy.otf` til `set text(font: "Mari")`-render
+  i stedet for `Mari-Book.otf`. Root cause: BFHchartsAssets v0.1.0 leverer
+  6 Mari-OTF-varianter (Light/Book/Regular/Bold/Heavy/Poster) der alle
+  har internal weight-metadata = 4 undtagen Bold (=7). Ambiguous metadata
+  → Typst vælger første scan-match (typisk Heavy alfabetisk). Verificeret
+  via `pdffonts SPC-41.pdf` (lokal: MariHeavy) vs `pdffonts SPC-36.pdf`
+  (Connect Cloud: MariBook). Fix i `inject_template_assets()`
+  (`R/utils_server_export.R`): efter `BFHchartsAssets::inject_bfh_assets()`
+  prunes staged `bfh-template/fonts/` til kun Mari-Book.otf + Mari-Bold.otf
+  + Arial-fallbacks. BFHchartsAssets selv urørt; biSPCharts kontrollerer
+  hvad Typst ser per export.
+
 * **Mari-font: forkert variant (fed) i UI lokalt.** CSS `@font-face`
   declarerer `font-family: 'Mari'` men pegede på `MariOffice-Book.ttf` +
   `MariOffice-Bold.ttf` der internt har family `"Mari Office"` (med

--- a/R/utils_server_export.R
+++ b/R/utils_server_export.R
@@ -143,14 +143,53 @@ inject_template_assets <- function(template_dir) {
     return(invisible(FALSE))
   }
 
-  safe_operation(
+  ok <- safe_operation(
     operation_name = "Inject template assets via BFHchartsAssets",
     code = {
       BFHchartsAssets::inject_bfh_assets(template_dir)
-      invisible(TRUE)
+      TRUE
     },
     fallback = FALSE
   )
+
+  # Post-inject font-prune: BFHchartsAssets leverer alle Mari-varianter
+  # (Light/Book/Regular/Bold/Heavy/Poster) i baade .otf (family="Mari") og
+  # .ttf (family="Mari Office")-format. Mari-*.otf-filerne har misvisende
+  # weight-metadata (alle weight=4 undtagen Bold=7), saa Typst's font-matcher
+  # kan vaelge fx Mari-Heavy.otf til "Mari weight=normal" i stedet for
+  # Mari-Book.otf -- konsekvens: PDF-body rendres med Heavy-variant
+  # (verificeret i SPC-41 vs SPC-36 PDF font-comparison).
+  #
+  # Fix: efter inject behold KUN Mari-Book.otf (default body) + Mari-Bold.otf
+  # (bold) + Arial-fallbacks. Mari-Heavy/Light/Poster + MariOffice-*.ttf +
+  # Mari.otf (Regular) fjernes fra staged fonts-dir saa Typst entydigt
+  # vaelger Book-variant. BFHchartsAssets selv er uaendret (companion-pkg
+  # leverer fortsat alle varianter; biSPCharts beslutter hvad Typst ser).
+  if (isTRUE(ok)) {
+    fonts_dir <- file.path(template_dir, "fonts")
+    if (dir.exists(fonts_dir)) {
+      keep <- c(
+        "Mari-Book.otf", "Mari-Bold.otf",
+        # Arial-varianter beholdes som Typst-fallback for ASCII-only-tekst
+        "ARIAL.TTF", "ARIALBD.TTF", "ARIALI.TTF", "ARIALBI.TTF"
+      )
+      all_fonts <- list.files(fonts_dir)
+      to_remove <- setdiff(all_fonts, keep)
+      if (length(to_remove) > 0) {
+        file.remove(file.path(fonts_dir, to_remove))
+        log_debug(
+          component = "[EXPORT]",
+          message = "Post-inject font-prune (#485 follow-up)",
+          details = list(
+            removed_count = length(to_remove),
+            kept = paste(keep, collapse = ", ")
+          )
+        )
+      }
+    }
+  }
+
+  invisible(ok)
 }
 
 # GET HOSPITAL NAME ===========================================================


### PR DESCRIPTION
## Summary

PDF-eksport rendrede body-tekst med MariHeavy-variant i stedet for MariBook. Verificeret via `pdffonts` sammenligning af lokal SPC-41.pdf (MariHeavy) vs published SPC-36.pdf (MariBook).

## Root cause

BFHchartsAssets v0.1.0 leverer 6 Mari-OTF-varianter via inject_bfh_assets(). Alle (undtagen Bold) har identisk internal weight=4, kun style varierer. Typst's font-matcher får flere weight=4-matches og vælger første scan-match (typisk Heavy alfabetisk).

## Fix

R/utils_server_export.R::inject_template_assets() pruner staged bfh-template/fonts/ efter inject til kun: Mari-Book.otf + Mari-Bold.otf + Arial-fallbacks. BFHchartsAssets uændret.

## Verifikation

Efter fix: pdffonts viser MariBook + Mari-Bold (matcher published SPC-36).

## Test plan

- [ ] Manuel: PDF-eksport viser body-tekst som Book-variant (lighter weight)
- [ ] Manuel: paritet med published Connect Cloud-PDF

## Related

- #517 (browser-CSS Mari-fix, merged)
- BFHchartsAssets v0.1.0 metadata-ambiguitet