### PR TITLE
test+ci: Wave 8c — logging redaction tests, flaky test fixes, edge-case tests, security scan

### DIFF
--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,0 +1,108 @@
+# Ugentlig sårbarhedsscanning af R-afhængigheder (fixes #591).
+#
+# Bruger oysteR til OSV-opslag mod installerede pakker (renv-låste versioner).
+# Ikke-blokerende: fund rapporteres i workflow-summary + opretter GitHub Issue
+# (advisory, blokerer ikke PRs).
+#
+# Kør manuelt: gh workflow run security-audit.yaml
+name: security-audit
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # mandag 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    name: dependency-vulnerability-scan
+
+    env:
+      GITHUB_PAT: ${{ secrets.BFH_ASSETS_PAT || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+      PKG_SYSREQS: "FALSE"
+      GOOGLE_API_KEY: ""
+      GEMINI_API_KEY: ""
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-renv@v2
+        with:
+          cache-version: 1
+
+      - name: Install oysteR
+        shell: Rscript {0}
+        run: |
+          if (!requireNamespace("oysteR", quietly = TRUE)) {
+            install.packages("oysteR", repos = "https://cloud.r-project.org")
+          }
+
+      - name: Scan for known vulnerabilities (oysteR)
+        id: oyster_scan
+        shell: Rscript {0}
+        run: |
+          pkgs <- tryCatch(
+            unique(renv::dependencies(quiet = TRUE)$Package),
+            error = function(e) installed.packages()[, "Package"]
+          )
+
+          audit <- tryCatch(
+            oysteR::audit_packages(pkgs),
+            error = function(e) {
+              message("oysteR scan fejlede: ", e$message)
+              NULL
+            }
+          )
+
+          if (!is.null(audit) && nrow(audit) > 0) {
+            vuln <- audit[isTRUE(audit$vulnerable), ]
+            if (nrow(vuln) > 0) {
+              writeLines("vulnerabilities_found=true", Sys.getenv("GITHUB_OUTPUT"))
+              message("=== SAARBARHEDER FUNDET (", nrow(vuln), ") ===")
+              print(vuln[, intersect(c("Package", "version", "id", "title"), names(vuln))])
+            } else {
+              writeLines("vulnerabilities_found=false", Sys.getenv("GITHUB_OUTPUT"))
+              message("Ingen kendte saarbarheder i ", length(pkgs), " pakke(r).")
+            }
+          } else {
+            writeLines("vulnerabilities_found=false", Sys.getenv("GITHUB_OUTPUT"))
+            message("Audit returnerede ingen resultater.")
+          }
+
+      - name: Aaben GitHub Issue ved fund (advisory)
+        if: steps.oyster_scan.outputs.vulnerabilities_found == 'true'
+        run: |
+          TODAY=$(date -u +%Y-%m-%d)
+          TITLE="[security-audit] Saarbare R-afhaengigheder fundet ($TODAY)"
+          BODY="oysteR fandt kendte CVE/OSV-match i installerede R-pakker.
+
+          Se workflow-loggen for detaljer: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+
+          Anbefalede handlinger:
+          1. Tjek workflow-loggen for berørte pakker
+          2. Opdater via renv::update() + renv::snapshot()
+          3. Commit ny renv.lock
+
+          _Automatisk oprettet af security-audit.yaml_"
+
+          # Opret kun issue hvis ingen aaben issue med samme praefiks
+          EXISTING=$(gh issue list --state open --label security --json title --jq '.[].title' | grep -c '^\[security-audit\]' || true)
+          if [ "$EXISTING" -eq 0 ]; then
+            gh issue create \
+              --title "$TITLE" \
+              --body "$BODY" \
+              --label security
+          else
+            echo "Aaben security-audit issue eksisterer allerede — springer over."
+          fi

--- a/tests/testthat/test-anhoej-thresholds.R
+++ b/tests/testthat/test-anhoej-thresholds.R
@@ -4,6 +4,8 @@
 
 library(testthat)
 
+set.seed(42) # reproducibilitet: make_qic_data bruger runif()
+
 # Hjælper: lav minimal qic_data med n observationer
 make_qic_data <- function(n_obs, n_crossings_min = NA, n_crossings = NA) {
   data.frame(

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -10,6 +10,8 @@
 #   - test-utils_qic_caching.R         — qicharts2-specifik cache
 #   - test-spc-cache-integration.R     — SPC pipeline cache integration
 
+set.seed(42) # reproducibilitet: create_cache_test_dataset bruger sample()
+
 clear_cache_if_available <- function(...) {
   if (exists("clear_performance_cache", mode = "function")) {
     clear_performance_cache(...)

--- a/tests/testthat/test-fct_spc_validate.R
+++ b/tests/testthat/test-fct_spc_validate.R
@@ -107,6 +107,31 @@ test_that("validate_spc_request kaster spc_input_error ved manglende n_var for p
   )
 })
 
+# 0-row pipeline (#588) =======================================================
+
+test_that("compute_spc_results_bfh kaster spc_input_error ved 0 rækker", {
+  empty_df <- data.frame(
+    dato = as.Date(character(0)),
+    vaerdi = numeric(0)
+  )
+  expect_error(
+    compute_spc_results_bfh(empty_df, "dato", "vaerdi", "run"),
+    class = "spc_input_error"
+  )
+})
+
+test_that("compute_spc_results_bfh fejlbesked nævner 'tom' eller 'empty' ved 0 rækker", {
+  empty_df <- data.frame(dato = as.Date(character(0)), vaerdi = numeric(0))
+  err <- tryCatch(
+    compute_spc_results_bfh(empty_df, "dato", "vaerdi", "run"),
+    spc_input_error = function(e) e
+  )
+  expect_true(
+    grepl("tom|empty|ingen|0", conditionMessage(err), ignore.case = TRUE),
+    info = paste("Fejlbesked mangler 'tom'/'empty'/'ingen'/'0':", conditionMessage(err))
+  )
+})
+
 test_that("validate_spc_request accepterer p-kort med n_var", {
   df <- data.frame(dato = 1:10, tæller = 1:10, naevner = rep(100L, 10))
   req <- validate_spc_request(df, "dato", "tæller", "p", n_var = "naevner")

--- a/tests/testthat/test-spc-cache-integration.R
+++ b/tests/testthat/test-spc-cache-integration.R
@@ -4,6 +4,8 @@
 
 library(testthat)
 
+set.seed(42) # reproducibilitet: create_test_data bruger rnorm() og sample()
+
 # Test data generator
 create_test_data <- function(n_rows = 50, chart_type = "run") {
   data <- data.frame(
@@ -210,6 +212,7 @@ test_that("get_cached_spc_result returns NULL on cache miss", {
 
 
 test_that("cache expires after TTL", {
+  skip_on_ci() # bruger Sys.sleep(1.5) — for langsom og timing-afhængig til CI
   skip_if_not_installed("digest")
 
   qic_cache <- create_qic_cache(max_size = 10)

--- a/tests/testthat/test-utils_csv_delimiter_detection.R
+++ b/tests/testthat/test-utils_csv_delimiter_detection.R
@@ -77,3 +77,26 @@ test_that("detect_csv_delimiter rejects one-column content as not parseable", {
   expect_equal(result$ncol, 0L)
   expect_equal(result$nrow, 0L)
 })
+
+test_that("detect_csv_delimiter parser UTF-8 BOM + semikolon korrekt", {
+  require_internal("detect_csv_delimiter", mode = "function")
+
+  # UTF-8 BOM = EF BB BF — tilføjes af Windows Notepad/Excel ved CSV-eksport
+  bom <- "\xef\xbb\xbf"
+  path <- tempfile(fileext = ".csv")
+  writeBin(
+    chartr("", "", paste0(bom, "Date;Count;Denominator\n2024-01-01;10,5;100\n2024-02-01;11,5;120\n")),
+    con = path
+  )
+  on.exit(unlink(path), add = TRUE)
+
+  result <- detect_csv_delimiter(path)
+
+  expect_true(result$parseable,
+    info = "BOM-prefixet fil skal fortsat genkendes som parseable"
+  )
+  expect_equal(result$strategy, "semikolon")
+  expect_equal(result$delimiter, ";")
+  expect_equal(result$ncol, 3L)
+  expect_equal(result$nrow, 2L)
+})

--- a/tests/testthat/test-utils_logging.R
+++ b/tests/testthat/test-utils_logging.R
@@ -55,10 +55,11 @@ test_that("log_info redakterer nøgle-navne der matcher secret-mønster", {
       details = list(api_key = "super_hemmeligt", rows = 42L)
     )
   )
-  expect_false(grepl("super_hemmeligt", paste(output, collapse = "")),
+  combined <- paste(output, collapse = "")
+  expect_false(grepl("super_hemmeligt", combined),
     info = "api_key-værdien må ikke fremgå af log-output"
   )
-  expect_true(grepl("REDACTED", paste(output, collapse = "")),
+  expect_true(grepl("REDACTED", combined),
     info = "Redakteret felt skal indeholde REDACTED"
   )
 })

--- a/tests/testthat/test-utils_logging.R
+++ b/tests/testthat/test-utils_logging.R
@@ -47,6 +47,7 @@ test_that("log_error accepterer details som liste", {
 # Secret-redaktion (#575) =====================================================
 
 test_that("log_info redakterer nøgle-navne der matcher secret-mønster", {
+  withr::local_envvar(SPC_LOG_LEVEL = "DEBUG")
   output <- capture.output(
     log_info(
       "test",
@@ -63,6 +64,7 @@ test_that("log_info redakterer nøgle-navne der matcher secret-mønster", {
 })
 
 test_that("log_warn redakterer token-felt i details", {
+  withr::local_envvar(SPC_LOG_LEVEL = "DEBUG")
   output <- capture.output(
     log_warn(
       "test",
@@ -78,6 +80,7 @@ test_that("log_warn redakterer token-felt i details", {
 })
 
 test_that("log_error redakterer password-felt i details", {
+  withr::local_envvar(SPC_LOG_LEVEL = "DEBUG")
   output <- capture.output(
     log_error(
       "test",
@@ -91,6 +94,7 @@ test_that("log_error redakterer password-felt i details", {
 })
 
 test_that("log_info bevarer ikke-hemmelige felter uændrede", {
+  withr::local_envvar(SPC_LOG_LEVEL = "DEBUG")
   output <- capture.output(
     log_info(
       "test",

--- a/tests/testthat/test-utils_logging.R
+++ b/tests/testthat/test-utils_logging.R
@@ -43,3 +43,64 @@ test_that("log_error accepterer details som liste", {
     )
   )
 })
+
+# Secret-redaktion (#575) =====================================================
+
+test_that("log_info redakterer nøgle-navne der matcher secret-mønster", {
+  output <- capture.output(
+    log_info(
+      "test",
+      .context = "TEST",
+      details = list(api_key = "super_hemmeligt", rows = 42L)
+    )
+  )
+  expect_false(grepl("super_hemmeligt", paste(output, collapse = "")),
+    info = "api_key-værdien må ikke fremgå af log-output"
+  )
+  expect_true(grepl("REDACTED", paste(output, collapse = "")),
+    info = "Redakteret felt skal indeholde REDACTED"
+  )
+})
+
+test_that("log_warn redakterer token-felt i details", {
+  output <- capture.output(
+    log_warn(
+      "test",
+      .context = "TEST",
+      details = list(token = "ghp_ABC123", user = "alice")
+    )
+  )
+  combined <- paste(output, collapse = "")
+  expect_false(grepl("ghp_ABC123", combined))
+  expect_true(grepl("REDACTED", combined))
+  # Ikke-hemmelige felter forbliver synlige
+  expect_true(grepl("alice", combined))
+})
+
+test_that("log_error redakterer password-felt i details", {
+  output <- capture.output(
+    log_error(
+      "test",
+      .context = "TEST",
+      details = list(password = "hemlig123", reason = "auth_failed")
+    )
+  )
+  combined <- paste(output, collapse = "")
+  expect_false(grepl("hemlig123", combined))
+  expect_true(grepl("REDACTED", combined))
+})
+
+test_that("log_info bevarer ikke-hemmelige felter uændrede", {
+  output <- capture.output(
+    log_info(
+      "test",
+      .context = "TEST",
+      details = list(rows = 42L, session_id = "abc", chart_type = "run")
+    )
+  )
+  combined <- paste(output, collapse = "")
+  expect_true(grepl("42", combined))
+  expect_true(grepl("abc", combined))
+  expect_true(grepl("run", combined))
+  expect_false(grepl("REDACTED", combined))
+})


### PR DESCRIPTION
## Ændringer

Wave 8c løser de resterende issues fra tracker #597:

- **#575** `test(logging)`: Tests der verificerer at `.redact_secrets()` maskerer nøgler som `api_key`, `token`, `password` i `log_info/warn/error(details=...)`. Implementeringen var allerede aktiv — tests låser kontrakten fast.

- **#589** `test(reproducibility)`: `set.seed(42)` tilføjet til 3 testfiler med ikke-deterministiske kald (`runif`, `rnorm`, `sample`); `skip_on_ci()` tilføjet til TTL-test med `Sys.sleep(1.5)` i `test-spc-cache-integration.R`.

- **#588** `test(edge-cases)`: 
  - `detect_csv_delimiter`: test for UTF-8 BOM + semikolon (Windows CSV-eksport format)
  - `compute_spc_results_bfh`: test for at 0-rækker-data kaster `spc_input_error` fra fuld pipeline

- **#591** `ci`: Ugentlig `security-audit.yaml` med `oysteR`-scanning mandag 06:00 UTC. Ikke-blokerende — fund åbner advisorisk GitHub Issue (deduplikkeret).

## Test plan

- [x] Pre-push gate grøn (lintr + manifest + regressionstests)
- [x] 4 atomiske commits, ét issue per commit
- [x] Alle nye tests er deterministiske (set.seed) og CI-sikre (skip_on_ci for Sys.sleep)
- [x] Ingen produktionskode ændret — kun tests + CI-workflow