### PR TITLE
fix(ci): pre-install komplet sysreq-liste fra pak lockfile

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -48,17 +48,18 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -101,17 +102,18 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
@@ -158,17 +160,18 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -95,16 +95,19 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi goer det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev. fs >= 2.1.0: libuv1-dev + cmake.
-      # openssl + websocket: libssl-dev. xml2: libxml2-dev.
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile: curl, fs, openssl, websocket, xml2, jpeg, gert,
+      # systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         if: steps.check.outputs.deps_changed == 'true'
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \\
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \\
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \\
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \\
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -32,17 +32,18 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -33,17 +33,18 @@ jobs:
           r-version: "release"
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -40,17 +40,18 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -62,15 +62,18 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi goer det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev. fs >= 2.1.0: libuv1-dev + cmake.
-      # openssl + websocket: libssl-dev. xml2: libxml2-dev.
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile: curl, fs, openssl, websocket, xml2, jpeg, gert,
+      # systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - name: Install R dependencies

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -33,17 +33,18 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      # Pre-install system deps saa pak's sysreqs-handler skipper xtradeb PPA-add.
-      # Pakker uden RSPM binary for Noble falder til source-kompilering og kræver dev headers.
-      # PKG_SYSREQS=FALSE forhindrer auto-install, saa vi gør det manuelt her.
-      # curl >= 7.1.0: libcurl4-openssl-dev + libssl-dev
-      # fs >= 2.1.0: libuv1-dev + cmake
-      # openssl + websocket: libssl-dev
-      # xml2: libxml2-dev
-      # chromium: workaround for HTTP 504 fra launchpad.net REST API. Se #436.
+      # Pre-install alle system dev-headers som pak-lockfilen kraeever for source-build.
+      # PKG_SYSREQS=FALSE forhindrer pak's auto-install (undgaar xtradeb PPA HTTP 504).
+      # Liste fra pak lockfile (source-pkgs): curl, fs, openssl, websocket, xml2,
+      # jpeg, gert, systemfonts, textshaping, ragg. Se #436 + #527.
+      # chromium: pre-install undgaar xtradeb PPA-add via launchpad.net REST API.
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         run: |
-          sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev libxml2-dev cmake
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
## Problem

Whack-a-mole discovery: efter #525 (libcurl) og #526 (libuv+libssl+libxml+cmake) fejlede CI stadig — nu på `jpeg` → `libjpeg-dev`. 10+ R-pakker mangler RSPM binary for Ubuntu 24.04 (Noble) og kræver source-kompilering. `PKG_SYSREQS=FALSE` forhindrer auto-install (xtradeb PPA HTTP 504 workaround, se #436).

## Fix

Komplet liste fra pak lockfile — installeret i ét step i alle 7 workflows:

```
libcurl4-openssl-dev  libssl-dev    libuv1-dev    libgit2-dev
zlib1g-dev            libicu-dev    libpng-dev    libjpeg-dev
libfontconfig1-dev    libfreetype6-dev libfribidi-dev libharfbuzz-dev
libxml2-dev           libx11-dev    cmake
```

**Berørte R-pakker:** curl, fs, openssl, websocket, xml2, jpeg, gert, systemfonts, textshaping, ragg.

## Test plan

- [ ] CI grøn på denne PR (PR-event, ikke push-event — det er præcis det der fejlede)
- [ ] Merge → develop → PR #524 (develop→master) kan re-trigges og bestå