### PR TITLE
[codex] Fix BFH params refactor and shinytest readiness

### DIFF
--- a/R/fct_spc_bfh_params.R
+++ b/R/fct_spc_bfh_params.R
@@ -8,6 +8,187 @@
 # - Freeze/part position-beregning
 # - Notes/comment-integrering
 
+ascii_column_name_for_bfh <- function(name) {
+  name <- gsub("\u00e6", "ae", name, ignore.case = TRUE)
+  name <- gsub("\u00f8", "oe", name, ignore.case = TRUE)
+  name <- gsub("\u00e5", "aa", name, ignore.case = TRUE)
+  name <- iconv(name, to = "ASCII//TRANSLIT")
+  if (is.na(name)) name <- ""
+  gsub("[^A-Za-z0-9_]", "_", name)
+}
+
+build_bfh_column_mapping <- function(data) {
+  sanitized_col_names <- vapply(names(data), ascii_column_name_for_bfh, character(1), USE.NAMES = FALSE)
+  if (anyDuplicated(sanitized_col_names)) {
+    duplicated_pairs <- names(data)[sanitized_col_names %in% sanitized_col_names[duplicated(sanitized_col_names)]]
+    spc_abort(
+      paste0(
+        "Kolonnenavne kolliderer efter sanitization: ",
+        paste(duplicated_pairs, collapse = ", "),
+        ". Omdoeb kolonnerne i kilde-data."
+      ),
+      class = "spc_input_error"
+    )
+  }
+
+  setNames(sanitized_col_names, names(data))
+}
+
+extract_freeze_position <- function(data, freeze_var) {
+  if (is.null(freeze_var) || !freeze_var %in% names(data)) {
+    return(NULL)
+  }
+
+  freeze_col <- data[[freeze_var]]
+  logical_vec <- suppressWarnings(as.logical(freeze_col))
+  numeric_vec <- suppressWarnings(as.numeric(freeze_col))
+  is_freeze <- (!is.na(logical_vec) & logical_vec) |
+    (!is.na(numeric_vec) & numeric_vec == 1)
+
+  freeze_positions <- which(is_freeze)
+  if (length(freeze_positions) == 0) NULL else freeze_positions[1]
+}
+
+extract_part_positions <- function(data, part_var) {
+  if (is.null(part_var) || !part_var %in% names(data)) {
+    return(NULL)
+  }
+
+  part_col <- data[[part_var]]
+  logical_vec <- suppressWarnings(as.logical(part_col))
+  numeric_vec <- suppressWarnings(as.numeric(part_col))
+  is_part_boundary <- (!is.na(logical_vec) & logical_vec) |
+    (!is.na(numeric_vec) & numeric_vec == 1)
+
+  part_positions <- which(is_part_boundary)
+  if (length(part_positions) == 0) NULL else part_positions
+}
+
+resolve_notes_column <- function(notes_column, col_mapping) {
+  if (is.null(notes_column)) {
+    return(NULL)
+  }
+
+  if (notes_column %in% names(col_mapping)) {
+    return(col_mapping[[notes_column]])
+  }
+
+  original_names <- names(col_mapping)
+  match_idx <- which(tolower(original_names) == tolower(notes_column))
+  if (length(match_idx) > 0) {
+    return(col_mapping[[original_names[match_idx[1]]]])
+  }
+
+  log_warn(
+    paste(
+      "Notes column not found in data:",
+      notes_column, "| Available columns:",
+      paste(head(original_names, 5), collapse = ", ")
+    ),
+    .context = "BFH_SERVICE"
+  )
+  NULL
+}
+
+extract_notes_vector <- function(data, notes_column) {
+  if (is.null(notes_column) || !notes_column %in% names(data)) {
+    return(NULL)
+  }
+
+  notes_char <- as.character(data[[notes_column]])
+  notes_char[is.na(notes_char)] <- ""
+  if (any(nzchar(notes_char))) notes_char else NULL
+}
+
+build_bfh_params_core <- function(
+  data,
+  col_mapping,
+  x_var,
+  y_var,
+  n_var,
+  freeze_var,
+  part_var,
+  notes_column,
+  target_value,
+  centerline_value,
+  chart_type,
+  extra_params
+) {
+  original_names <- names(data)
+  names(data) <- unname(col_mapping[names(data)])
+
+  x_var_sanitized <- col_mapping[x_var]
+  y_var_sanitized <- col_mapping[y_var]
+  n_var_sanitized <- if (!is.null(n_var)) col_mapping[n_var] else NULL
+
+  log_debug(
+    paste(
+      "Column name sanitization:",
+      if (x_var != x_var_sanitized) paste(x_var, "\u2192", x_var_sanitized) else "none",
+      if (y_var != y_var_sanitized) paste(y_var, "\u2192", y_var_sanitized) else "none"
+    ),
+    .context = "BFH_SERVICE"
+  )
+
+  params <- list(
+    data = data,
+    x = rlang::sym(x_var_sanitized),
+    y = rlang::sym(y_var_sanitized),
+    chart_type = chart_type,
+    .column_mapping = col_mapping,
+    .original_names = original_names
+  )
+  if (!is.null(n_var_sanitized)) {
+    params$n <- rlang::sym(n_var_sanitized)
+  }
+
+  freeze_var_sanitized <- if (!is.null(freeze_var)) col_mapping[freeze_var] else NULL
+  part_var_sanitized <- if (!is.null(part_var)) col_mapping[part_var] else NULL
+  freeze_position <- extract_freeze_position(data, freeze_var_sanitized)
+  part_positions <- extract_part_positions(data, part_var_sanitized)
+
+  if (!is.null(freeze_position)) {
+    params$freeze <- freeze_position
+    log_debug(paste("Freeze position set to:", freeze_position), .context = "BFH_SERVICE")
+  }
+  if (!is.null(part_positions)) {
+    params$part <- part_positions
+    log_debug(paste("Part boundaries:", paste(part_positions, collapse = ", ")), .context = "BFH_SERVICE")
+  }
+
+  if (!is.null(target_value)) {
+    params$target_value <- normalize_scale_for_bfh(target_value, chart_type, "target")
+  }
+  if (!is.null(centerline_value)) {
+    params$cl <- normalize_scale_for_bfh(centerline_value, chart_type, "centerline")
+  }
+
+  notes_column_sanitized <- resolve_notes_column(notes_column, col_mapping)
+  notes <- extract_notes_vector(data, notes_column_sanitized)
+  if (!is.null(notes)) {
+    params$notes <- notes
+  }
+
+  if (length(extra_params) > 0) {
+    if ("chart_title" %in% names(extra_params)) {
+      extra_params$chart_title <- resolve_bfh_chart_title(extra_params$chart_title)
+    }
+    params <- c(params, extra_params)
+  }
+
+  log_debug(
+    paste(
+      "BFHchart parameters mapped:",
+      "chart_type =", chart_type,
+      ", has_denominator =", !is.null(n_var),
+      ", has_freeze =", !is.null(params$freeze),
+      ", has_part =", !is.null(params$part)
+    ),
+    .context = "BFH_SERVICE"
+  )
+  params
+}
+
 #' Map biSPCharts Parameters to BFHchart API
 #'
 #' Transforms biSPCharts-style parameters to BFHchart API conventions. Handles
