### PR TITLE
docs(workaround): link Danish-char workaround til BFHcharts#327 (closes #562)

### DIFF
--- a/R/fct_spc_bfh_params.R
+++ b/R/fct_spc_bfh_params.R
@@ -304,11 +304,11 @@ map_to_bfh_params <- function(
     operation_name = "BFHchart parameter mapping",
     code = {
       # 1. .original_row_id allerede injiceret foer safe_operation (se trin 0 ovenfor).
-      # 1b. WORKAROUND (M8 #462): BFHcharts rejects Danish characters (æøå)
-      # i column names — biSPCharts ASCII-translit'er navnene før kald +
-      # rev-mapper output for at bevare brugerens originale navne i UI.
-      # FOLLOW-UP: åbn issue i BFHcharts for native Danish-character-support
-      # i column-name-validator, og fjern denne workaround når levereret.
+      # 1b. WORKAROUND: BFHcharts rejects Danish characters (æøå) i column
+      # names — biSPCharts ASCII-translit'er navnene før kald + rev-mapper
+      # output for at bevare brugerens originale navne i UI.
+      # FOLLOW-UP: BFHcharts#327 — fjern workaround når upstream leverer
+      # native Danish-character-support i column-name-validator.
       build_bfh_params_core(
         data = data,
         col_mapping = col_mapping,


### PR DESCRIPTION
## Ændringer

Audit af WORKAROUND/legacy-markers fra issue #562 fundet:

| Type | Antal | Status |
|---|---|---|
| Intern API-evolution (\`legacy parameter\`, \`legacy fallback\`) | ~60 | OK — biSPCharts-internt, ikke sibling-pakke gap |
| Sibling-pakke workaround | **1** | Mangler upstream-link |
| Local milestone-ref (#462) | 1 | OK — refererer biSPCharts-internt |

Issue-claim om "42 markers i 4 filer der mangler upstream-tracking" var overdrevet. Kun **én** ægte sibling-pakke workaround i \`R/fct_spc_bfh_params.R:307-311\` (ASCII-translit for danske kolonnenavne).

## Fix

1. Oprettet upstream issue: [BFHcharts#327](https://github.com/johanreventlow/BFHcharts/issues/327) — \"Native Danish character support in column-name validator\"
2. Opdateret comment fra \`FOLLOW-UP: åbn issue i BFHcharts\` til \`FOLLOW-UP: BFHcharts#327\` for cross-repo-tracking

Når BFHcharts#327 leveres, kan \`ascii_column_name_for_bfh()\` + reverse-mapping fjernes.

## Test plan

- [x] lintr/pre-push grøn
- [x] Ingen funktionel ændring (kun comment)

Closes #562