### PR TITLE
docs: fix utils_event_system refs + ADR README gap (#530, #531)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ observeEvent(app_state$events$data_updated,
 })
 ```
 
-**Filer:** `global.R` (events), `R/utils_event_system.R` (`setup_event_listeners()`),
+**Filer:** `global.R` (events), `R/utils_server_event_listeners.R` (`setup_event_listeners()`),
 emit API via `create_emit_api()`.
 
 ### App State Structure

--- a/R/config_observer_priorities.R
+++ b/R/config_observer_priorities.R
@@ -8,10 +8,10 @@
 # ANVENDES AF:
 #   - Alle observeEvent() calls med priority parameter
 #   - Race condition prevention system
-#   - Event-bus listeners i utils_event_system.R
+#   - Event-bus listeners i utils_server_event_listeners.R
 #
 # RELATERET:
-#   - utils_event_system.R - Event listener setup
+#   - utils_server_event_listeners.R - Event listener setup
 #   - CLAUDE.md Section 3.1.1 - Race Condition Prevention
 #   - See: docs/CONFIGURATION.md for complete guide
 # ==============================================================================

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -143,6 +143,30 @@ ADRs er **immutable** efter accept:
 |-----|-------|--------|------|
 | [ADR-001](./ADR-001-pure-bfhcharts-workflow.md) | Pure BFHcharts Workflow for SPC Calculation | Accepted | 2025-10-10 |
 | [ADR-002](./ADR-002-ui-sync-throttle-250ms.md) | UI Sync Throttle 250ms | Accepted | 2025-10-10 |
+| [ADR-014](./ADR-014-deprecate-optimized-event-pipeline.md) | Deprecate Optimized Event Pipeline | Accepted | — |
+| [ADR-015](./ADR-015-bfhchart-migrering.md) | BFHcharts Migration (Hybrid Architecture) | Accepted | — |
+| [ADR-016](./ADR-016-gemini-integration.md) | Gemini AI Integration | Accepted | — |
+| [ADR-017](./ADR-017-test-regression-gate-design.md) | Test Regression Gate Design | Accepted | — |
+| [ADR-018](./ADR-018-minimal-public-api-surface.md) | Minimal Public API Surface | Accepted | — |
+| [ADR-019](./ADR-019-production-entrypoint-and-pkgload-boundary.md) | Production Entrypoint and pkgload Boundary | Accepted | — |
+
+### Nummereringsgap: ADR-003..ADR-013
+
+ADR-numrene 003-013 er **ikke allokerede**. Følgende load-bearing
+arkitektoniske beslutninger bør retroaktivt dokumenteres som ADRs (se
+issue #531 — udskudt arbejde):
+
+- Unified event-architecture (event-bus + emit + prioriterede observers)
+- Centraliseret app_state-design + hierarkisk reactiveValues-struktur
+- Session-persistence via localStorage (issue #193)
+- Hybrid Anti-Race Strategy (5-lags race-prevention)
+
+Indtil ADRs er skrevet, refererer CLAUDE.md (sektion 2) til den primære
+kode-implementation: `R/utils_server_event_listeners.R`,
+`R/state_management.R`, `R/utils_local_storage.R`.
+
+Nye ADRs efter denne note bør fortsætte fra ADR-020+ for at undgå
+forvirring med det dokumenterede gap.
 
 ## Søgning i ADRs
 


### PR DESCRIPTION
## Summary

- CLAUDE.md sektion 2 + config_observer_priorities.R: rette stale ref `utils_event_system.R` → `utils_server_event_listeners.R`
- docs/adr/README.md: tabel udvidet med ADR-014..019; nummereringsgap ADR-003..013 dokumenteret med liste over load-bearing beslutninger der mangler retroaktive ADRs

## Test plan
- [x] grep verificeret ingen utils_event_system-refs tilbage
- [x] ADR-tabel matcher faktiske filer i docs/adr/

Fixes #530
Refs #531 (delvis — kun README/refs; full ADR-skrivning udskudt)