### PR TITLE
fix(ci): curl libcurl4 + biSPCharts source-pkg manifest

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,11 +48,15 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -94,11 +98,15 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -144,11 +152,15 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -97,9 +97,11 @@ jobs:
 
       # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
       # Workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
+      - name: Pre-install system deps (libcurl + chromium workaround)
         if: steps.check.outputs.deps_changed == 'true'
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies
         if: steps.check.outputs.deps_changed == 'true'

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,11 +32,15 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -33,11 +33,15 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -40,11 +40,15 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -62,10 +62,14 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -33,11 +33,15 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API der rammer
-      # add-apt-repository ppa:xtradeb/apps. Se #436 (Canonical DDoS recovery).
-      - name: Pre-install chromium (workaround xtradeb PPA flake)
-        run: sudo apt-get install -y chromium-browser || sudo snap install chromium || true
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
+      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
+      # forhindrer auto-install, saa vi gør det manuelt her.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (libcurl + chromium workaround)
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/dev/_regen_manifest.R
+++ b/dev/_regen_manifest.R
@@ -25,21 +25,18 @@ files <- files[file.exists(files)]
 cat("Total files i bundle:", length(files), "\n")
 
 # biSPCharts er app'en selv — skal IKKE indgå som dependency i manifest.
-# Unload + remove fra installed library for at undgå "installed from source"-fejl.
+# rsconnect::writeManifest() fejler hvis pakken er source-installeret.
+# Unload + fjern fra library inden writeManifest.
 if ("biSPCharts" %in% loadedNamespaces() &&
     requireNamespace("pkgload", quietly = TRUE)) {
   try(pkgload::unload("biSPCharts"), silent = TRUE)
 }
-# Forsøg at fjerne biSPCharts fra .libPaths, så rsconnect ikke ser den som dep
-try({
-  bisp_lib <- find.package("biSPCharts", quiet = TRUE)
-  if (length(bisp_lib) > 0) {
-    cat("Bemærk: biSPCharts er installeret i:", bisp_lib, "\n")
-    cat("Hvis manifest fejler med 'installed from source', kør:\n")
-    cat("  remove.packages('biSPCharts')\n")
-    cat("og forsøg igen.\n")
-  }
-}, silent = TRUE)
+bisp_path <- tryCatch(find.package("biSPCharts"), error = function(e) character(0))
+if (length(bisp_path) > 0) {
+  cat("Fjerner source-installeret biSPCharts fra library:", bisp_path, "\n")
+  remove.packages("biSPCharts", lib = dirname(bisp_path))
+  cat("biSPCharts fjernet\n")
+}
 
 rsconnect::writeManifest(appDir = ".", appFiles = files)
 cat("manifest.json regenereret OK\n")


### PR DESCRIPTION
## Problem

To uafhængige CI-fejl:

### 1. `curl` 7.1.0 source-kompilering (master + develop)
`curl` R-pakke 7.1.0 har ingen RSPM binary for Ubuntu 24.04 (Noble) og falder tilbage til source-kompilering. `PKG_SYSREQS=FALSE` forhindrer auto-install af system-deps, men `libcurl4-openssl-dev` kræves for compilation — ikke pre-installeret på GitHub runners.

**Berørte workflows:** `testthat`, `R-CMD-check` (alle 3 jobs), `coverage`, `export-smoke-test`, `shinytest2`, `sibling-bump-poller`, `auto-regen-manifest`.

### 2. `_regen_manifest.R` fjernede ikke biSPCharts (develop)
`dev/_regen_manifest.R` detekterede source-installeret biSPCharts men printede kun en advarsel og kaldte derefter `rsconnect::writeManifest()`, som fejlede med source-pakken stadig i library.

## Fix

**Commit A** — `fix(ci): pre-install libcurl4-openssl-dev for curl source build`
Tilføjer `sudo apt-get install -y libcurl4-openssl-dev` til pre-install-steget i alle 7 berørte workflows.

**Commit B** — `fix(ci): remove biSPCharts from library before writeManifest`
Fikser `_regen_manifest.R` til at kalde `pkgload::unload()` + `remove.packages()` inden `writeManifest()`.

## Test plan

- [ ] CI grøn på denne PR's branch (testthat + R-CMD-check)
- [ ] Efter merge til develop: manuelt trigger `workflow_dispatch` på `auto-regen-manifest` for at verificere script-fix
- [ ] Develop → master release-PR vil dermed også rette master-branch CI