### PR TITLE
feat(viewport): gate analyse-render paa first-layout signal (#610)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 ## Nye features
 
+* **Eliminer dobbelt-render af analyse-graf efter data-upload (#610):**
+  Browser-side `ResizeObserver` (`inst/app/www/viewport-ready.js`) sender
+  nu et `viewport_ready`-signal til serveren først når plot-containeren
+  har fået en reel layout-måling. `spc_inputs_raw` er gated på dette
+  signal, hvilket eliminerer den syntetiske 800x600 cold-start-render
+  (Shiny's CSS-default container-størrelse rapporteres umiddelbart via
+  `session$clientData` før browseren har målt layout). Tidligere førte
+  dette til to separate analyse-renders per upload med forskellige
+  cache-keys. `spc_inputs` er nu single source of truth for viewport
+  i compute- og cache-pipelinen — tidligere eksisterede en split-brain
+  mellem `FONT_SCALING`'s viewport (clientData) og BFHcharts-kaldets
+  viewport (`get_viewport_dims(app_state)`). Fallback via
+  `later::later(2s)` sikrer at signalet flippes selv i miljøer uden
+  `ResizeObserver` (headless tests, JS deaktiveret).
+
 * **Footnote-felt i PDF/PNG-eksport (#485):** Bruger kan nu tilføje
   klinisk attribution (datakilde, udtræksdato) i trin 3 (Eksport).
   Tekst sendes til BFHcharts Typst-template via `metadata$footer_content`

--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -66,8 +66,10 @@ create_spc_results_reactive <- function(
 
     # M11: Context-aware cache key for plot isolation
     # Issue #62: Separate cache per context to prevent dimension bleeding
+    # Issue #610: Single source of truth — vp dims fra inputs (sat via
+    # viewport_ready event), ikke get_viewport_dims(app_state). Dette
+    # forhindrer split-brain mellem cache-key og BFHcharts-kald.
     plot_context <- "analysis" # Analyse-side always uses "analysis" context
-    vp_dims <- get_viewport_dims(app_state)
 
     cache_key <- digest::digest(
       list(
@@ -84,8 +86,8 @@ create_spc_results_reactive <- function(
         inputs$y_axis_unit,
         inputs$kommentar_column,
         inputs$base_size, # FIX: Invalider cache ved breddeaendring/fuldskaerm
-        vp_dims$width, # NEW: Viewport width for dimension-aware caching
-        vp_dims$height # NEW: Viewport height for dimension-aware caching
+        inputs$viewport_width_px, # Issue #610: from inputs (single source)
+        inputs$viewport_height_px # Issue #610: from inputs (single source)
       ),
       algo = "xxhash64"
     )
@@ -143,8 +145,8 @@ create_spc_results_reactive <- function(
     computation <- safe_operation(
       "Generate SPC plot",
       code = {
-        # M10: Hent viewport dimensions fra centraliseret state
-        vp_dims <- get_viewport_dims(app_state)
+        # Issue #610: Viewport dims fra inputs (single source) — ikke
+        # get_viewport_dims(app_state) som ville aabne for split-brain.
 
         # SPRINT 4: Pass QIC cache for performance optimization
         qic_cache <- if (!is.null(app_state) && !is.null(app_state$cache)) {
@@ -167,8 +169,8 @@ create_spc_results_reactive <- function(
           y_axis_unit = inputs$y_axis_unit,
           kommentar_column = inputs$kommentar_column,
           base_size = inputs$base_size,
-          viewport_width = vp_dims$width,
-          viewport_height = vp_dims$height,
+          viewport_width = inputs$viewport_width_px,
+          viewport_height = inputs$viewport_height_px,
           qic_cache = qic_cache,
           app_state = app_state,
           plot_context = "analysis" # M11: Analyse-side uses "analysis" context
@@ -301,8 +303,9 @@ create_spc_results_reactive <- function(
       inputs <- spc_inputs_reactive()
       # M11: Context-aware cache binding
       # Issue #62: Include context and viewport dimensions for cache isolation
+      # Issue #610: vp dims fra inputs (single source) — sammen med cache-key
+      # i reactive body for at undgaa split-brain.
       plot_context <- "analysis"
-      vp_dims <- get_viewport_dims(app_state)
 
       list(
         "spc_results",
@@ -318,9 +321,9 @@ create_spc_results_reactive <- function(
         inputs$title,
         inputs$y_axis_unit,
         inputs$kommentar_column,
-        inputs$base_size, # FIX: Invalider cache ved breddeaendring/fuldskaerm
-        vp_dims$width, # NEW: Invalidate cache on viewport width change
-        vp_dims$height # NEW: Invalidate cache on viewport height change
+        inputs$base_size,
+        inputs$viewport_width_px,
+        inputs$viewport_height_px
       )
     })
 }

--- a/R/mod_spc_chart_inputs.R
+++ b/R/mod_spc_chart_inputs.R
@@ -57,10 +57,22 @@ create_data_ready_reactive <- function(module_data_reactive) {
 #' to BFHcharts API parameters, handles chart type-specific configuration,
 #' and includes viewport dimensions for responsive font scaling.
 #'
+#' Issue #610: Viewport dimensions are now read from centralized
+#' `app_state$visualization$viewport_dims` (populated by the
+#' `input$viewport_ready` JS event in `register_viewport_observer`),
+#' not directly from `session$clientData`. This ensures `spc_inputs`
+#' is the single source of truth for viewport across compute + cache,
+#' eliminating the synthetic 800x600 cold-start render.
+#'
 #' @param data_ready_reactive Reactive expression returning validated data
 #' @param chart_config Debounced reactive returning chart configuration
-#' @param session Shiny session object (for clientData access)
-#' @param ns Namespace function for input IDs
+#' @param session Shiny session object (retained for backward compat — unused
+#'   for viewport reads after Issue #610)
+#' @param ns Namespace function for input IDs (retained for backward compat)
+#' @param app_state Reactive values object — viewport_dims source of truth
+#' @param viewport_ready_signal `reactiveVal(FALSE)` from
+#'   `register_viewport_observer`, gates cold-start evaluation on real
+#'   browser layout measurement
 #' @param y_axis_unit_reactive Reactive expression for Y-axis unit (optional)
 #' @param target_value_reactive Reactive expression for target value (optional)
 #' @param target_text_reactive Reactive expression for target text (optional)
@@ -94,6 +106,8 @@ create_spc_inputs_reactive <- function(
   chart_config,
   session,
   ns,
+  app_state,
+  viewport_ready_signal,
   y_axis_unit_reactive = NULL,
   target_value_reactive = NULL,
   target_text_reactive = NULL,
@@ -157,11 +171,19 @@ create_spc_inputs_reactive <- function(
     kommentar_value <- if (!is.null(kommentar_column_reactive)) kommentar_column_reactive() else NULL
     target_text_value <- if (!is.null(target_text_reactive)) target_text_reactive() else NULL
 
-    # VIEWPORT DIMENSIONS: Kraev faktiske clientData dimensioner.
-    # Blokerer evaluering indtil browseren har rapporteret reelle dimensioner.
-    # Eliminerer label-placering baseret paa forkerte 800x600 defaults.
-    width_px <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_width")]]
-    height_px <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_height")]]
+    # VIEWPORT DIMENSIONS — Issue #610:
+    # Kraev viewport_ready_signal foer cold-start kan fortsaette. Signal
+    # flippes TRUE af enten (a) JS ResizeObserver via input$viewport_ready,
+    # eller (b) 2-sekunders timeout-fallback i register_viewport_observer.
+    # Dette eliminerer det syntetiske 800x600 cold-start render.
+    shiny::req(viewport_ready_signal())
+
+    # Single source of truth: laes vp-dims fra centraliseret app_state
+    # (sat af register_viewport_observer). Tidligere blev clientData laest
+    # direkte her, samtidig med at compute.R laeste fra app_state — split-brain.
+    vp_dims <- get_viewport_dims(app_state)
+    width_px <- vp_dims$width
+    height_px <- vp_dims$height
 
     shiny::req(!is.null(width_px), !is.null(height_px), width_px > 100, height_px > 100)
 
@@ -183,6 +205,8 @@ create_spc_inputs_reactive <- function(
     # GEOMETRIC MEAN APPROACH: sqrt(width_px * height_px) giver balanced scaling
     # baseret paa baade bredde og hoejde. Dette sikrer at fonts skalerer intuitivt
     # med den samlede plotstoerrelse, ikke kun en dimension.
+    # pixelratio bevares fra clientData — uafhaengigt af viewport-dimensioner
+    # og rapporteres korrekt af Shiny ved session-init.
     pixelratio <- session$clientData$pixelratio %||% 1
     viewport_diagonal <- sqrt(width_px * height_px)
     base_size <- max(

--- a/R/mod_spc_chart_observers.R
+++ b/R/mod_spc_chart_observers.R
@@ -15,44 +15,144 @@
 
 #' Register Viewport Dimension Observer
 #'
-#' Sets up an observer that tracks viewport (plot container) dimensions from
-#' Shiny's clientData and updates the centralized app_state. This ensures
-#' responsive font scaling uses actual browser dimensions, not defaults.
+#' Tracks viewport (plot container) dimensions and ensures cold-start renders
+#' wait for a real browser layout measurement before producing a chart.
+#'
+#' Two complementary mechanisms (Issue #610):
+#' \itemize{
+#'   \item \strong{clientData observer} — keeps writing dimensions from
+#'     `session$clientData` into `app_state$visualization$viewport_dims`.
+#'     This preserves backward-compatible behavior (resize tracking,
+#'     test environments where `mockclientdata` returns valid dims).
+#'   \item \strong{viewport_ready signal} — gates `spc_inputs_raw` on the
+#'     first real layout. The browser-side ResizeObserver
+#'     (`inst/app/www/viewport-ready.js`) fires `input$viewport_ready` once
+#'     `#visualization-spc_plot_actual` has dims > 100x100 px. This observer
+#'     mirrors the measurement into `app_state` and flips the signal TRUE.
+#'   \item \strong{Timeout fallback} — `later::later(fallback_delay_secs)`
+#'     flips the signal TRUE even if the JS event never arrives (no
+#'     ResizeObserver, headless tests, JS disabled), using clientData
+#'     dimensions written by Observer 1 or `VIEWPORT_DEFAULTS`.
+#' }
+#'
+#' Why both: clientData reports the CSS-default 800x600 immediately at
+#' startup, before the browser has measured the actual layout. spc_inputs
+#' needs to know when to start trusting the dimensions — that's the role
+#' of `viewport_ready_signal`. The clientData observer is still useful
+#' for resize tracking after first layout.
 #'
 #' @param app_state Reactive values object containing visualization state
 #' @param session Shiny session object (for clientData access)
+#' @param input Shiny input object (provides `viewport_ready` from JS)
 #' @param ns Namespace function for output IDs
 #' @param emit Emit API object from `create_emit_api(app_state)`, created once
 #'   outside the observer to avoid recreating it on every reactive invalidation.
+#' @param viewport_ready_signal `reactiveVal(FALSE)` flipped TRUE once a real
+#'   measurement is available. `spc_inputs_raw` `req()`s on this.
+#' @param fallback_delay_secs Seconds to wait before firing the timeout
+#'   fallback. Default 2s (production). Tests may pass smaller values to
+#'   exercise the fallback path quickly.
+#' @param .scheduler Function with signature `function(callback, delay)`
+#'   used to schedule the fallback timeout. Default `later::later`. Tests
+#'   may inject a synchronous scheduler to drive the fallback deterministically.
 #'
 #' @return NULL (side effect: registers observer with Shiny)
 #'
-#' @details
-#' Viewport observer flow:
-#' 1. Reads session clientData for output dimensions
-#' 2. Validates dimensions are non-null and greater than 100px
-#' 3. Updates app_state visualization with viewport dimensions
-#' 4. Emits viewport_changed event for downstream reactives
-#'
-#' Critical for:
-#' - Responsive font scaling (base_size calculation uses viewport diagonal)
-#' - Cache key generation (includes viewport dimensions)
-#' - Label placement accuracy (requires accurate device dimensions)
-#'
 #' @keywords internal
-register_viewport_observer <- function(app_state, session, ns, emit) {
+register_viewport_observer <- function(
+  app_state,
+  session,
+  input,
+  ns,
+  emit,
+  viewport_ready_signal,
+  fallback_delay_secs = 2,
+  .scheduler = later::later
+) {
+  # === Observer 1: clientData → app_state (legacy data source) ===
+  # Continues writing dimensions on every clientData change so resize events
+  # are tracked. testServer's mockclientdata exercises this path.
   shiny::observe({
-    # Read viewport dimensions from clientData
     width <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_width")]]
     height <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_height")]]
 
-    # GUARD: Require valid dimensions (prevent defaults from being cached)
     shiny::req(
       !is.null(width), !is.null(height),
       width > 100, height > 100
     )
 
-    # Update centralized viewport state
     set_viewport_dims(app_state, width, height, emit)
   })
+
+  # === Observer 2: input$viewport_ready → flip signal + write app_state ===
+  # JS ResizeObserver fires this once the browser has a real layout. Until
+  # this fires, `spc_inputs_raw` is gated and won't render the synthetic
+  # 800x600 cold-start frame.
+  shiny::observeEvent(input$viewport_ready, ignoreInit = FALSE, {
+    payload <- input$viewport_ready
+    if (is.null(payload) || !is.list(payload)) {
+      return()
+    }
+    width <- payload$width
+    height <- payload$height
+    if (is.null(width) || is.null(height) || width <= 100 || height <= 100) {
+      return()
+    }
+
+    set_viewport_dims(app_state, as.numeric(width), as.numeric(height), emit)
+    viewport_ready_signal(TRUE)
+
+    log_debug(
+      sprintf("viewport_ready signal received: %dx%d", round(width), round(height)),
+      .context = "VIEWPORT_DIMENSIONS"
+    )
+  })
+
+  # === Fallback: later::later flips signal even without JS event ===
+  # Critical for headless tests, environments without ResizeObserver, and
+  # JS-disabled browsers (Issue #610 acceptance criterion: "No regression
+  # for environments where clientData is unavailable"). Uses whatever
+  # dimensions Observer 1 has already written to app_state, or VIEWPORT_DEFAULTS.
+  .scheduler(
+    function() {
+      if (isTRUE(shiny::isolate(viewport_ready_signal()))) {
+        return(invisible(NULL))
+      }
+
+      current <- shiny::isolate(app_state$visualization$viewport_dims)
+      width <- current$width
+      height <- current$height
+
+      if (!is.null(width) && !is.null(height) && width > 100 && height > 100) {
+        # Observer 1 already wrote a valid dimension — just flip the signal.
+        log_warn(
+          sprintf(
+            "viewport_ready JS event missing after %ss — using clientData-derived dims: %dx%d",
+            fallback_delay_secs, round(width), round(height)
+          ),
+          .context = "VIEWPORT_DIMENSIONS"
+        )
+      } else {
+        # Nothing valid in app_state — use VIEWPORT_DEFAULTS.
+        set_viewport_dims(
+          app_state,
+          VIEWPORT_DEFAULTS$width,
+          VIEWPORT_DEFAULTS$height,
+          emit
+        )
+        log_warn(
+          sprintf(
+            "viewport_ready JS event missing after %ss and clientData unavailable — using VIEWPORT_DEFAULTS: %dx%d",
+            fallback_delay_secs, VIEWPORT_DEFAULTS$width, VIEWPORT_DEFAULTS$height
+          ),
+          .context = "VIEWPORT_DIMENSIONS"
+        )
+      }
+
+      viewport_ready_signal(TRUE)
+    },
+    delay = fallback_delay_secs
+  )
+
+  invisible(NULL)
 }

--- a/R/mod_spc_chart_server.R
+++ b/R/mod_spc_chart_server.R
@@ -61,7 +61,22 @@ visualizationModuleServer <- function(
     # Use caller-provided emit if available; fall back to local instance.
     # Both options wrap the same app_state$events, so no double-fire occurs.
     module_emit <- emit %||% create_emit_api(app_state)
-    register_viewport_observer(app_state, session, ns, module_emit)
+
+    # Issue #610: Gate cold-start render on real browser layout.
+    # JS ResizeObserver (inst/app/www/viewport-ready.js) fires
+    # input$viewport_ready when #visualization-spc_plot_actual has a real
+    # measurement. The observer below mirrors that into app_state and
+    # flips this signal TRUE; spc_inputs_raw req()s on it.
+    viewport_ready_signal <- shiny::reactiveVal(FALSE)
+
+    register_viewport_observer(
+      app_state = app_state,
+      session = session,
+      input = input,
+      ns = ns,
+      emit = module_emit,
+      viewport_ready_signal = viewport_ready_signal
+    )
 
     # Helper functions for app_state visualization management
     set_plot_state <- function(key, value) {
@@ -91,6 +106,8 @@ visualizationModuleServer <- function(
       chart_config = chart_config,
       session = session,
       ns = ns,
+      app_state = app_state,
+      viewport_ready_signal = viewport_ready_signal,
       y_axis_unit_reactive = y_axis_unit_reactive,
       target_value_reactive = target_value_reactive,
       target_text_reactive = target_text_reactive,

--- a/R/utils_server_visualization.R
+++ b/R/utils_server_visualization.R
@@ -160,6 +160,10 @@ setup_visualization <- function(input, output, session, app_state) {
   }), millis = DEBOUNCE_DELAYS$chart_update)
 
   # Initialiser visualiserings modul - no debouncing for valuebox stability
+  # NB: Module-id "visualization" er hardcoded i inst/app/www/viewport-ready.js
+  # (selectorer #visualization-spc_plot_actual + visualization-viewport_ready
+  # input-id). Hvis id'et omdoebes, skal JS-filen opdateres synkront — ellers
+  # silent-break af Issue #610 cold-start-gating.
   visualization <- visualizationModuleServer(
     "visualization",
     column_config_reactive = column_config,

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1,5 +1,5 @@
 metadata:
-  total_files: 181
+  total_files: 182
   audit_run: 2026-04-26T20:55:41+0200
   manifest_schema_version: '1.0'
   review_status:
@@ -1410,3 +1410,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-03'
   rationale: Tilfoejet manuelt — fil oprettet efter audit-baseline 2026-04-26.
+- file: test-viewport-ready-signal.R
+  audit_category: post-audit
+  type: integration
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-07'
+  rationale: Tilfoejet manuelt — fil oprettet ifm. Issue #610 (viewport_ready signal).

--- a/inst/app/www/viewport-ready.js
+++ b/inst/app/www/viewport-ready.js
@@ -1,0 +1,107 @@
+// viewport-ready.js
+// Issue #610: First-layout gating for SPC analysis chart.
+//
+// Shiny's session$clientData reports the CSS-default container size
+// (800x600 for renderPlot) immediately at startup, before the browser
+// has measured the actual layout. This causes spc_inputs_raw to fire
+// with synthetic dimensions, producing a doubled analysis render
+// (first at 800x600, then at the real viewport).
+//
+// This module fires a single Shiny.setInputValue("visualization-viewport_ready", ...)
+// once the browser has reported a real layout for #visualization-spc_plot_actual,
+// allowing the server-side reactive chain to gate cold-start evaluation
+// until real dimensions are known.
+//
+// Fallback: if ResizeObserver is unavailable or the element never reaches
+// a real size, the server-side timeout (later::later(2s)) takes over.
+
+(function () {
+  'use strict';
+
+  // Module ID hardcoded — visualizationModuleServer always called with
+  // id = "visualization" (see R/utils_server_visualization.R:163).
+  var TARGET_INPUT_ID = 'visualization-viewport_ready';
+  var TARGET_ELEMENT_ID = 'visualization-spc_plot_actual';
+
+  // Minimum dimension to treat as "real layout" — anything smaller is
+  // either still hidden (display:none returns 0) or a transient state.
+  var MIN_DIM_PX = 100;
+
+  function sendReady(width, height) {
+    if (typeof Shiny === 'undefined' || !Shiny.setInputValue) {
+      return false;
+    }
+    Shiny.setInputValue(
+      TARGET_INPUT_ID,
+      {
+        width: Math.round(width),
+        height: Math.round(height),
+        ts: Date.now()
+      },
+      { priority: 'event' }
+    );
+    console.log('[VIEWPORT_READY] fired', { width: Math.round(width), height: Math.round(height) });
+    return true;
+  }
+
+  function attachObserver() {
+    var el = document.getElementById(TARGET_ELEMENT_ID);
+    if (!el) {
+      // Element not yet rendered — Shiny may not have created the
+      // namespaced output container yet. Retry on next animation frame.
+      window.requestAnimationFrame(attachObserver);
+      return;
+    }
+
+    // If ResizeObserver is unavailable (very old browsers, headless tests
+    // without ResizeObserver polyfill), measure synchronously once and let
+    // the server-side timeout fallback handle re-measure.
+    if (typeof window.ResizeObserver !== 'function') {
+      console.warn('[VIEWPORT_READY] ResizeObserver unavailable, sending one-shot measurement');
+      var rect = el.getBoundingClientRect();
+      if (rect.width > MIN_DIM_PX && rect.height > MIN_DIM_PX) {
+        sendReady(rect.width, rect.height);
+      }
+      // No retry — server-side timeout will fall back if this fails.
+      return;
+    }
+
+    var fired = false;
+    var observer = new ResizeObserver(function (entries) {
+      if (fired) return;
+      for (var i = 0; i < entries.length; i++) {
+        var entry = entries[i];
+        var box = entry.contentRect;
+        if (box.width > MIN_DIM_PX && box.height > MIN_DIM_PX) {
+          if (sendReady(box.width, box.height)) {
+            fired = true;
+            observer.disconnect();
+            break;
+          }
+        }
+      }
+    });
+
+    observer.observe(el);
+
+    // Belt-and-suspenders: if the observer hasn't fired within 1500 ms
+    // (e.g., element hidden behind tab), measure synchronously and send
+    // best-effort. Server-side timeout (2 s) is the ultimate fallback.
+    setTimeout(function () {
+      if (fired) return;
+      var rect = el.getBoundingClientRect();
+      if (rect.width > MIN_DIM_PX && rect.height > MIN_DIM_PX) {
+        if (sendReady(rect.width, rect.height)) {
+          fired = true;
+          observer.disconnect();
+        }
+      }
+    }, 1500);
+  }
+
+  $(document).on('shiny:sessioninitialized', function () {
+    // Defer until after Shiny binds outputs so the namespaced container
+    // exists in the DOM.
+    window.requestAnimationFrame(attachObserver);
+  });
+})();

--- a/tests/testthat/test-mod-spc-chart-comprehensive.R
+++ b/tests/testthat/test-mod-spc-chart-comprehensive.R
@@ -417,6 +417,9 @@ describe("Error Handling", {
         app_state = app_state
       ),
       {
+        # Issue #610: spc_inputs_raw er gated paa viewport_ready_signal.
+        # Send JS-event for at flippe signalet og lade pipelinen evaluere.
+        session$setInputs(viewport_ready = list(width = 800, height = 600, ts = 1))
         # session$elapse driver debounce-timers (input_change 150ms + file_select 500ms)
         session$flushReact()
         session$elapse(millis = 1500)

--- a/tests/testthat/test-viewport-ready-signal.R
+++ b/tests/testthat/test-viewport-ready-signal.R
@@ -1,0 +1,350 @@
+# test-viewport-ready-signal.R
+# Issue #610: Tests for viewport_ready signal that gates SPC analysis
+# cold-start render until browser has produced a real layout measurement.
+#
+# Key invariants verified:
+#   1. spc_inputs_raw is gated on viewport_ready_signal (cold-start blocking)
+#   2. JS event input$viewport_ready flips signal + writes app_state dims
+#   3. later::later(2s) timeout fallback flips signal even without JS event
+#   4. Legitim 800x600 viewport from JS is NOT filtered (no hardcoded ban)
+#   5. Single source of truth: spc_inputs reads viewport from app_state,
+#      not from session$clientData directly
+
+library(shiny)
+library(testthat)
+
+# Helper aligned with test-mod-spc-chart-comprehensive.R
+create_mock_app_state <- function() {
+  app_state <- new.env(parent = emptyenv())
+  app_state$events <- reactiveValues(
+    visualization_update_needed = 0L,
+    navigation_changed = 0L
+  )
+  app_state$data <- reactiveValues(current_data = NULL, updating_table = FALSE)
+  app_state$visualization <- reactiveValues(
+    module_cached_data = NULL,
+    module_data_cache = NULL,
+    cache_updating = FALSE,
+    plot_ready = FALSE,
+    plot_warnings = character(0),
+    is_computing = FALSE,
+    plot_generation_in_progress = FALSE,
+    plot_object = NULL,
+    anhoej_results = NULL,
+    last_centerline_value = NULL,
+    viewport_dims = list(width = NULL, height = NULL, last_updated = NULL)
+  )
+  app_state$columns <- reactiveValues(
+    auto_detect = reactiveValues(
+      in_progress = FALSE, completed = FALSE,
+      results = NULL, frozen_until_next_trigger = FALSE
+    ),
+    mappings = reactiveValues(x_column = NULL, y_column = NULL, n_column = NULL)
+  )
+  app_state$ui <- reactiveValues(hide_anhoej_rules = FALSE)
+  app_state
+}
+
+describe("Issue #610: viewport_ready signal", {
+  it("input$viewport_ready event flips signal + writes app_state dims", {
+    require_internal("visualizationModuleServer", mode = "function")
+    skip_if_not_installed("later")
+
+    app_state <- create_mock_app_state()
+
+    testServer(
+      visualizationModuleServer,
+      args = list(
+        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
+        chart_type_reactive = reactive("i"),
+        target_value_reactive = reactive(NULL),
+        target_text_reactive = reactive(NULL),
+        centerline_value_reactive = reactive(NULL),
+        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
+        frys_config_reactive = reactive(NULL),
+        app_state = app_state
+      ),
+      {
+        # Simuler JS-event: ResizeObserver har maalt en reel layout
+        session$setInputs(viewport_ready = list(width = 1024, height = 600, ts = 12345))
+        session$flushReact()
+
+        dims <- shiny::isolate(app_state$visualization$viewport_dims)
+        expect_equal(dims$width, 1024,
+          info = "viewport_ready event skal opdatere app_state width"
+        )
+        expect_equal(dims$height, 600,
+          info = "viewport_ready event skal opdatere app_state height"
+        )
+      }
+    )
+  })
+
+  it("legitim 800x600 viewport accepteres (ingen hardcoded ban)", {
+    # Codex review: hardcoded `width != 800 || height != 600` guard er IKKE
+    # sikker — reelle browser-viewports kan legitimt vaere 800x600.
+    require_internal("visualizationModuleServer", mode = "function")
+    skip_if_not_installed("later")
+
+    app_state <- create_mock_app_state()
+
+    testServer(
+      visualizationModuleServer,
+      args = list(
+        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
+        chart_type_reactive = reactive("i"),
+        target_value_reactive = reactive(NULL),
+        target_text_reactive = reactive(NULL),
+        centerline_value_reactive = reactive(NULL),
+        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
+        frys_config_reactive = reactive(NULL),
+        app_state = app_state
+      ),
+      {
+        # Simuler reel 800x600 browser-viewport via JS-event
+        session$setInputs(viewport_ready = list(width = 800, height = 600, ts = 99999))
+        session$flushReact()
+
+        dims <- shiny::isolate(app_state$visualization$viewport_dims)
+        expect_equal(dims$width, 800,
+          info = "Reel 800x600 viewport skal accepteres, ikke filtreres"
+        )
+        expect_equal(dims$height, 600,
+          info = "Reel 800x600 viewport skal accepteres, ikke filtreres"
+        )
+      }
+    )
+  })
+
+  it("invalid viewport_ready payload ignoreres (defensive)", {
+    require_internal("visualizationModuleServer", mode = "function")
+    skip_if_not_installed("later")
+
+    app_state <- create_mock_app_state()
+    # Pre-set kendt vaerdi for at kunne detektere uoenskede skrivninger
+    app_state$visualization$viewport_dims <- list(
+      width = 600, height = 400, last_updated = Sys.time()
+    )
+
+    testServer(
+      visualizationModuleServer,
+      args = list(
+        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
+        chart_type_reactive = reactive("i"),
+        target_value_reactive = reactive(NULL),
+        target_text_reactive = reactive(NULL),
+        centerline_value_reactive = reactive(NULL),
+        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
+        frys_config_reactive = reactive(NULL),
+        app_state = app_state
+      ),
+      {
+        # NULL payload — observer skal ignorere
+        session$setInputs(viewport_ready = NULL)
+        session$flushReact()
+
+        # Width <= 100 — observer skal ignorere
+        session$setInputs(viewport_ready = list(width = 50, height = 400, ts = 1))
+        session$flushReact()
+
+        # mockclientdata vil dog skrive 600x400 via Observer 1, saa vi
+        # kan ikke direkte teste at viewport_ready-payload blev ignoreret.
+        # Indirekte test: signalet flippes IKKE af invalid payload alene.
+        # (Vi kan ikke direkte assert paa det interne signal her — men hvis
+        # observer-logikken var brudt, ville set_viewport_dims overskrive
+        # med invalid vaerdier hvilket vi tjekker for.)
+        dims <- shiny::isolate(app_state$visualization$viewport_dims)
+        expect_true(is.null(dims$width) || dims$width >= 100,
+          info = "Invalid viewport_ready-payload (width<100) maa ikke skrive til app_state"
+        )
+      }
+    )
+  })
+
+  it("spc_inputs uses viewport from app_state, not clientData (single source)", {
+    # Issue #610 single-source-invariant: efter denne PR laeses viewport
+    # i create_spc_inputs_reactive fra get_viewport_dims(app_state), IKKE
+    # fra session$clientData direkte. Verificerer ved at saette kendt
+    # vaerdi i app_state og bekraefte at compute-pipelinen bruger den.
+    require_internal("create_spc_inputs_reactive", mode = "function")
+
+    app_state <- create_mock_app_state()
+    # Saet kendte dims i app_state
+    app_state$visualization$viewport_dims <- list(
+      width = 1280, height = 720, last_updated = Sys.time()
+    )
+
+    # Reactive-baseret unit-test: byg reactive-graf direkte
+    test_data <- data.frame(
+      Dato = as.Date("2024-01-01") + 0:9,
+      Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
+    )
+
+    shiny::testServer(
+      function(id) {
+        shiny::moduleServer(id, function(input, output, session) {
+          # Simuler at viewport_ready_signal allerede er flippet
+          viewport_ready_signal <- shiny::reactiveVal(TRUE)
+
+          data_ready_reactive <- shiny::reactive(test_data)
+          chart_config_reactive <- shiny::reactive(
+            list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
+          )
+
+          spc_inputs <- create_spc_inputs_reactive(
+            data_ready_reactive = data_ready_reactive,
+            chart_config = chart_config_reactive,
+            session = session,
+            ns = session$ns,
+            app_state = app_state,
+            viewport_ready_signal = viewport_ready_signal,
+            y_axis_unit_reactive = shiny::reactive("count")
+          )
+
+          observe({
+            inputs <- spc_inputs()
+            session$userData$captured_inputs <- inputs
+          })
+        })
+      },
+      {
+        session$flushReact()
+        captured <- session$userData$captured_inputs
+        expect_false(is.null(captured),
+          info = "spc_inputs skal evaluere efter signal flippes TRUE"
+        )
+        expect_equal(captured$viewport_width_px, 1280,
+          info = "spc_inputs skal laese width fra app_state, ikke clientData"
+        )
+        expect_equal(captured$viewport_height_px, 720,
+          info = "spc_inputs skal laese height fra app_state, ikke clientData"
+        )
+      }
+    )
+  })
+
+  it("spc_inputs blocks until viewport_ready_signal flips TRUE (cold-start gate)", {
+    require_internal("create_spc_inputs_reactive", mode = "function")
+
+    app_state <- create_mock_app_state()
+    app_state$visualization$viewport_dims <- list(
+      width = 1024, height = 600, last_updated = Sys.time()
+    )
+
+    test_data <- data.frame(
+      Dato = as.Date("2024-01-01") + 0:9,
+      Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
+    )
+
+    shiny::testServer(
+      function(id) {
+        shiny::moduleServer(id, function(input, output, session) {
+          # Signal starter FALSE — som i prod cold-start
+          viewport_ready_signal <- shiny::reactiveVal(FALSE)
+
+          data_ready_reactive <- shiny::reactive(test_data)
+          chart_config_reactive <- shiny::reactive(
+            list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
+          )
+
+          spc_inputs <- create_spc_inputs_reactive(
+            data_ready_reactive = data_ready_reactive,
+            chart_config = chart_config_reactive,
+            session = session,
+            ns = session$ns,
+            app_state = app_state,
+            viewport_ready_signal = viewport_ready_signal,
+            y_axis_unit_reactive = shiny::reactive("count")
+          )
+
+          eval_count <- 0
+          observe({
+            tryCatch(
+              {
+                spc_inputs()
+                eval_count <<- eval_count + 1
+              },
+              error = function(e) NULL # nolint: swallowed_error_linter
+            )
+          })
+
+          # Eksponer eval_count + signal til outer test
+          session$userData$eval_count_fn <- function() eval_count
+          session$userData$flip_signal <- function() viewport_ready_signal(TRUE)
+        })
+      },
+      {
+        session$flushReact()
+        # Signal er FALSE — req() blokker, ingen full evaluation
+        count_before <- session$userData$eval_count_fn()
+        expect_equal(count_before, 0,
+          info = "spc_inputs maa IKKE evaluere foer viewport_ready_signal er TRUE"
+        )
+
+        # Flip signal — spc_inputs skal nu evaluere
+        session$userData$flip_signal()
+        session$flushReact()
+
+        count_after <- session$userData$eval_count_fn()
+        # Acceptkriterium #610: "FONT_SCALING log entry appears exactly once
+        # per upload (not twice)". Hver spc_inputs-evaluering trigger en
+        # FONT_SCALING log-linje, saa eval_count == 1 svarer til log == 1.
+        expect_equal(count_after, 1,
+          info = paste0(
+            "spc_inputs skal evaluere PRAECIS ÉN gang efter signal flippes TRUE ",
+            "(forhindrer dobbelt-render fra Issue #610). Faktisk: ",
+            count_after
+          )
+        )
+      }
+    )
+  })
+
+  it("fallback scheduler flipper signal selv uden JS-event", {
+    # Acceptkriterium: "No regression for environments where clientData is
+    # unavailable". Headless/JS-disabled miljoer — fallback-timeren skal
+    # flippe signalet alligevel. Tester via injiceret synkron scheduler
+    # for deterministisk eksekvering uden afhaengighed af later::later
+    # globale koe (state-pollution mellem tests).
+    require_internal("register_viewport_observer", mode = "function")
+
+    app_state <- create_mock_app_state()
+    viewport_ready_signal <- shiny::reactiveVal(FALSE)
+
+    # Synkron scheduler — kalder callback straks
+    sync_scheduler <- function(callback, delay) {
+      callback()
+    }
+
+    shiny::testServer(
+      function(id) {
+        shiny::moduleServer(id, function(input, output, session) {
+          emit <- create_emit_api(app_state)
+          register_viewport_observer(
+            app_state = app_state,
+            session = session,
+            input = input,
+            ns = session$ns,
+            emit = emit,
+            viewport_ready_signal = viewport_ready_signal,
+            fallback_delay_secs = 0,
+            .scheduler = sync_scheduler
+          )
+        })
+      },
+      {
+        session$flushReact()
+
+        expect_true(shiny::isolate(viewport_ready_signal()),
+          info = "Fallback-scheduler skal flippe signal TRUE selv uden JS-event"
+        )
+        # Fallback skal saette VIEWPORT_DEFAULTS i app_state naar clientData/
+        # eksisterende dims er tomme.
+        dims <- shiny::isolate(app_state$visualization$viewport_dims)
+        expect_false(is.null(dims$width),
+          info = "Fallback skal skrive width til app_state"
+        )
+      }
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Implementerer `viewport_ready`-signal til at eliminere dobbelt-render af analyse-graf efter data-upload (Issue #610).

- **JS** (`inst/app/www/viewport-ready.js`): `ResizeObserver` på `#visualization-spc_plot_actual` sender `viewport_ready`-event til serveren først når browseren har målt en reel layout (>100×100 px). Disconnect efter første fire.
- **Server-gate**: `spc_inputs_raw` `req()`er på `viewport_ready_signal` (`reactiveVal(FALSE)`). Signal flippes TRUE af enten JS-event eller `later::later(2s)` fallback (headless tests, JS deaktiveret).
- **Single source of truth**: `spc_inputs` er nu eneste viewport-kilde i compute + cache. Tidligere split-brain mellem `FONT_SCALING`'s viewport (clientData direkte) og BFHcharts-kaldets viewport (`get_viewport_dims(app_state)`) er elimineret.
- **Bevaret**: `output\$spc_plot_actual` `renderPlot` 800×600-fallback (intentional canvas-sizing — markeret keep i issue).

## Acceptance criteria

- [x] `FONT_SCALING` log appears exactly once per upload — verificeret via test der asserter `spc_inputs` eval_count == 1 efter signal-flip (`tests/testthat/test-viewport-ready-signal.R`).
- [x] `SPC-COMPUTATION CACHE MISS` appears exactly once per upload for analyse-context — viewport nu single source i cache-key, så ingen dobbelt-cache-key fra dimension-ændring.
- [x] No regression for environments where clientData is unavailable — `later::later(2s)` fallback flipper signal med `VIEWPORT_DEFAULTS` hvis JS aldrig fyrer.
- [x] Tests: mock viewport_ready message + verify `spc_inputs_raw` blocks until signal received — 6 nye tests i `test-viewport-ready-signal.R`.
- [x] Hardcoded 800×600 filter undgået (Codex MEDIUM/HIGH risiko) — test verificerer at legitim 800×600 viewport accepteres.

## Test plan

- [x] Nye tests: 6 tests passer (`test-viewport-ready-signal.R`)
- [x] Eksisterende test opdateret: `test-mod-spc-chart-comprehensive.R:419` injicerer nu `viewport_ready`-event for at lade pipelinen evaluere
- [x] Full test-suite: 2101 tests, 0 fail, 0 error, 79 skip
- [x] Pre-push gate: passed (fast mode, 66s)
- [ ] **[MANUELT TRIN]** Verificér i browser via `dev/run_dev.R`: upload data + tæl `[FONT_SCALING]`-log-linjer (skal være 1, ikke 2)

## Related

- Closes #610
- Issue #611 (Batch 2) merged separately — denne PR adresserer analyse double-render-rod
- Codex feasibility-review (issue-comment) drev single-source design