### PR TITLE
chore(wave-8b): code quality — branding docs, tidyverse, observer hygiene

### DIFF
--- a/R/app_initialization.R
+++ b/R/app_initialization.R
@@ -322,5 +322,5 @@ get_initialization_status_report <- function(init_results) {
     )
   }
 
-  return(do.call(rbind, status_rows))
+  dplyr::bind_rows(status_rows)
 }

--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -253,7 +253,9 @@ main_app_server <- function(input, output, session) {
   session_debugger$event("server_setup_complete")
   log_debug("All server components setup completed", .context = "SESSION_LIFECYCLE")
 
-  # FASE 3: Emit session_started event for name-only detection
+  # FASE 3: Emit session_started event for name-only detection.
+  # reactive(TRUE) + once = TRUE + ignoreInit = FALSE er bevidst:
+  # observer skal køre én gang straks ved session-start (init-trigger-pattern).
   shiny::observeEvent(shiny::reactive(TRUE),
     {
       emit$session_started()

--- a/R/fct_spc_helpers.R
+++ b/R/fct_spc_helpers.R
@@ -35,7 +35,9 @@ is_column_numeric <- function(col, threshold = 0.5) {
 value_box_signal_theme <- function(status_info, signal) {
   colors <- get_hospital_colors()
   if (status_info$status == "ready" && isTRUE(signal)) {
-    # Signal detekteret: medium graa baggrund med hvid tekst (matcher btn-secondary)
+    # Signal detekteret: medium graa baggrund med hvid tekst (matcher btn-secondary).
+    # "#ffffff" er bevidst — brand-paletten har ingen white-farve; white-on-grey-mid
+    # er klinisk konvention for signal-tilstand (WCAG 4.5:1 kontrast OK).
     bslib::value_box_theme(bg = colors$ui_grey_mid, fg = "#ffffff")
   } else if (status_info$status == "ready") {
     # Ingen signal (OK): lys graa baggrund med moerk tekst

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -49,11 +49,15 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     )
 
     # Tilbage-knap: Trin 3 -> Trin 2
-    shiny::observeEvent(input$back_to_analysis, {
-      if (!is.null(parent_session)) {
-        bslib::nav_select("main_navbar", selected = "analyser", session = parent_session)
+    shiny::observeEvent(input$back_to_analysis,
+      ignoreNULL = TRUE,
+      ignoreInit = TRUE,
+      {
+        if (!is.null(parent_session)) {
+          bslib::nav_select("main_navbar", selected = "analyser", session = parent_session)
+        }
       }
-    })
+    )
 
     # PREVIEW GENERATION ======================================================
 

--- a/R/utils_analytics_pins.R
+++ b/R/utils_analytics_pins.R
@@ -82,13 +82,13 @@ read_shinylogs_all <- function(log_directory) {
       }
     )
   })
-  entries <- Filter(Negate(is.null), entries)
+  entries <- purrr::compact(entries)
   if (length(entries) == 0) {
     return(empty_result)
   }
 
   bind_safe <- function(lst) {
-    dfs <- Filter(function(x) !is.null(x), lst)
+    dfs <- purrr::compact(lst)
     if (length(dfs) == 0) {
       return(data.frame())
     }

--- a/R/utils_cache_generators.R
+++ b/R/utils_cache_generators.R
@@ -13,7 +13,9 @@ get_hospital_branding_config <- function() {
     code = {
       branding_config <- list()
 
-      # Hospital colors
+      # Hospital colors — kald getter hvis tilgængelig; ellers BFH-brand defaults.
+      # Defaults matcher BFHtheme::bfh_cols() farvepalette og er korrekte for
+      # biSPCharts-brug; de erstatter IKKE branding-getter under normal drift.
       if (exists("get_hospital_colors", mode = "function")) {
         branding_config$colors <- get_hospital_colors()
       } else {
@@ -42,6 +44,7 @@ get_hospital_branding_config <- function() {
       return(branding_config)
     },
     fallback = function(e) {
+      # Error-fallback: minimale BFH-brand defaults så UI ikke crasher.
       log_warn(paste("Failed to generate hospital branding cache:", e$message), "CACHE_GENERATOR")
       return(list(
         colors = list(primary = "#007dbb", secondary = "#646c6f"),

--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -89,30 +89,6 @@ register_chart_type_events <- function(app_state, emit, input, session, register
     input, session, app_state, register_observer
   )
 
-  # Passiv timing-monitor
-  if (!is.null(app_state$ui)) {
-    observers$timing_monitor <- register_observer(
-      "timing_monitor",
-      shiny::observeEvent(app_state$ui$last_programmatic_update,
-        ignoreInit = TRUE,
-        priority = OBSERVER_PRIORITIES$LOWEST,
-        {
-          current_time <- Sys.time()
-          last_update <- shiny::isolate(app_state$ui$last_programmatic_update)
-
-          if (!is.null(last_update)) {
-            freeze_state <- shiny::isolate(app_state$columns$auto_detect$frozen_until_next_trigger) %||% FALSE
-
-            autodetect_in_progress <- if (!is.null(app_state$columns)) {
-              shiny::isolate(app_state$columns$auto_detect$in_progress) %||% FALSE
-            } else {
-              FALSE
-            }
-          }
-        }
-      )
-    )
-  }
 
   observers
 }
@@ -175,6 +151,9 @@ observe_chart_type_input <- function(input, session, app_state, register_observe
           error_type = "processing"
         )
       },
+      # ignoreInit = FALSE er bevidst: observer skal køre ved session-start
+      # for at initialisere UI korrekt baseret på default/restored chart_type.
+      # Session-restore guard (linje 126) forhindrer race condition.
       ignoreInit = FALSE,
       priority = OBSERVER_PRIORITIES$UI_SYNC
     )

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -27,6 +27,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
   # observer -- den trigges nu via performSessionRestore custom message.
   shiny::observeEvent(input$session_peek,
     ignoreNULL = TRUE,
+    ignoreInit = TRUE,
     {
       peek <- input$session_peek
 

--- a/R/utils_spc_data_processing.R
+++ b/R/utils_spc_data_processing.R
@@ -83,9 +83,8 @@ filter_complete_spc_data <- function(data, y_col, n_col = NULL, x_col = NULL) {
         original_x_class <- class(data[[x_col]])
       }
 
-      # Filter data to complete rows using tidyverse approach
       data_filtered <- data |>
-        dplyr::slice(which(complete_rows))
+        dplyr::filter(complete_rows)
 
       # PRESERVE POSIXct/Date formats
       if (!is.null(x_col) && x_col %in% names(data) && !is.null(original_x_class)) {


### PR DESCRIPTION
## Wave 8b — code quality cleanup

Fortsættelse af Wave 8 code-review backlog (#597).

### Ændringer

| Issue | Handling |
|-------|----------|
| #579 | Dokumenterer intentionelle hardcoded farver (WCAG + BFH-brand fallback) |
| #587 | `do.call(rbind)` → `bind_rows`, `Filter(Negate)` → `compact`, `slice(which)` → `filter` |
| #593 | Slet dead timing_monitor, `ignoreInit=TRUE` på 2 observers, dokumentér 2 intentionelle `ignoreInit=FALSE` |

### Udeladte items (verificeret stale/false positives)

- `tapply` i anhoej_rules: korrekt per-fase-ekstraktion — ikke et problem
- `class()[1]` i logging: korrekt — ikke dispatch-logik
- `do.call(c, lapply)`: bevidst POSIXct-preservering
- debounce-konstant: allerede `DEBOUNCE_DELAYS$chart_update` — stale

## Test plan

- [x] FAIL 0 | PASS 5921
- [x] Pre-push gate bestået