### PR TITLE
fix(ui): \u-escape non-ASCII chars i mod_export_ui.R

### DIFF
--- a/R/mod_export_ui.R
+++ b/R/mod_export_ui.R
@@ -164,7 +164,7 @@ mod_export_ui <- function(id) {
               ns("export_title"),
               "Indikatortitel:",
               value = "",
-              placeholder = "Skriv en kort titel, eller tilføj en konklusion,\n**der tydeligt opsummerer, hvad grafen fortæller**",
+              placeholder = "Skriv en kort titel, eller tilf\u00f8j en konklusion,\n**der tydeligt opsummerer, hvad grafen fort\u00e6ller**",
               width = "100%",
               rows = 2,
               resize = "vertical"
@@ -315,7 +315,7 @@ mod_export_ui <- function(id) {
               ns("export_footnote"),
               "Datakilde ell. fodnote:",
               value = "",
-              placeholder = "Eksempel: Datakilde: KvalDB udtræk 2026-04-29",
+              placeholder = "Eksempel: Datakilde: KvalDB udtr\u00e6k 2026-04-29",
               width = "100%"
             ),
             # HTML5 maxlength (klient-side hard cap; server validerer ogsaa)


### PR DESCRIPTION
## Summary

R CMD check (`error-on: warning`) blokerede #513 med:

```
* checking code files for non-ASCII characters ... WARNING
Found the following file with non-ASCII characters:
  R/mod_export_ui.R
```

To placeholder-strings havde rå unicode-tegn (æ/ø) i R-kode. Per R portability-kontrakt skal R-kode kun bruge ASCII; kommentarer er undtaget.

## Changes

`R/mod_export_ui.R` (2 linjer):
- L167: `'tilføj en konklusion ... fortæller'` → `\u00f8`/`\u00e6`-escapes
- L318: `'udtræk'` → `\u00e6`-escape

UI-rendering uændret (R parser \u-escapes som same chars).

## Verifikation

```r
tools::showNonASCIIfile('R/mod_export_ui.R')
# (intet output)
```

## Related

- #520 (warning-cleanup, merged)
- #513 (develop→master, blokeret af denne sidste warning)