### PR TITLE
fix(ci): install complete set of source-pkg dev headers

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -49,13 +49,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -99,13 +102,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -153,13 +159,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -95,12 +95,16 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install chromium saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi goer det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev. fs >= 2.1.0: libuv1-dev + cmake.
+      # openssl + websocket: libssl-dev. xml2: libxml2-dev.
+      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         if: steps.check.outputs.deps_changed == 'true'
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -33,13 +33,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -34,13 +34,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -41,13 +41,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -63,12 +63,14 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi goer det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev. fs >= 2.1.0: libuv1-dev + cmake.
+      # openssl + websocket: libssl-dev. xml2: libxml2-dev.
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -34,13 +34,16 @@ jobs:
           use-public-rspm: true
 
       # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # libcurl4-openssl-dev: curl R-pakke >= 7.1.0 har ingen RSPM binary for Noble —
-      # falder tilbage til source-kompilering der kræver dev headers. PKG_SYSREQS=FALSE
-      # forhindrer auto-install, saa vi gør det manuelt her.
+      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
+      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
+      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
+      # fs >= 2.1.0: libuv1-dev + cmake
+      # openssl + websocket: libssl-dev
+      # xml2: libxml2-dev
       # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
-      - name: Pre-install system deps (libcurl + chromium workaround)
+      - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
## Problem

PR #525 fixede kun `libcurl4-openssl-dev`. CI fejlede derefter på næste manglende sysreq: `fs` 2.1.0 kræver `libuv1-dev` (og `cmake`).

**Root cause:** Flere R-pakker mangler RSPM binary for Ubuntu 24.04 (Noble) og falder til source-kompilering. `PKG_SYSREQS=FALSE` forhindrer automatisk system-dep-install. Hver manglende dep giver ny CI-fejl.

**Pakker og deps (fra pak lockfile):**
| R-pakke | System deps |
|---------|-------------|
| `curl` 7.1.0 | `libcurl4-openssl-dev`, `libssl-dev` |
| `fs` 2.1.0 | `libuv1-dev`, `cmake` |
| `openssl` 2.4.0 | `libssl-dev` |
| `websocket` 1.4.4 | `libssl-dev` |
| `xml2` 1.5.2 | `libxml2-dev` |

## Fix

Pre-install komplet liste i alle 7 workflows:
```bash
sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
```

## Test plan

- [ ] CI grøn på denne PR (testthat + R-CMD-check)
- [ ] Efter merge → develop: PR #524 (develop→master) kan re-trigges