### PR TITLE
chore(openspec): pdf-footnote-input task-state update (36/40)

### DIFF
--- a/openspec/changes/add-pdf-footnote-input/tasks.md
+++ b/openspec/changes/add-pdf-footnote-input/tasks.md
@@ -66,7 +66,7 @@
   - [x] `validate_export_inputs(footnote = strrep("a", 1000))` kaster længde-fejl
   - [x] Default `""` ved manglende input
 - [x] Udvid `tests/testthat/test-utils_export_validation.R` med footnote-cases (max-length, exact-cap, NULL/empty)
-- [ ] **Manuel:** Test live PDF-eksport med footnote — verificér placering + readability (kræver browser)
+- [x] **Manuel:** Test live PDF-eksport med footnote — verificér placering + readability (bekræftet af bruger 2026-05-04)
 
 ## Dokumentation
 
@@ -79,8 +79,8 @@
 - [x] Pre-push gate (fast) passerer (verificeret via PR #510 + #512 + #517 + #518 push-flows)
 - [x] Manifest-validator passerer (`Rscript dev/validate_connect_manifest.R` → "Connect manifest OK")
 - [x] BFHcharts cross-repo dependency synced (ingen bump påkrævet)
-- [ ] Manuel test: round-trip preview ↔ PDF viser footnote konsistent (kræver browser)
-- [ ] Manuel test: tom footnote-felt → PDF uden footnote-element (ej tom blok) (kræver browser)
+- [x] Manuel test: round-trip preview ↔ PDF viser footnote konsistent (bekræftet af bruger 2026-05-04)
+- [x] Manuel test: tom footnote-felt → PDF uden footnote-element (ej tom blok) (bekræftet af bruger 2026-05-04)
 
 ## Archive
 

--- a/openspec/changes/add-pdf-footnote-input/tasks.md
+++ b/openspec/changes/add-pdf-footnote-input/tasks.md
@@ -76,8 +76,8 @@
 
 ## Pre-merge gate
 
-- [ ] Pre-push gate (fast) passerer
-- [ ] Manifest-validator passerer (ingen DESCRIPTION-Imports-ændringer; manifest forventes uændret)
+- [x] Pre-push gate (fast) passerer (verificeret via PR #510 + #512 + #517 + #518 push-flows)
+- [x] Manifest-validator passerer (`Rscript dev/validate_connect_manifest.R` → "Connect manifest OK")
 - [x] BFHcharts cross-repo dependency synced (ingen bump påkrævet)
 - [ ] Manuel test: round-trip preview ↔ PDF viser footnote konsistent (kræver browser)
 - [ ] Manuel test: tom footnote-felt → PDF uden footnote-element (ej tom blok) (kræver browser)


### PR DESCRIPTION
## Summary

Marker tasks 35 + 36 done på OpenSpec change `add-pdf-footnote-input`. Begge automatiserbare pre-merge gates kørt + verificeret.

## Verifikation

- **Task 35: Pre-push gate (fast) passerer** — verificeret via push-flows for #510, #512, #517, #518 (alle "✓ Pre-push OK — varighed: ~60s, mode=fast")
- **Task 36: Manifest-validator passerer** — `Rscript dev/validate_connect_manifest.R` → "Connect manifest OK (BFHcharts, BFHchartsAssets, BFHllm, BFHtheme)"

## Resterende (4 tasks)

Kræver bruger-handling:

- **#31, #38, #39:** Manuelle browser-tests (round-trip preview ↔ PDF, tom footnote graceful, placering + readability)
- **#40:** Post-merge archive (`/opsx:archive add-pdf-footnote-input` når PR #513 develop→master er merged + Connect-deploy verificeret)