### PR TITLE
fix(security): Wave 4 — Security MEDIUM (6 issues fra #597)

### DIFF
--- a/.Renviron.example
+++ b/.Renviron.example
@@ -17,5 +17,5 @@ GOOGLE_API_KEY=your_api_key_here
 # Bruges af session$onSessionEnded() til at pushe shinylogs-aggregat.
 # Hvis ikke sat, preserveres data kun lokalt i logs/.
 GITHUB_PAT=ghp_your_fine_grained_token_here
-PIN_REPO_URL=https://github.com/johanreventlow/bispcharts-analytics-data.git
+PIN_REPO_URL=https://github.com/YOUR_ORG/YOUR_ANALYTICS_REPO.git
 # PIN_REPO_BRANCH=main  # valgfri, default: main

--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -98,11 +98,6 @@ validate_safe_file_path <- function(uploaded_path) {
     normalizePath(file.path(tempdir(), "shiny-uploads"), mustWork = FALSE)
   )
 
-  # Add current working directory data folder if it exists
-  if (dir.exists("./data")) {
-    allowed_bases <- c(allowed_bases, normalizePath("./data", mustWork = FALSE))
-  }
-
   # Validate path is within allowed directories with enhanced checking
   # Normalize paths to forward slashes for consistent cross-platform comparison
   safe_path <- any(vapply(allowed_bases, function(base) {

--- a/R/fct_file_validation.R
+++ b/R/fct_file_validation.R
@@ -31,11 +31,9 @@ check_row_count_csv <- function(file_info) {
     {
       con <- file(file_info$datapath, "r")
       on.exit(close(con), add = TRUE)
-      line_count <- 0
-      while (length(readLines(con, n = 1)) > 0) {
-        line_count <- line_count + 1
-        if (line_count > get_max_upload_line_count()) break
-      }
+      max_lines <- get_max_upload_line_count()
+      lines <- readLines(con, n = max_lines + 1L, warn = FALSE)
+      line_count <- length(lines)
       if (line_count > get_upload_warning_row_count()) {
         log_warn("Large row count detected - performance risk",
           component = "[FILE_SECURITY]",

--- a/R/utils_analytics_github.R
+++ b/R/utils_analytics_github.R
@@ -97,6 +97,10 @@ sync_logs_to_github <- function(all_data,
   auth_url <- inject_pat_into_url(repo_url, pat)
   filename <- build_session_filename(session_id)
 
+  # gert.trace=FALSE forhindrer libgit2 C-niveau trace-logging i at emitte rå URL
+  old_trace_opt <- options(gert.trace = FALSE)
+  on.exit(options(old_trace_opt), add = TRUE)
+
   tryCatch(
     {
       gert::git_clone(

--- a/R/utils_local_storage.R
+++ b/R/utils_local_storage.R
@@ -134,7 +134,8 @@ restore_column_class <- function(values, class_info) {
   # Factor: brug gemte levels for at bevare rækkefølge
   if (isTRUE(class_info$is_factor)) {
     char_values <- as.character(values)
-    return(factor(char_values, levels = class_info$levels))
+    stored_levels <- head(class_info$levels, 10000L)
+    return(factor(char_values, levels = stored_levels))
   }
 
   # Date: parse ISO8601

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -8,7 +8,7 @@
 default:
   golem_name: biSPCharts
   golem_version: 1.0.0
-  app_prod: false
+  app_prod: true
 
   # Basic application settings
   app:


### PR DESCRIPTION
## Ændringer

Lukker alle 6 Wave 4 Security MEDIUM issues fra code-review backlog (#597):

- **#567** `.Renviron.example`: erstat konkret analytics-repo-URL med generisk placeholder
- **#569** `utils_local_storage.R`: factor levels fra localStorage begrænset til max 10.000 (OOM-beskyttelse)
- **#564** `fct_file_validation.R`: `readLines` line-by-line loop erstattet med bounded enkelt-kald `readLines(n=max+1, warn=FALSE)`
- **#565** `fct_file_operations.R`: fjern dead CWD-relativ `./data` block fra `allowed_path_bases` (mappen eksisterede aldrig i repo)
- **#566** `utils_analytics_github.R`: `options(gert.trace=FALSE)` scope-guard forhindrer libgit2 C-niveau trace-logging i at emitte rå PAT-URL
- **#568** `inst/golem-config.yml`: flip default `app_prod: false` → `true` (safe-fail ved manglende `R_CONFIG_ACTIVE`)

**Note #568:** Issue-body claimede fejlagtigt `hide_error_details: false` + `level: DEBUG` i default — disse var allerede safe (`true` + `WARN`). Kun `app_prod` var reelt problem.

## Testplan

- [x] `devtools::load_all()` + `testthat::test_dir()` — FAIL 0 | PASS 5921
- [x] Pre-push gate bestået (lintr, manifest, regression-tests)
- [ ] Code review