### PR TITLE
fix(reactive): debounce-leak + timeout-aktivitet + main_navbar-konsolidering (#533, #534, #536)

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -226,17 +226,27 @@ main_app_server <- function(input, output, session) {
   ## Track forrige tab for kontekstuel tilbagenavigation paa hjaelpesider
   current_tab <- shiny::reactiveVal("start")
   previous_tab <- shiny::reactiveVal("start")
-  shiny::observeEvent(input$main_navbar, ignoreInit = TRUE, {
-    new_tab <- input$main_navbar
-    old_tab <- current_tab()
-    help_tabs <- c("app_guide", "hjaelp")
-    if (new_tab %in% help_tabs) {
-      previous_tab(old_tab)
+  # Issue #536: Konsolideret main_navbar-observer.
+  # Tidligere fandtes en duplikeret observer i utils_server_event_listeners.R
+  # som emittede navigation_changed. Vi konsoliderer her med STATE_MANAGEMENT-
+  # priority for at garantere active_tab er sat FØR navigation_changed-listeners
+  # (STATUS_UPDATES = 500) afvikles. Atomisk: state-write → emit.
+  shiny::observeEvent(input$main_navbar,
+    ignoreInit = TRUE,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      new_tab <- input$main_navbar
+      old_tab <- current_tab()
+      help_tabs <- c("app_guide", "hjaelp")
+      if (new_tab %in% help_tabs) {
+        previous_tab(old_tab)
+      }
+      current_tab(new_tab)
+      # Opdater app_state saa eksport-observere kan gate paa aktiv tab (Issue #394)
+      app_state$session$active_tab <- new_tab
+      emit$navigation_changed()
     }
-    current_tab(new_tab)
-    # Opdater app_state saa eksport-observere kan gate paa aktiv tab (Issue #394)
-    app_state$session$active_tab <- new_tab
-  })
+  )
 
   ## App-vejledning modul (tilbagenavigation til forrige tab)
   mod_app_guide_server("app_guide", parent_session = session, previous_tab = previous_tab)

--- a/R/utils_server_event_listeners.R
+++ b/R/utils_server_event_listeners.R
@@ -135,17 +135,10 @@ setup_event_listeners <- function(app_state, emit, input, output, session, ui_se
   # 7. Wizard navigation gates (utils_server_wizard_gates.R)
   setup_wizard_gates(input, output, app_state, session)
 
-  # Issue #193: Bridge manuel tab-skift til event-bus
-  register_observer(
-    "main_navbar_manual",
-    shiny::observeEvent(input$main_navbar,
-      ignoreInit = TRUE,
-      priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
-      {
-        emit$navigation_changed()
-      }
-    )
-  )
+  # Issue #536: main_navbar-observer er konsolideret til app_server_main.R
+  # (med STATE_MANAGEMENT-priority for at sikre state-write FØR emit). Den
+  # tidligere duplikerede observer her er fjernet for at undgå race condition
+  # hvor navigation_changed-listeners så stale active_tab.
 
   # 8. Paste data og sample data observers (utils_server_paste_data.R)
   setup_paste_data_observers(input, output, app_state, session, emit, ui_service)

--- a/R/utils_server_events_navigation.R
+++ b/R/utils_server_events_navigation.R
@@ -29,6 +29,31 @@
 register_navigation_events <- function(app_state, emit, session, register_observer) {
   observers <- list()
 
+  # Session-scoped debounce trigger for test_mode_ready (issue #533)
+  # Construct debounce reactive ONCE per session — not per observer firing,
+  # which would leak reactive objects.
+  test_mode_trigger <- shiny::reactiveVal(0L)
+  test_mode_debounce_ms <- shiny::isolate(app_state$test_mode$debounce_delay) %||% 500
+  debounced_test_mode <- shiny::debounce(
+    shiny::reactive({
+      test_mode_trigger()
+    }),
+    millis = test_mode_debounce_ms
+  )
+
+  observers$test_mode_debounced <- register_observer(
+    "test_mode_debounced",
+    shiny::observeEvent(debounced_test_mode(),
+      ignoreInit = TRUE,
+      priority = OBSERVER_PRIORITIES$AUTO_DETECT,
+      {
+        if (isTRUE(app_state$test_mode$race_prevention_active)) {
+          emit$test_mode_debounced_autodetect()
+        }
+      }
+    )
+  )
+
   # Navigation changed
   observers$navigation_changed <- register_observer(
     "navigation_changed",
@@ -137,18 +162,8 @@ register_navigation_events <- function(app_state, emit, session, register_observ
         data_available <- !is.null(app_state$data$current_data)
 
         if (data_available && !autodetect_completed) {
-          debounce_delay <- app_state$test_mode$debounce_delay %||% 500
-
-          debounced_test_mode_trigger <- shiny::debounce(
-            shiny::reactive({
-              if (app_state$test_mode$race_prevention_active) {
-                emit$test_mode_debounced_autodetect()
-              }
-            }),
-            millis = debounce_delay
-          )
-
-          debounced_test_mode_trigger()
+          # Trigger session-scoped debounce reactive (#533).
+          test_mode_trigger(shiny::isolate(test_mode_trigger()) + 1L)
         } else if (autodetect_completed) {
           emit$ui_sync_needed()
         }

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -141,12 +141,32 @@ activate_session_timeout_from_config <- function(input, session,
     .scheduler = .scheduler
   )
 
-  # Nulstil timer ved enhver input-aendring
-  shiny::observe({
-    # Touch alle inputs for at oprette reaktiv afhaengighed
-    shiny::reactiveValuesToList(input)
-    timeout_handle$reset()
-  })
+  # Nulstil timer ved konkrete bruger-handlinger (issue #534).
+  # Tidligere brugte vi reactiveValuesToList(input) — det touchede ALLE inputs
+  # inkl. programmatiske updateSelectizeInput-kald (chart-type sync, restore-flow),
+  # hvilket undergravede "brugeraktivitet"-semantikken.
+  user_activity_inputs <- c(
+    "main_navbar", # tab-skift
+    "data_file", # primaer file-upload
+    "direct_file_upload", # paste/sample alternative file-upload
+    "load_paste_data", # paste-knap
+    "selected_sample", # sample-data valg
+    "trigger_file_upload", # file-upload trigger-knap
+    "selected_excel_sheet", # Excel sheet-valg
+    "manual_autodetect_button", # eksplicit autodetect
+    "back_to_upload", # wizard tilbage
+    "continue_to_export", # wizard fortsaet
+    "toggle_sample_dropdown" # sample-dropdown toggle
+  )
+
+  for (input_id in user_activity_inputs) {
+    local({
+      id <- input_id
+      shiny::observeEvent(input[[id]], ignoreInit = TRUE, {
+        timeout_handle$reset()
+      })
+    })
+  }
 
   # Annuller timer naar session lukker
   session$onSessionEnded(function() {

--- a/tests/testthat/test-utils_server_event_listeners.R
+++ b/tests/testthat/test-utils_server_event_listeners.R
@@ -38,12 +38,6 @@ test_that("setup_event_listeners orchestrates modular registrars and cleanup", {
   )
 
   testthat::local_mocked_bindings(
-    observeEvent = function(eventExpr, handlerExpr, ...) {
-      make_fake_observer("main_navbar_manual", state)
-    },
-    .package = "shiny"
-  )
-  testthat::local_mocked_bindings(
     register_data_lifecycle_events = make_event_registrar("data", state),
     register_autodetect_events = make_event_registrar("autodetect", state),
     register_ui_sync_events = make_event_registrar("ui", state),
@@ -73,10 +67,13 @@ test_that("setup_event_listeners orchestrates modular registrars and cleanup", {
     state$calls,
     c("data", "autodetect", "ui", "navigation", "chart", "wizard", "paste")
   )
+  # Issue #536: main_navbar-observer er konsolideret til app_server_main.R,
+  # så `main_navbar_manual` skal IKKE længere findes i event_listeners-registry.
   expect_true(all(c(
     "data_observer", "autodetect_observer", "ui_observer",
-    "navigation_observer", "chart_observer", "main_navbar_manual"
+    "navigation_observer", "chart_observer"
   ) %in% names(registry)))
+  expect_false("main_navbar_manual" %in% names(registry))
   expect_true(is.function(ended_callback))
 
   ended_callback()


### PR DESCRIPTION
## Summary

Tre relaterede observer-hygiene-bugs i én commit (samme cluster).

### #533 Debounce memory leak
`shiny::debounce(reactive())` blev konstrueret inde i `test_mode_ready`-observer-body i `utils_server_events_navigation.R` → ny reactive pr. firing → leak. Hejset til session-scope: shared `reactiveVal` + debounce-wrapper oprettes én gang.

### #534 Timeout-reset på programmatiske inputs
`shiny::observe(reactiveValuesToList(input))` i `utils_server_session_helpers.R` touchede ALLE inputs inkl. programmatiske `updateSelectizeInput`-kald (chart-type sync, restore-flow), hvilket undergravede bruger-aktivitets-semantikken. Erstattet med eksplicit liste over bruger-trigger-inputs.

### #536 Duplikeret main_navbar-observer
`app_server_main.R` skrev `active_tab` uden priority; `event_listeners.R` emittede `navigation_changed` med `STATUS_UPDATES` (500). Forbrugere af `navigation_changed` kunne læse stale `active_tab`. Konsolideret til én observer i `app_server_main.R` med `STATE_MANAGEMENT`-priority (2000). Atomisk: state-write → emit.

## Test plan
- [x] testthat suite session/navigation/event filter: 443 PASS, 1 SKIP, 0 FAIL
- [x] Test-stub for `main_navbar_manual` opdateret til at forvente fjernet observer

Fixes #533
Fixes #534
Fixes #536