@@ -116,35 +297,8 @@ map_to_bfh_params <- function(
     data$.original_row_id <- seq_len(nrow(data))
   }
 
-  # M6 (#460): omd\u00f8bt fra sanitize_column_name til ascii_column_name_for_bfh
-  # for at undg\u00e5 shadow-collision med utils_input_sanitization.R-versionen
-  # der har MODSAT semantik (tillader \u00e6\u00f8\u00e5, kun til UI-display).
-  # NB: iconv("ASCII//TRANSLIT") alene mapper \u00e5\u2192a og \u00f8\u2192o, ikke \u00e5\u2192aa og
-  # \u00f8\u2192oe \u2014 s\u00e5 eksplicitte gsub-mappings bevares (dansk konvention).
-  ascii_column_name_for_bfh <- function(name) {
-    name <- gsub("\u00e6", "ae", name, ignore.case = TRUE)
-    name <- gsub("\u00f8", "oe", name, ignore.case = TRUE)
-    name <- gsub("\u00e5", "aa", name, ignore.case = TRUE)
-    name <- iconv(name, to = "ASCII//TRANSLIT")
-    if (is.na(name)) name <- ""
-    gsub("[^A-Za-z0-9_]", "_", name)
-  }
-
-  # Kollisionscheck: to distinkte kolonner maa ikke kollidere efter sanitization.
-  # Placeret FOER safe_operation saa spc_input_error propagerer til kalder (#422).
-  # Silent failure her giver forkert plot uden fejlbesked til brugeren.
-  sanitized_col_names <- vapply(names(data), ascii_column_name_for_bfh, character(1), USE.NAMES = FALSE)
-  if (anyDuplicated(sanitized_col_names)) {
-    duplicated_pairs <- names(data)[sanitized_col_names %in% sanitized_col_names[duplicated(sanitized_col_names)]]
-    spc_abort(
-      paste0(
-        "Kolonnenavne kolliderer efter sanitization: ",
-        paste(duplicated_pairs, collapse = ", "),
-        ". Omdoeb kolonnerne i kilde-data."
-      ),
-      class = "spc_input_error"
-    )
-  }
+  col_mapping <- build_bfh_column_mapping(data)
+  extra_params <- list(...)
 
   safe_operation(
     operation_name = "BFHchart parameter mapping",
@@ -155,183 +309,20 @@ map_to_bfh_params <- function(
       # rev-mapper output for at bevare brugerens originale navne i UI.
       # FOLLOW-UP: åbn issue i BFHcharts for native Danish-character-support
       # i column-name-validator, og fjern denne workaround når levereret.
-      # sanitized_col_names beregnet foer safe_operation (kollisionscheck) -- genbrug her.
-
-      # Create column name mapping (original -> sanitized)
-      col_mapping <- setNames(sanitized_col_names, names(data))
-
-      # Store original names for later reversal
-      original_names <- names(data)
-
-      # Rename data columns to sanitized names
-      # CRITICAL: Use unname() to get just the values, not named character vector
-      names(data) <- unname(col_mapping[names(data)])
-
-      # Map biSPCharts variable names to sanitized versions
-      x_var_sanitized <- col_mapping[x_var]
-      y_var_sanitized <- col_mapping[y_var]
-      n_var_sanitized <- if (!is.null(n_var)) col_mapping[n_var] else NULL
-
-      log_debug(
-        paste(
-          "Column name sanitization:",
-          if (x_var != x_var_sanitized) paste(x_var, "\u2192", x_var_sanitized) else "none",
-          if (y_var != y_var_sanitized) paste(y_var, "\u2192", y_var_sanitized) else "none"
-        ),
-        .context = "BFH_SERVICE"
-      )
-
-      # 2. Build base parameters (using NSE - bare column names with SANITIZED names)
-      params <- list(
+      build_bfh_params_core(
         data = data,
-        x = rlang::sym(x_var_sanitized),
-        y = rlang::sym(y_var_sanitized),
+        col_mapping = col_mapping,
+        x_var = x_var,
+        y_var = y_var,
+        n_var = n_var,
+        freeze_var = freeze_var,
+        part_var = part_var,
+        notes_column = notes_column,
+        target_value = target_value,
+        centerline_value = centerline_value,
         chart_type = chart_type,
-        .column_mapping = col_mapping, # Store mapping for potential reversal
-        .original_names = original_names
+        extra_params = extra_params
       )
-
-      # 3. Add denominator if provided
-      if (!is.null(n_var_sanitized)) {
-        params$n <- rlang::sym(n_var_sanitized)
-      }
-
-      # 4. Add freeze parameter if provided
-      # NOTE: freeze_var and part_var still reference ORIGINAL names, need to look up in sanitized data
-      freeze_var_sanitized <- if (!is.null(freeze_var)) col_mapping[freeze_var] else NULL
-      part_var_sanitized <- if (!is.null(part_var)) col_mapping[part_var] else NULL
-
-      if (!is.null(freeze_var_sanitized) && freeze_var_sanitized %in% names(data)) {
-        # Find first TRUE value in freeze column (using SANITIZED name)
-        freeze_col <- data[[freeze_var_sanitized]]
-        # Convert to logical vector, handling both TRUE/FALSE and 0/1 values
-        logical_vec <- suppressWarnings(as.logical(freeze_col))
-        numeric_vec <- suppressWarnings(as.numeric(freeze_col))
-        # Combine: TRUE if either logical TRUE or numeric 1
-        is_freeze <- (!is.na(logical_vec) & logical_vec == TRUE) |
-          (!is.na(numeric_vec) & numeric_vec == 1)
-        freeze_positions <- which(is_freeze)
-        if (length(freeze_positions) > 0) {
-          params$freeze <- freeze_positions[1]
-          log_debug(
-            paste("Freeze position set to:", freeze_positions[1]),
-            .context = "BFH_SERVICE"
-          )
-        }
-      }
-
-      # 5. Add part parameter if provided
-      if (!is.null(part_var_sanitized) && part_var_sanitized %in% names(data)) {
-        # BUG FIX: Each TRUE in Skift column marks a part boundary directly
-        # Previous implementation used diff() which found BOTH TRUE->FALSE and FALSE->TRUE changes,
-        # resulting in double boundaries (e.g., marking row 13 gave boundaries at 12 AND 13)
-        part_col <- data[[part_var_sanitized]]
-
-        # Convert to logical vector, handling both TRUE/FALSE and 0/1 values
-        logical_vec <- suppressWarnings(as.logical(part_col))
-        numeric_vec <- suppressWarnings(as.numeric(part_col))
-
-        # Combine: TRUE if either logical TRUE or numeric 1
-        is_part_boundary <- (!is.na(logical_vec) & logical_vec == TRUE) |
-          (!is.na(numeric_vec) & numeric_vec == 1)
-
-        part_positions <- which(is_part_boundary)
-        if (length(part_positions) > 0) {
-          params$part <- part_positions
-          log_debug(
-            paste("Part boundaries:", paste(part_positions, collapse = ", ")),
-            .context = "BFH_SERVICE"
-          )
-        }
-      }
-
-      # 6. Add target value if provided (normalized if needed)
-      if (!is.null(target_value)) {
-        params$target_value <- normalize_scale_for_bfh(
-          value = target_value,
-          chart_type = chart_type,
-          param_name = "target"
-        )
-      }
-
-      # 7. Add centerline value if provided (normalized if needed)
-      # BFHcharts parameter name: cl (not centerline_value)
-      if (!is.null(centerline_value)) {
-        params$cl <- normalize_scale_for_bfh(
-          value = centerline_value,
-          chart_type = chart_type,
-          param_name = "centerline"
-        )
-      }
-
-      # 7b. Add notes column if provided (map kommentarer -> notes)
-      # BFHcharts expects a character vector for the notes parameter
-      # IMPORTANT: notes_column refers to ORIGINAL column name (before sanitization)
-
-      # ROBUST COLUMN NAME MATCHING: Case-insensitive with fallback
-      notes_column_sanitized <- NULL
-      if (!is.null(notes_column)) {
-        # Try exact match first
-        if (notes_column %in% names(col_mapping)) {
-          notes_column_sanitized <- col_mapping[notes_column]
-        } else {
-          # Fallback: Case-insensitive match
-          original_names <- names(col_mapping)
-          match_idx <- which(tolower(original_names) == tolower(notes_column))
-          if (length(match_idx) > 0) {
-            notes_column_sanitized <- col_mapping[original_names[match_idx[1]]]
-          } else {
-            log_warn(
-              paste(
-                "Notes column not found in data:",
-                notes_column, "| Available columns:",
-                paste(head(original_names, 5), collapse = ", ")
-              ),
-              .context = "BFH_SERVICE"
-            )
-          }
-        }
-      }
-
-      if (!is.null(notes_column_sanitized) && notes_column_sanitized %in% names(data)) {
-        # Extract notes data and ensure it's character type
-        notes_data <- data[[notes_column_sanitized]]
-
-        # Convert to character vector (handles factor, numeric, etc.)
-        notes_char <- as.character(notes_data)
-
-        # Replace NA with empty strings (BFHcharts may not handle NA)
-        notes_char[is.na(notes_char)] <- ""
-
-        # Kun send notes hvis der faktisk er ikke-tomme noter
-        # Tomme notes-vektorer kan foraarsage langsom label placement i BFHcharts
-        if (any(nzchar(notes_char))) {
-          params$notes <- notes_char
-        }
-      }
-
-      # 8. Pass through additional parameters
-      extra_params <- list(...)
-      if (length(extra_params) > 0) {
-        if ("chart_title" %in% names(extra_params)) {
-          extra_params$chart_title <- resolve_bfh_chart_title(extra_params$chart_title)
-        }
-        params <- c(params, extra_params)
-      }
-
-      log_debug(
-        paste(
-          "BFHchart parameters mapped:",
-          "chart_type =", chart_type,
-          ", has_denominator =", !is.null(n_var),
-          ", has_freeze =", !is.null(params$freeze),
-          ", has_part =", !is.null(params$part)
-        ),
-        .context = "BFH_SERVICE"
-      )
-
-      # NOTE: Don't use return() inside safe_operation code blocks!
-      params
     },
     fallback = NULL,
     error_type = "parameter_mapping"

--- a/R/utils_server_session_persistence.R
+++ b/R/utils_server_session_persistence.R
@@ -1,0 +1,71 @@
+# Session persistence helpers.
+
+state_flag <- function(value, default = FALSE) {
+  if (is.null(value) || length(value) == 0 || anyNA(value)) {
+    return(default)
+  }
+  isTRUE(value[[1]])
+}
+
+register_session_save_status_output <- function(output, app_state) {
+  output$session_save_status <- shiny::renderUI({
+    has_saved <- !is.null(get_last_save_time(app_state))
+    auto_save_on <- is_auto_save_enabled(app_state)
+
+    if (isFALSE(auto_save_on)) {
+      return(shiny::span(
+        shiny::icon("triangle-exclamation"),
+        " Automatisk lagring deaktiveret",
+        style = paste0("color: ", get_hospital_colors()$danger, "; font-size: 0.8rem;"),
+        title = "Browseren har ikke plads til mere. Din data er stadig i appen."
+      ))
+    }
+
+    if (!has_saved) {
+      return(NULL)
+    }
+
+    shiny::span(
+      shiny::icon("check"),
+      " ",
+      shiny::span(id = "save-elapsed-text", "Session gemt"),
+      style = paste0("color: ", get_hospital_colors()$lightgrey, "; font-size: 0.8rem;"),
+      title = "Indstillinger og data gemmes automatisk i din browser"
+    )
+  })
+}
+
+register_local_storage_save_result_observer <- function(input, obs_manager, app_state) {
+  obs_save_result <- shiny::observeEvent(input$local_storage_save_result, {
+    result <- input$local_storage_save_result
+    if (is.null(result)) {
+      return()
+    }
+
+    log_info(
+      sprintf("localStorage save result: success=%s", isTRUE(result$success)),
+      .context = "LOCAL_STORAGE"
+    )
+
+    if (isTRUE(result$success)) {
+      set_last_save_time(app_state)
+    } else {
+      log_warn("localStorage save failed (quota or permission)", .context = "AUTO_SAVE")
+      set_auto_save_enabled(app_state, FALSE)
+      shiny::showNotification(
+        paste0(
+          "Browseren kan ikke gemme mere data (lokal lagerplads fuld). ",
+          "Automatisk lagring er deaktiveret for denne session."
+        ),
+        type = "warning",
+        duration = 8
+      )
+    }
+  })
+
+  if (!is.null(obs_manager)) {
+    obs_manager$add(obs_save_result, "local_storage_save_result")
+  }
+
+  invisible(obs_save_result)
+}

--- a/R/utils_server_session_status.R
+++ b/R/utils_server_session_status.R
@@ -1,0 +1,96 @@
+# Session status observers and output helpers.
+
+evaluate_dataLoaded_status <- function(app_state, session = NULL) {
+  current_data_check <- app_state$data$current_data
+
+  if (is.null(current_data_check)) {
+    return("FALSE")
+  }
+
+  meaningful_data <- evaluate_data_content_cached(
+    current_data_check,
+    session = session,
+    invalidate_events = c("data_loaded", "session_reset", "navigation_changed")
+  )
+
+  file_uploaded_check <- app_state$session$file_uploaded
+  user_started_session_check <- app_state$session$user_started_session
+  user_has_started <- file_uploaded_check || user_started_session_check %||% FALSE
+
+  log_debug_kv(
+    meaningful_data = meaningful_data,
+    file_uploaded_check = file_uploaded_check,
+    user_started_session_check = user_started_session_check,
+    user_has_started = user_has_started,
+    .context = "NAVIGATION_UNIFIED"
+  )
+
+  if (meaningful_data || user_has_started) "TRUE" else "FALSE"
+}
+
+evaluate_has_data_status <- function(app_state, session = NULL) {
+  current_data_check <- app_state$data$current_data
+
+  if (is.null(current_data_check)) {
+    return("false")
+  }
+
+  meaningful_data <- evaluate_data_content_cached(
+    current_data_check,
+    session = session,
+    invalidate_events = c("data_loaded", "session_reset", "navigation_changed")
+  )
+
+  if (meaningful_data) "true" else "false"
+}
+
+register_session_status_observers <- function(events, evaluator, setter, priority) {
+  observers <- lapply(
+    c("data_updated", "session_reset", "navigation_changed"),
+    function(event_name) {
+      force(event_name)
+      shiny::observeEvent(events[[event_name]], ignoreInit = TRUE, priority = priority, {
+        setter(evaluator())
+      })
+    }
+  )
+
+  invisible(observers)
+}
+
+register_session_status_outputs <- function(output, session, app_state) {
+  if (is.null(shiny::isolate(app_state$session$dataLoaded_status))) {
+    app_state$session$dataLoaded_status <- "FALSE"
+  }
+
+  data_loaded_evaluator <- function() evaluate_dataLoaded_status(app_state, session)
+  register_session_status_observers(
+    events = app_state$events,
+    evaluator = data_loaded_evaluator,
+    setter = function(value) app_state$session$dataLoaded_status <- value,
+    priority = OBSERVER_PRIORITIES$DATA_PROCESSING
+  )
+
+  output$dataLoaded <- shiny::renderText(app_state$session$dataLoaded_status)
+  outputOptions(output, "dataLoaded", suspendWhenHidden = FALSE)
+
+  if (is.null(shiny::isolate(app_state$session$has_data_status))) {
+    set_has_data_status(app_state, "false")
+  }
+
+  has_data_evaluator <- function() evaluate_has_data_status(app_state, session)
+  register_session_status_observers(
+    events = app_state$events,
+    evaluator = has_data_evaluator,
+    setter = function(value) set_has_data_status(app_state, value),
+    priority = OBSERVER_PRIORITIES$DATA_PROCESSING
+  )
+
+  shiny::observeEvent(TRUE, once = TRUE, priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT, {
+    app_state$session$dataLoaded_status <- data_loaded_evaluator()
+    set_has_data_status(app_state, has_data_evaluator())
+  })
+
+  output$has_data <- shiny::renderText(app_state$session$has_data_status)
+  outputOptions(output, "has_data", suspendWhenHidden = FALSE)
+}

--- a/tests/testthat/test-bfh-module-integration.R
+++ b/tests/testthat/test-bfh-module-integration.R
@@ -45,13 +45,17 @@ wait_for_bfh_plot_ready <- function(app, timeout = 15000) {
 }
 
 expect_bfh_plot_ready <- function(app) {
-  expect_true(
-    wait_for_bfh_plot_ready(app),
-    info = paste0(
-      bfh_plot_ready_output,
-      " skal blive TRUE før BFH shinytest2-screenshot"
+  ready <- wait_for_bfh_plot_ready(app)
+  if (!ready) {
+    stop(
+      paste0(
+        bfh_plot_ready_output,
+        " blev ikke TRUE før BFH shinytest2-screenshot"
+      ),
+      call. = FALSE
     )
-  )
+  }
+  expect_true(ready)
 }
 
 # Test fixtures helper
@@ -85,6 +89,8 @@ get_app_driver <- function(name) {
 # Helper to upload CSV via current upload input id
 upload_test_data <- function(app, csv_path) {
   app$upload_file(direct_file_upload = csv_path)
+  app$wait_for_idle(timeout = 5000)
+  app$click("load_paste_data")
   app$wait_for_idle(timeout = 5000)
 }
 


### PR DESCRIPTION
## Summary

- Refactors `map_to_bfh_params()` into a short orchestration layer with pure helpers for freeze positions, part boundaries, notes extraction, and BFH column mapping.
- Moves session status and persistence helper functions into separate session helper files, continuing the `setup_helper_observers()` split.
- Updates the BFH shinytest2 module test flow so uploaded CSV preview data is actually loaded before chart configuration, and readiness failures stop before screenshot capture.

## Issue Handling

Fixes #547.
Fixes #595.
Refs #546: session status/persistence helpers are split out, but the remaining auto-save/settings observer body in `setup_helper_observers()` is still too large, so this issue should stay open.

## Validation

- `devtools::load_all(quiet=TRUE)`
- `testthat::test_file('tests/testthat/test-fct-spc-bfh-params-collision.R', reporter='summary')`
- `testthat::test_file('tests/testthat/test-100x-mismatch-prevention.R', reporter='summary')`
- `testthat::test_file('tests/testthat/test-tidyverse-purrr-operations.R', reporter='summary')` with one existing skip for `HOSPITAL_COLORS not available`
- Local shinytest2 run was attempted with `NOT_CRAN=true RUN_SHINYTEST2=1`, but this sandbox cannot start Chrome/chromote, so the BFH module tests skip locally.
- Repository pre-push fast hook passed before push.

## Merge Path

Target this PR into `develop`. After that lands, promote `develop` to `master` in the normal follow-up PR.