### PR TITLE
fix(reactive): eksplicit observer priority + dokumentér data_updated cycles (#535, #539)

### DIFF
--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -136,139 +136,144 @@ validate_safe_file_path <- function(uploaded_path) {
 setup_file_upload <- function(input, output, session, app_state, emit, ui_service = NULL) {
   # Unified state: App state is always available
 
-  # File upload handler
-  shiny::observeEvent(input$data_file, ignoreInit = TRUE, {
-    # RATE LIMITING: Prevent DoS via rapid uploads
-    # Uses RATE_LIMITS$file_upload_seconds for centralized security configuration
-    last_upload_time <- shiny::isolate(app_state$session$last_upload_time)
-    if (!is.null(last_upload_time)) {
-      time_since_upload <- as.numeric(difftime(Sys.time(), last_upload_time, units = "secs"))
-      min_upload_interval <- RATE_LIMITS$file_upload_seconds
+  # File upload handler — STATE_MANAGEMENT da upload muterer current_data + triggerer
+  # autodetect og persistence (#535).
+  shiny::observeEvent(input$data_file,
+    ignoreInit = TRUE,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      # RATE LIMITING: Prevent DoS via rapid uploads
+      # Uses RATE_LIMITS$file_upload_seconds for centralized security configuration
+      last_upload_time <- shiny::isolate(app_state$session$last_upload_time)
+      if (!is.null(last_upload_time)) {
+        time_since_upload <- as.numeric(difftime(Sys.time(), last_upload_time, units = "secs"))
+        min_upload_interval <- RATE_LIMITS$file_upload_seconds
 
-      if (time_since_upload < min_upload_interval) {
-        shiny::showNotification(
-          "Vent venligst et \u00f8jeblik, f\u00f8r du uploader en ny fil.",
-          type = "warning",
-          duration = 3
+        if (time_since_upload < min_upload_interval) {
+          shiny::showNotification(
+            "Vent venligst et \u00f8jeblik, f\u00f8r du uploader en ny fil.",
+            type = "warning",
+            duration = 3
+          )
+          log_warn(
+            paste("Upload rate limit triggered - last upload", round(time_since_upload, 1), "seconds ago"),
+            .context = "FILE_UPLOAD_SECURITY",
+            details = list(session_id = sanitize_session_token(session$token))
+          )
+          return()
+        }
+      }
+
+      shiny::req(input$data_file)
+
+      # Luk upload-modal automatisk naar fil er valgt (#167)
+      shiny::removeModal()
+
+      # Start workflow tracer for file upload
+      # SPRINT 1 SECURITY FIX: Sanitize session token before logging
+      upload_tracer <- debug_workflow_tracer("file_upload_workflow", app_state, sanitize_session_token(session$token))
+      upload_tracer$step("upload_initiated")
+
+
+      log_info("File upload started",
+        .context = "FILE_UPLOAD_FLOW",
+        details = list(
+          filename = input$data_file$name,
+          size_bytes = input$data_file$size,
+          file_type = input$data_file$type
         )
-        log_warn(
-          paste("Upload rate limit triggered - last upload", round(time_since_upload, 1), "seconds ago"),
-          .context = "FILE_UPLOAD_SECURITY",
-          details = list(session_id = sanitize_session_token(session$token))
+      )
+
+      upload_tracer$step("file_validation")
+
+      # ENHANCED FILE VALIDATION
+      # SPRINT 1 SECURITY FIX: Sanitize session token before logging
+      validation_result <- validate_uploaded_file(input$data_file, sanitize_session_token(session$token))
+      if (!validation_result$valid) {
+        upload_tracer$complete("file_validation_failed")
+        log_error("File validation failed",
+          .context = "ERROR_HANDLING",
+          details = list(
+            validation_errors = validation_result$errors,
+            filename = input$data_file$name
+          )
+        )
+
+        shiny::showNotification(
+          paste("Filvalidering fejlede:", paste(validation_result$errors, collapse = "; ")),
+          type = "error",
+          duration = 8
         )
         return()
       }
-    }
 
-    shiny::req(input$data_file)
+      upload_tracer$step("file_validation_complete")
 
-    # Luk upload-modal automatisk naar fil er valgt (#167)
-    shiny::removeModal()
+      # Show loading indicator (replaced waiter with simple logging)
 
-    # Start workflow tracer for file upload
-    # SPRINT 1 SECURITY FIX: Sanitize session token before logging
-    upload_tracer <- debug_workflow_tracer("file_upload_workflow", app_state, sanitize_session_token(session$token))
-    upload_tracer$step("upload_initiated")
-
-
-    log_info("File upload started",
-      .context = "FILE_UPLOAD_FLOW",
-      details = list(
-        filename = input$data_file$name,
-        size_bytes = input$data_file$size,
-        file_type = input$data_file$type
-      )
-    )
-
-    upload_tracer$step("file_validation")
-
-    # ENHANCED FILE VALIDATION
-    # SPRINT 1 SECURITY FIX: Sanitize session token before logging
-    validation_result <- validate_uploaded_file(input$data_file, sanitize_session_token(session$token))
-    if (!validation_result$valid) {
-      upload_tracer$complete("file_validation_failed")
-      log_error("File validation failed",
-        .context = "ERROR_HANDLING",
-        details = list(
-          validation_errors = validation_result$errors,
-          filename = input$data_file$name
-        )
+      # Close upload modal automatically
+      on.exit(
+        {
+          shiny::removeModal()
+        },
+        add = TRUE
       )
 
-      shiny::showNotification(
-        paste("Filvalidering fejlede:", paste(validation_result$errors, collapse = "; ")),
-        type = "error",
-        duration = 8
+      upload_tracer$step("state_management_setup")
+
+      # Unified state assignment only - Set table updating flag
+      set_table_updating(app_state, TRUE)
+
+      log_debug("File upload state flags set", .context = "FILE_UPLOAD_FLOW")
+      on.exit(
+        {
+          # Unified state assignment only - Clear table updating flag
+          set_table_updating(app_state, FALSE)
+        },
+        add = TRUE
       )
-      return()
+
+      # Enhanced path traversal protection
+      file_path <- validate_safe_file_path(input$data_file$datapath)
+
+      file_ext <- tools::file_ext(input$data_file$name)
+
+
+      if (file.exists(file_path)) {
+        file_info <- file.info(file_path)
+      }
+
+      safe_operation(
+        operation_name = "Fil upload processing",
+        code = {
+          upload_tracer$step("file_processing_started")
+
+          if (file_ext %in% c("xlsx", "xls")) {
+            log_info("Starting Excel file processing", .context = "FILE_UPLOAD_FLOW")
+            handle_excel_upload(file_path, session, app_state, emit, ui_service)
+            upload_tracer$step("excel_processing_complete")
+          } else {
+            log_info("Starting CSV file processing", .context = "FILE_UPLOAD_FLOW")
+            # SPRINT 1 SECURITY FIX: Sanitize token passed to handle_csv_upload
+            handle_csv_upload(file_path, app_state, sanitize_session_token(session$token), emit)
+            upload_tracer$step("csv_processing_complete")
+          }
+
+          # Complete workflow tracing
+          upload_tracer$complete("file_upload_workflow_complete")
+          log_info("File upload workflow completed successfully", .context = "FILE_UPLOAD_FLOW")
+
+          # Update rate limiting timestamp after successful upload
+          set_last_upload_time(app_state)
+        },
+        error_type = "network",
+        emit = emit,
+        app_state = app_state,
+        session = session,
+        show_user = TRUE
+      )
     }
-
-    upload_tracer$step("file_validation_complete")
-
-    # Show loading indicator (replaced waiter with simple logging)
-
-    # Close upload modal automatically
-    on.exit(
-      {
-        shiny::removeModal()
-      },
-      add = TRUE
-    )
-
-    upload_tracer$step("state_management_setup")
-
-    # Unified state assignment only - Set table updating flag
-    set_table_updating(app_state, TRUE)
-
-    log_debug("File upload state flags set", .context = "FILE_UPLOAD_FLOW")
-    on.exit(
-      {
-        # Unified state assignment only - Clear table updating flag
-        set_table_updating(app_state, FALSE)
-      },
-      add = TRUE
-    )
-
-    # Enhanced path traversal protection
-    file_path <- validate_safe_file_path(input$data_file$datapath)
-
-    file_ext <- tools::file_ext(input$data_file$name)
-
-
-    if (file.exists(file_path)) {
-      file_info <- file.info(file_path)
-    }
-
-    safe_operation(
-      operation_name = "Fil upload processing",
-      code = {
-        upload_tracer$step("file_processing_started")
-
-        if (file_ext %in% c("xlsx", "xls")) {
-          log_info("Starting Excel file processing", .context = "FILE_UPLOAD_FLOW")
-          handle_excel_upload(file_path, session, app_state, emit, ui_service)
-          upload_tracer$step("excel_processing_complete")
-        } else {
-          log_info("Starting CSV file processing", .context = "FILE_UPLOAD_FLOW")
-          # SPRINT 1 SECURITY FIX: Sanitize token passed to handle_csv_upload
-          handle_csv_upload(file_path, app_state, sanitize_session_token(session$token), emit)
-          upload_tracer$step("csv_processing_complete")
-        }
-
-        # Complete workflow tracing
-        upload_tracer$complete("file_upload_workflow_complete")
-        log_info("File upload workflow completed successfully", .context = "FILE_UPLOAD_FLOW")
-
-        # Update rate limiting timestamp after successful upload
-        set_last_upload_time(app_state)
-      },
-      error_type = "network",
-      emit = emit,
-      app_state = app_state,
-      session = session,
-      show_user = TRUE
-    )
-  })
+  )
 
   # UNIFIED EVENT SYSTEM: Auto-detection is now handled by data_loaded events
   # The event system automatically triggers auto-detection when new data is loaded

--- a/R/mod_export_ai.R
+++ b/R/mod_export_ai.R
@@ -254,6 +254,7 @@ register_ai_suggestion_handler <- function(session, input, output, app_state) {
     shiny::observeEvent(
       ai_task$result(),
       ignoreInit = TRUE,
+      priority = OBSERVER_PRIORITIES$DATA_PROCESSING,
       {
         suggestion <- ai_task$result()
 

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -52,6 +52,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     shiny::observeEvent(input$back_to_analysis,
       ignoreNULL = TRUE,
       ignoreInit = TRUE,
+      priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
       {
         if (!is.null(parent_session)) {
           bslib::nav_select("main_navbar", selected = "analyser", session = parent_session)
@@ -252,7 +253,8 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         shiny::updateNumericInput(session, "png_width", value = as.integer(dims[1]))
         shiny::updateNumericInput(session, "png_height", value = as.integer(dims[2]))
       },
-      ignoreInit = TRUE
+      ignoreInit = TRUE,
+      priority = OBSERVER_PRIORITIES$UI_SYNC
     )
 
     # Saet dropdown til "Brugerdefineret" naar brugeren aendrer dimensioner manuelt
@@ -270,7 +272,8 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
           shiny::updateSelectInput(session, "png_preset", selected = "custom")
         }
       },
-      ignoreInit = TRUE
+      ignoreInit = TRUE,
+      priority = OBSERVER_PRIORITIES$UI_SYNC
     )
 
     # PDF PREVIEW GENERATION ==================================================

--- a/R/mod_landing_server.R
+++ b/R/mod_landing_server.R
@@ -40,46 +40,61 @@ mod_landing_server <- function(id, parent_session = NULL, app_state = NULL) {
     })
 
     # "Kom i gang" knap: vis navbar-trin og navigér til Upload
-    shiny::observeEvent(input$start_wizard, {
-      if (!is.null(parent_session)) {
-        shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
-        bslib::nav_select("main_navbar", selected = "upload", session = parent_session)
+    shiny::observeEvent(input$start_wizard,
+      priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+      {
+        if (!is.null(parent_session)) {
+          shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
+          bslib::nav_select("main_navbar", selected = "upload", session = parent_session)
+        }
       }
-    })
+    )
 
     # Discoveryability-links: navigér til hjælpefanerne uden at aktivere wizard-nav
-    shiny::observeEvent(input$goto_app_guide, {
-      if (!is.null(parent_session)) {
-        shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
-        bslib::nav_select("main_navbar", selected = "app_guide", session = parent_session)
+    shiny::observeEvent(input$goto_app_guide,
+      priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+      {
+        if (!is.null(parent_session)) {
+          shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
+          bslib::nav_select("main_navbar", selected = "app_guide", session = parent_session)
+        }
       }
-    })
+    )
 
-    shiny::observeEvent(input$goto_spc, {
-      if (!is.null(parent_session)) {
-        shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
-        bslib::nav_select("main_navbar", selected = "hjaelp", session = parent_session)
+    shiny::observeEvent(input$goto_spc,
+      priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+      {
+        if (!is.null(parent_session)) {
+          shinyjs::runjs("document.body.classList.add('wizard-nav-active');")
+          bslib::nav_select("main_navbar", selected = "hjaelp", session = parent_session)
+        }
       }
-    })
+    )
 
-    # Bruger vælger "Gendan session"
-    shiny::observeEvent(input$restore_saved_session, {
-      log_info("Bruger valgte at gendanne gemt session", .context = "SESSION_RESTORE")
-      if (!is.null(parent_session)) {
-        parent_session$sendCustomMessage("performSessionRestore", list())
+    # Bruger vælger "Gendan session" — STATE_MANAGEMENT da restore muterer state.
+    shiny::observeEvent(input$restore_saved_session,
+      priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+      {
+        log_info("Bruger valgte at gendanne gemt session", .context = "SESSION_RESTORE")
+        if (!is.null(parent_session)) {
+          parent_session$sendCustomMessage("performSessionRestore", list())
+        }
       }
-    })
+    )
 
-    # Bruger vælger "Start ny session"
-    shiny::observeEvent(input$discard_saved_session, {
-      log_info("Bruger valgte at kassere gemt session og starte ny", .context = "SESSION_RESTORE")
-      if (!is.null(parent_session)) {
-        clearDataLocally(parent_session)
-        parent_session$sendCustomMessage("discardPendingRestore", list())
+    # Bruger vælger "Start ny session" — STATE_MANAGEMENT da clear muterer state.
+    shiny::observeEvent(input$discard_saved_session,
+      priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+      {
+        log_info("Bruger valgte at kassere gemt session og starte ny", .context = "SESSION_RESTORE")
+        if (!is.null(parent_session)) {
+          clearDataLocally(parent_session)
+          parent_session$sendCustomMessage("discardPendingRestore", list())
+        }
+        if (!is.null(app_state)) {
+          set_session_peek_result(app_state, list(has_payload = FALSE))
+        }
       }
-      if (!is.null(app_state)) {
-        set_session_peek_result(app_state, list(has_payload = FALSE))
-      }
-    })
+    )
   })
 }

--- a/R/utils_analytics_consent.R
+++ b/R/utils_analytics_consent.R
@@ -61,6 +61,7 @@ setup_analytics_consent <- function(input, session, hashed_token, log_directory 
   session$sendCustomMessage("spc_set_consent_version", config$consent_version)
 
   shiny::observeEvent(input$analytics_consent,
+    priority = OBSERVER_PRIORITIES$LOGGING,
     {
       consent <- input$analytics_consent
 
@@ -122,6 +123,7 @@ setup_analytics_consent <- function(input, session, hashed_token, log_directory 
   )
 
   shiny::observeEvent(input$analytics_client_metadata,
+    priority = OBSERVER_PRIORITIES$LOGGING,
     {
       metadata <- format_analytics_metadata(input$analytics_client_metadata)
       if (!is.null(metadata)) {
@@ -136,6 +138,7 @@ setup_analytics_consent <- function(input, session, hashed_token, log_directory 
   )
 
   shiny::observeEvent(input$analytics_performance,
+    priority = OBSERVER_PRIORITIES$LOGGING,
     {
       perf <- input$analytics_performance
       if (!is.null(perf)) {

--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -44,40 +44,56 @@ setup_column_management <- function(input, output, session, app_state, emit) {
   log_debug_block("COLUMN_MGMT", "Setting up column management")
 
   # Auto-detekterings knap handler - koerer altid naar bruger trykker
-  shiny::observeEvent(input$auto_detect_columns, {
-    # FASE 3: Use event-driven manual trigger for consistency
-    safe_operation(
-      "Manual auto-detection trigger",
-      code = {
-        emit$manual_autodetect_button() # This triggers the event listener with frozen state bypass
-      },
-      fallback = NULL,
-      session = session,
-      show_user = TRUE,
-      error_type = "processing",
-      emit = emit,
-      app_state = app_state
-    )
-  })
+  # AUTO_DETECT-priority: kolonne-detection er central data-processing.
+  shiny::observeEvent(input$auto_detect_columns,
+    priority = OBSERVER_PRIORITIES$AUTO_DETECT,
+    {
+      safe_operation(
+        "Manual auto-detection trigger",
+        code = {
+          emit$manual_autodetect_button() # triggerer event-listener med frozen state-bypass
+        },
+        fallback = NULL,
+        session = session,
+        show_user = TRUE,
+        error_type = "processing",
+        emit = emit,
+        app_state = app_state
+      )
+    }
+  )
 
-  # Rediger kolonnenavne modal
-  shiny::observeEvent(input$edit_column_names, {
-    show_column_edit_modal(session, app_state)
-  })
+  # Rediger kolonnenavne modal — STATUS_UPDATES (UI-modal kun).
+  shiny::observeEvent(input$edit_column_names,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      show_column_edit_modal(session, app_state)
+    }
+  )
 
-  # Bekraeft kolonnenavn aendringer
-  shiny::observeEvent(input$confirm_column_names, {
-    handle_column_name_changes(input, session, app_state, emit)
-  })
+  # Bekraeft kolonnenavn aendringer — STATE_MANAGEMENT (muterer column-names).
+  shiny::observeEvent(input$confirm_column_names,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      handle_column_name_changes(input, session, app_state, emit)
+    }
+  )
 
-  # Tilfoej kolonne
-  shiny::observeEvent(input$add_column, {
-    show_add_column_modal()
-  })
+  # Tilfoej kolonne — STATUS_UPDATES (UI-modal kun).
+  shiny::observeEvent(input$add_column,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      show_add_column_modal()
+    }
+  )
 
-  shiny::observeEvent(input$confirm_add_col, {
-    handle_add_column(input, session, app_state, emit)
-  })
+  # STATE_MANAGEMENT: muterer current_data med ny kolonne.
+  shiny::observeEvent(input$confirm_add_col,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      handle_add_column(input, session, app_state, emit)
+    }
+  )
 
   # UNIFIED EVENT SYSTEM: No longer returning autodetect_trigger
   # Auto-detection is handled through emit$auto_detection_started() events
@@ -285,8 +301,9 @@ setup_data_table <- function(input, output, session, app_state, emit) {
     )
   })
 
-  # Haandter excelR tabel aendringer
+  # Haandter excelR tabel aendringer — STATE_MANAGEMENT (muterer current_data).
   shiny::observeEvent(input$main_data_table,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
     {
       # Use unified state management
       updating_table_check <- app_state$data$updating_table
@@ -388,32 +405,35 @@ setup_data_table <- function(input, output, session, app_state, emit) {
     ignoreInit = TRUE
   )
 
-  # Tilfoej raekke
-  shiny::observeEvent(input$add_row, {
-    # UNIFIED EVENT SYSTEM: Direct access to current data
-    current_data_check <- app_state$data$current_data
-    shiny::req(current_data_check)
+  # Tilfoej raekke — STATE_MANAGEMENT (muterer current_data).
+  shiny::observeEvent(input$add_row,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      # UNIFIED EVENT SYSTEM: Direct access to current data
+      current_data_check <- app_state$data$current_data
+      shiny::req(current_data_check)
 
-    # Saet vedvarende flag for at forhindre auto-save interferens
-    # Use unified state management
-    set_table_op_in_progress(app_state, TRUE)
+      # Saet vedvarende flag for at forhindre auto-save interferens
+      # Use unified state management
+      set_table_op_in_progress(app_state, TRUE)
 
-    new_row <- current_data_check[1, ]
-    new_row[1, ] <- NA
+      new_row <- current_data_check[1, ]
+      new_row[1, ] <- NA
 
-    # Dual-state sync for compatibility during migration
-    current_data <- get_current_data(app_state)
-    set_current_data(app_state, rbind(current_data, new_row))
+      # Dual-state sync for compatibility during migration
+      current_data <- get_current_data(app_state)
+      set_current_data(app_state, rbind(current_data, new_row))
 
-    # Emit event to trigger downstream effects
-    emit$data_updated("column_changed")
+      # Emit event to trigger downstream effects
+      emit$data_updated("column_changed")
 
-    shiny::showNotification("Ny r\u00e6kke tilf\u00f8jet", type = "message")
+      shiny::showNotification("Ny r\u00e6kke tilf\u00f8jet", type = "message")
 
-    # Trigger event-driven cleanup instead of timing-based
-    # Use unified state management
-    set_table_op_cleanup_needed(app_state, TRUE)
-  })
+      # Trigger event-driven cleanup instead of timing-based
+      # Use unified state management
+      set_table_op_cleanup_needed(app_state, TRUE)
+    }
+  )
 
   # UNIFIED STATE: Table reset functionality moved to utils_server_management.R
   # Uses emit$session_reset() events and unified app_state management

--- a/R/utils_server_events_data.R
+++ b/R/utils_server_events_data.R
@@ -29,6 +29,13 @@
 register_data_lifecycle_events <- function(app_state, emit, input, output, session, ui_service, register_observer) {
   observers <- list()
 
+  # Issue #539: data_updated triggerer to observers her (cache-clear + y-axis-reset)
+  # plus auto-save observere i utils_server_session_helpers.R (data + settings, hver
+  # debounced af forskellige grunde, dokumenteret i samme fil omkring linje 247).
+  # Multiple observers er bevidst design — cache-clear (STATE_MANAGEMENT) skal køre
+  # før strategy-handler og y-axis-reset (LOWEST). Auto-save er debounced og rammer
+  # ikke samme reactive-flush.
+
   # Consolidated data update handler (REFACTORED: Using strategy pattern)
   observers$data_updated <- register_observer(
     "data_updated",

--- a/R/utils_server_paste_data.R
+++ b/R/utils_server_paste_data.R
@@ -8,117 +8,128 @@
 
 setup_paste_data_observers <- function(input, output, app_state, session, emit, ui_service = NULL) {
   # Observer: "Fortsaet" knap -- indlaes pasted data
-  shiny::observeEvent(input$load_paste_data, {
-    shinyjs::disable("load_paste_data")
-    shinyjs::html(
-      "load_paste_data",
-      as.character(shiny::tagList(
-        shiny::icon("spinner", class = "fa-spin"),
-        " Indl\u00e6ser..."
-      ))
-    )
-    on.exit({
-      shinyjs::enable("load_paste_data")
+  # STATE_MANAGEMENT: data-ingest muterer current_data (#535)
+  shiny::observeEvent(input$load_paste_data,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      shinyjs::disable("load_paste_data")
       shinyjs::html(
         "load_paste_data",
         as.character(shiny::tagList(
-          "Forts\u00e6t ", shiny::icon("arrow-right")
+          shiny::icon("spinner", class = "fa-spin"),
+          " Indl\u00e6ser..."
         ))
       )
-    })
-    # Bevar chart_type fra eksempeldatasaet-valg (reset_form_fields saetter den til "run")
-    current_chart_type <- input$chart_type
-
-    # Nulstil alle indstillinger inden nyt datasaet processeres
-    if (!is.null(ui_service)) {
-      ui_service$reset_form_fields()
-    }
-
-    # Gendan chart_type hvis den var sat (fx fra eksempeldatasaet)
-    if (!is.null(current_chart_type) && nzchar(current_chart_type) && current_chart_type != CHART_TYPES_EN$run) {
-      shiny::updateSelectizeInput(session, "chart_type", selected = current_chart_type)
-    }
-
-    safe_operation(
-      "Paste data parsing",
-      code = {
-        handle_paste_data(
-          text_data = input$paste_data_input,
-          app_state = app_state,
-          session_id = sanitize_session_token(session$token),
-          emit = emit
+      on.exit({
+        shinyjs::enable("load_paste_data")
+        shinyjs::html(
+          "load_paste_data",
+          as.character(shiny::tagList(
+            "Forts\u00e6t ", shiny::icon("arrow-right")
+          ))
         )
-      },
-      fallback = {
-        shiny::showNotification(
-          paste0(
-            "Data kunne ikke l\u00e6ses. S\u00f8rg for at data har kolonneoverskrifter ",
-            "adskilt med semikolon eller tabulator."
-          ),
-          type = "error", duration = 6
-        )
-      },
-      session = session,
-      error_type = "processing",
-      emit = emit,
-      app_state = app_state
-    )
-  })
+      })
+      # Bevar chart_type fra eksempeldatasaet-valg (reset_form_fields saetter den til "run")
+      current_chart_type <- input$chart_type
 
-  # Observer: Toggle dropdown for eksempeldatasaet
-  shiny::observeEvent(input$toggle_sample_dropdown, {
-    shinyjs::toggle("sample_data_dropdown")
-  })
+      # Nulstil alle indstillinger inden nyt datasaet processeres
+      if (!is.null(ui_service)) {
+        ui_service$reset_form_fields()
+      }
+
+      # Gendan chart_type hvis den var sat (fx fra eksempeldatasaet)
+      if (!is.null(current_chart_type) && nzchar(current_chart_type) && current_chart_type != CHART_TYPES_EN$run) {
+        shiny::updateSelectizeInput(session, "chart_type", selected = current_chart_type)
+      }
+
+      safe_operation(
+        "Paste data parsing",
+        code = {
+          handle_paste_data(
+            text_data = input$paste_data_input,
+            app_state = app_state,
+            session_id = sanitize_session_token(session$token),
+            emit = emit
+          )
+        },
+        fallback = {
+          shiny::showNotification(
+            paste0(
+              "Data kunne ikke l\u00e6ses. S\u00f8rg for at data har kolonneoverskrifter ",
+              "adskilt med semikolon eller tabulator."
+            ),
+            type = "error", duration = 6
+          )
+        },
+        session = session,
+        error_type = "processing",
+        emit = emit,
+        app_state = app_state
+      )
+    }
+  )
+
+  # Observer: Toggle dropdown for eksempeldatasaet — STATUS_UPDATES (UI toggle).
+  shiny::observeEvent(input$toggle_sample_dropdown,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      shinyjs::toggle("sample_data_dropdown")
+    }
+  )
 
   # Observer: Bruger vaelger eksempeldatasaet fra dropdown
-  shiny::observeEvent(input$selected_sample, {
-    sample_id <- input$selected_sample
+  # DATA_PROCESSING: sampleloading opdaterer paste-felt + chart_type.
+  shiny::observeEvent(input$selected_sample,
+    priority = OBSERVER_PRIORITIES$DATA_PROCESSING,
+    {
+      sample_id <- input$selected_sample
 
-    # Find datasaet-metadata fra config
-    dataset <- NULL
-    for (ds in SAMPLE_DATASETS) {
-      if (ds$id == sample_id) {
-        dataset <- ds
-        break
+      # Find datasaet-metadata fra config
+      dataset <- NULL
+      for (ds in SAMPLE_DATASETS) {
+        if (ds$id == sample_id) {
+          dataset <- ds
+          break
+        }
+      }
+
+      if (is.null(dataset)) {
+        shiny::showNotification(
+          "Ukendt eksempeldatas\u00e6t",
+          type = "error", duration = 3
+        )
+        return()
+      }
+
+      # Laes CSV-fil fra inst/extdata/
+      sample_path <- bisp_system_file("extdata", dataset$file)
+      if (sample_path == "" || !file.exists(sample_path)) {
+        sample_path <- file.path("inst", "extdata", dataset$file)
+      }
+
+      if (file.exists(sample_path)) {
+        sample_text <- readLines(sample_path, warn = FALSE, encoding = "UTF-8")
+        shiny::updateTextAreaInput(
+          session, "paste_data_input",
+          value = paste(sample_text, collapse = "\n")
+        )
+        # Saet chart type dropdown til det anbefalede chart type for datasaettet
+        shiny::updateSelectizeInput(
+          session, "chart_type",
+          selected = dataset$chart_type
+        )
+        shiny::showNotification(
+          paste0(dataset$label, " indsat \u2014 tryk Forts\u00e6t for at analysere"),
+          type = "message", duration = 4
+        )
+      } else {
+        shiny::showNotification(
+          paste0("Kunne ikke finde fil: ", dataset$file),
+          type = "error", duration = 3
+        )
       }
     }
-
-    if (is.null(dataset)) {
-      shiny::showNotification(
-        "Ukendt eksempeldatas\u00e6t",
-        type = "error", duration = 3
-      )
-      return()
-    }
-
-    # Laes CSV-fil fra inst/extdata/
-    sample_path <- bisp_system_file("extdata", dataset$file)
-    if (sample_path == "" || !file.exists(sample_path)) {
-      sample_path <- file.path("inst", "extdata", dataset$file)
-    }
-
-    if (file.exists(sample_path)) {
-      sample_text <- readLines(sample_path, warn = FALSE, encoding = "UTF-8")
-      shiny::updateTextAreaInput(
-        session, "paste_data_input",
-        value = paste(sample_text, collapse = "\n")
-      )
-      # Saet chart type dropdown til det anbefalede chart type for datasaettet
-      shiny::updateSelectizeInput(
-        session, "chart_type",
-        selected = dataset$chart_type
-      )
-      shiny::showNotification(
-        paste0(dataset$label, " indsat \u2014 tryk Forts\u00e6t for at analysere"),
-        type = "message", duration = 4
-      )
-    } else {
-      shiny::showNotification(
-        paste0("Kunne ikke finde fil: ", dataset$file),
-        type = "error", duration = 3
-      )
-    }
-  })
+  )
 
   # Download handler: Tom Excel-skabelon
   output$download_template <- shiny::downloadHandler(
@@ -141,107 +152,113 @@ setup_paste_data_observers <- function(input, output, app_state, session, emit, 
   )
 
   # Observer: "Indlaes xlsx/csv" knap -- trigger skjult fileInput
-  shiny::observeEvent(input$trigger_file_upload, {
-    # Klik paa det skjulte fileInput via JS
-    shinyjs::click("direct_file_upload")
-  })
+  shiny::observeEvent(input$trigger_file_upload,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      shinyjs::click("direct_file_upload")
+    }
+  )
 
   # Observer: Direkte fil-upload -- valider og behandl via eksisterende upload-logik
-  shiny::observeEvent(input$direct_file_upload, {
-    req(input$direct_file_upload)
-    file_info <- input$direct_file_upload
+  # STATE_MANAGEMENT: data-ingest muterer current_data (#535).
+  shiny::observeEvent(input$direct_file_upload,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      req(input$direct_file_upload)
+      file_info <- input$direct_file_upload
 
-    # Filvalidering (rate limiting, stoerrelse, MIME, korruption)
-    validation_result <- validate_uploaded_file(
-      file_info, sanitize_session_token(session$token)
-    )
-    if (!validation_result$valid) {
-      shiny::showNotification(
-        paste("Filvalidering fejlede:", paste(validation_result$errors, collapse = "; ")),
-        type = "error", duration = 5
+      # Filvalidering (rate limiting, stoerrelse, MIME, korruption)
+      validation_result <- validate_uploaded_file(
+        file_info, sanitize_session_token(session$token)
       )
-      return()
-    }
-
-    safe_operation(
-      "Behandl uploadet fil",
-      fallback = function(e) {
-        # H6 (#452): tidligere blev fejl efter MIME-validering swallowed
-        # silent (show_user = FALSE, fallback = NULL). Nu f\u00e5r brugeren
-        # en dansk fejl-besked s\u00e5 de ved hvorfor paste-feltet er tomt.
+      if (!validation_result$valid) {
         shiny::showNotification(
-          paste0("Filen \"", file_info$name, "\" kunne ikke indl\u00e6ses: ", e$message),
-          type = "error",
-          duration = 6
+          paste("Filvalidering fejlede:", paste(validation_result$errors, collapse = "; ")),
+          type = "error", duration = 5
         )
-        NULL
-      },
-      code = {
-        ext <- tolower(tools::file_ext(file_info$name))
+        return()
+      }
 
-        if (ext %in% c("xlsx", "xls")) {
-          excel_sheets <- list_excel_sheets(file_info$datapath)
-          if (is.null(excel_sheets) || length(excel_sheets) == 0) {
-            shiny::showNotification(
-              "Excel-filen kunne ikke l\u00e6ses (ingen ark fundet)",
-              type = "error", duration = 5
-            )
-            return()
-          }
-          if (is_bispchart_excel_format(excel_sheets)) {
-            # biSPCharts gem-format: gendannelse direkte uden paste-felt
-            handle_excel_upload(file_info$datapath, session, app_state, emit, ui_service)
-          } else if (length(excel_sheets) == 1) {
-            # Standard single-sheet: laes direkte
-            data <- readxl::read_excel(
-              file_info$datapath,
-              sheet = excel_sheets[1],
-              col_names = TRUE
-            )
+      safe_operation(
+        "Behandl uploadet fil",
+        fallback = function(e) {
+          # H6 (#452): tidligere blev fejl efter MIME-validering swallowed
+          # silent (show_user = FALSE, fallback = NULL). Nu f\u00e5r brugeren
+          # en dansk fejl-besked s\u00e5 de ved hvorfor paste-feltet er tomt.
+          shiny::showNotification(
+            paste0("Filen \"", file_info$name, "\" kunne ikke indl\u00e6ses: ", e$message),
+            type = "error",
+            duration = 6
+          )
+          NULL
+        },
+        code = {
+          ext <- tolower(tools::file_ext(file_info$name))
+
+          if (ext %in% c("xlsx", "xls")) {
+            excel_sheets <- list_excel_sheets(file_info$datapath)
+            if (is.null(excel_sheets) || length(excel_sheets) == 0) {
+              shiny::showNotification(
+                "Excel-filen kunne ikke l\u00e6ses (ingen ark fundet)",
+                type = "error", duration = 5
+              )
+              return()
+            }
+            if (is_bispchart_excel_format(excel_sheets)) {
+              # biSPCharts gem-format: gendannelse direkte uden paste-felt
+              handle_excel_upload(file_info$datapath, session, app_state, emit, ui_service)
+            } else if (length(excel_sheets) == 1) {
+              # Standard single-sheet: laes direkte
+              data <- readxl::read_excel(
+                file_info$datapath,
+                sheet = excel_sheets[1],
+                col_names = TRUE
+              )
+              shiny::updateTextAreaInput(
+                session, "paste_data_input",
+                value = excel_data_to_paste_text(data)
+              )
+              shiny::showNotification(
+                paste0("\"", file_info$name, "\" indl\u00e6st \u2014 tryk Forts\u00e6t for at analysere"),
+                type = "message", duration = 3
+              )
+            } else {
+              # Standard multi-sheet: vis sheet-picker, vent paa eksplicit valg
+              empty_flags <- detect_empty_sheets(file_info$datapath, excel_sheets)
+              app_state$session$pending_excel_upload <- list(
+                datapath = file_info$datapath,
+                name = file_info$name,
+                sheets = excel_sheets,
+                empty_flags = empty_flags
+              )
+              shinyjs::show("excel_sheet_dropdown")
+              shiny::showNotification(
+                paste0(
+                  "\"", file_info$name, "\" indeholder ",
+                  length(excel_sheets),
+                  " faneblade \u2014 v\u00e6lg det \u00f8nskede ark fra menuen"
+                ),
+                type = "message", duration = 5
+              )
+            }
+          } else if (ext %in% c("csv", "txt")) {
+            # CSV: encoding-aware preview i paste-felt (#166)
+            text_content <- read_csv_detect_encoding(file_info$datapath)
             shiny::updateTextAreaInput(
               session, "paste_data_input",
-              value = excel_data_to_paste_text(data)
+              value = paste(text_content, collapse = "\n")
             )
             shiny::showNotification(
               paste0("\"", file_info$name, "\" indl\u00e6st \u2014 tryk Forts\u00e6t for at analysere"),
               type = "message", duration = 3
             )
           } else {
-            # Standard multi-sheet: vis sheet-picker, vent paa eksplicit valg
-            empty_flags <- detect_empty_sheets(file_info$datapath, excel_sheets)
-            app_state$session$pending_excel_upload <- list(
-              datapath = file_info$datapath,
-              name = file_info$name,
-              sheets = excel_sheets,
-              empty_flags = empty_flags
-            )
-            shinyjs::show("excel_sheet_dropdown")
-            shiny::showNotification(
-              paste0(
-                "\"", file_info$name, "\" indeholder ",
-                length(excel_sheets),
-                " faneblade \u2014 v\u00e6lg det \u00f8nskede ark fra menuen"
-              ),
-              type = "message", duration = 5
-            )
+            shiny::showNotification("Kun xlsx, xls og csv filer underst\u00f8ttes", type = "error")
           }
-        } else if (ext %in% c("csv", "txt")) {
-          # CSV: encoding-aware preview i paste-felt (#166)
-          text_content <- read_csv_detect_encoding(file_info$datapath)
-          shiny::updateTextAreaInput(
-            session, "paste_data_input",
-            value = paste(text_content, collapse = "\n")
-          )
-          shiny::showNotification(
-            paste0("\"", file_info$name, "\" indl\u00e6st \u2014 tryk Forts\u00e6t for at analysere"),
-            type = "message", duration = 3
-          )
-        } else {
-          shiny::showNotification("Kun xlsx, xls og csv filer underst\u00f8ttes", type = "error")
         }
-      }
-    )
-  })
+      )
+    }
+  )
 
   # Render: Excel sheet-picker dropdown items (vises ved multi-sheet upload)
   output$excel_sheet_dropdown_items <- shiny::renderUI({
@@ -253,56 +270,60 @@ setup_paste_data_observers <- function(input, output, app_state, session, emit, 
   })
 
   # Observer: Bruger vaelger ark fra sheet-picker dropdown
-  shiny::observeEvent(input$selected_excel_sheet, {
-    sheet_name <- input$selected_excel_sheet
-    pending <- app_state$session$pending_excel_upload
+  # STATE_MANAGEMENT: data-ingest muterer current_data (#535).
+  shiny::observeEvent(input$selected_excel_sheet,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      sheet_name <- input$selected_excel_sheet
+      pending <- app_state$session$pending_excel_upload
 
-    if (is.null(pending) || is.null(sheet_name) || !nzchar(sheet_name)) {
-      shinyjs::hide("excel_sheet_dropdown")
-      return()
-    }
-    if (!sheet_name %in% pending$sheets) {
-      shiny::showNotification(
-        paste0("Ukendt ark: ", sheet_name),
-        type = "error", duration = 3
-      )
-      shinyjs::hide("excel_sheet_dropdown")
-      return()
-    }
-
-    safe_operation(
-      "Indlaes valgt Excel-ark",
-      fallback = function(e) {
-        # H6 (#452): user-facing fejl-besked i stedet for silent fallback.
-        shiny::showNotification(
-          paste0("Arket \"", sheet_name, "\" kunne ikke indl\u00e6ses: ", e$message),
-          type = "error",
-          duration = 6
-        )
+      if (is.null(pending) || is.null(sheet_name) || !nzchar(sheet_name)) {
         shinyjs::hide("excel_sheet_dropdown")
-        NULL
-      },
-      code = {
-        data <- readxl::read_excel(
-          path = pending$datapath,
-          sheet = sheet_name,
-          col_names = TRUE
-        )
-        shiny::updateTextAreaInput(
-          session, "paste_data_input",
-          value = excel_data_to_paste_text(data)
-        )
-        shiny::showNotification(
-          paste0(
-            "Ark \"", sheet_name, "\" indl\u00e6st - tryk Forts\u00e6t for at analysere"
-          ),
-          type = "message", duration = 4
-        )
-        app_state$session$pending_excel_upload <- NULL
-        shinyjs::hide("excel_sheet_dropdown")
+        return()
       }
-    )
-  })
+      if (!sheet_name %in% pending$sheets) {
+        shiny::showNotification(
+          paste0("Ukendt ark: ", sheet_name),
+          type = "error", duration = 3
+        )
+        shinyjs::hide("excel_sheet_dropdown")
+        return()
+      }
+
+      safe_operation(
+        "Indlaes valgt Excel-ark",
+        fallback = function(e) {
+          # H6 (#452): user-facing fejl-besked i stedet for silent fallback.
+          shiny::showNotification(
+            paste0("Arket \"", sheet_name, "\" kunne ikke indl\u00e6ses: ", e$message),
+            type = "error",
+            duration = 6
+          )
+          shinyjs::hide("excel_sheet_dropdown")
+          NULL
+        },
+        code = {
+          data <- readxl::read_excel(
+            path = pending$datapath,
+            sheet = sheet_name,
+            col_names = TRUE
+          )
+          shiny::updateTextAreaInput(
+            session, "paste_data_input",
+            value = excel_data_to_paste_text(data)
+          )
+          shiny::showNotification(
+            paste0(
+              "Ark \"", sheet_name, "\" indl\u00e6st - tryk Forts\u00e6t for at analysere"
+            ),
+            type = "message", duration = 4
+          )
+          app_state$session$pending_excel_upload <- NULL
+          shinyjs::hide("excel_sheet_dropdown")
+        }
+      )
+    }
+  )
 }
 
 # ---- Internal helpers --------------------------------------------------------

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -28,6 +28,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
   shiny::observeEvent(input$session_peek,
     ignoreNULL = TRUE,
     ignoreInit = TRUE,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
     {
       peek <- input$session_peek
 
@@ -93,6 +94,7 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
   # Auto-gendan session data naar tilgaengelig (hvis aktiveret)
   shiny::observeEvent(input$auto_restore_data,
     ignoreInit = TRUE,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
     {
       shiny::req(input$auto_restore_data)
 
@@ -346,15 +348,21 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
     once = TRUE
   )
 
-  # Clear saved handler
-  shiny::observeEvent(input$clear_saved, {
-    handle_clear_saved_request(input, session, app_state, emit, ui_service)
-  })
+  # Clear saved handler — STATUS_UPDATES (åbner confirm-modal).
+  shiny::observeEvent(input$clear_saved,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      handle_clear_saved_request(input, session, app_state, emit, ui_service)
+    }
+  )
 
-  # Confirm clear saved handler
-  shiny::observeEvent(input$confirm_clear_saved, {
-    handle_confirm_clear_saved(session, app_state, emit, ui_service)
-  })
+  # Confirm clear saved handler — STATE_MANAGEMENT (rydder localStorage + state).
+  shiny::observeEvent(input$confirm_clear_saved,
+    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
+    {
+      handle_confirm_clear_saved(session, app_state, emit, ui_service)
+    }
+  )
 
   # NOTE: output$dataLoaded is now handled in server_helpers.R with smart logic
   # NOTE: manual_save, show_upload_modal og save_status_display observers

--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -176,21 +176,27 @@ setup_wizard_gates <- function(input, output, app_state, session) {
   )
 
   # Tilbage-knap: Trin 2 -> Trin 1
-  shiny::observeEvent(input$back_to_upload, {
-    bslib::nav_select("main_navbar", selected = "upload", session = session)
-  })
+  shiny::observeEvent(input$back_to_upload,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      bslib::nav_select("main_navbar", selected = "upload", session = session)
+    }
+  )
 
   # Fortsaet-knap: Trin 2 -> Trin 3 (kun hvis plot er klar)
-  shiny::observeEvent(input$continue_to_export, {
-    if (!isTRUE(shiny::isolate(app_state$visualization$plot_ready))) {
-      shiny::showNotification(
-        "V\u00e6lg kolonner og generer et diagram f\u00f8rst",
-        type = "warning", duration = 3
-      )
-      return()
+  shiny::observeEvent(input$continue_to_export,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      if (!isTRUE(shiny::isolate(app_state$visualization$plot_ready))) {
+        shiny::showNotification(
+          "V\u00e6lg kolonner og generer et diagram f\u00f8rst",
+          type = "warning", duration = 3
+        )
+        return()
+      }
+      bslib::nav_select("main_navbar", selected = "eksporter", session = session)
     }
-    bslib::nav_select("main_navbar", selected = "eksporter", session = session)
-  })
+  )
 }
 
 #' Setup observers for paste data og sample data loading

--- a/R/utils_ui_ui_helpers.R
+++ b/R/utils_ui_ui_helpers.R
@@ -108,13 +108,16 @@ help_back_link <- function(ns) {
 #' @param previous_tab ReactiveVal med den forrige tab
 #' @noRd
 setup_help_back_navigation <- function(input, parent_session, previous_tab) {
-  shiny::observeEvent(input$go_back, {
-    if (!is.null(parent_session) && !is.null(previous_tab)) {
-      dest <- previous_tab()
-      if (dest == "start") {
-        shinyjs::runjs("document.body.classList.remove('wizard-nav-active');")
+  shiny::observeEvent(input$go_back,
+    priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
+    {
+      if (!is.null(parent_session) && !is.null(previous_tab)) {
+        dest <- previous_tab()
+        if (dest == "start") {
+          shinyjs::runjs("document.body.classList.remove('wizard-nav-active');")
+        }
+        bslib::nav_select("main_navbar", selected = dest, session = parent_session)
       }
-      bslib::nav_select("main_navbar", selected = dest, session = parent_session)
     }
-  })
+  )
 }


### PR DESCRIPTION
## Summary

### #535 Observer-priorities sweep
22 observers bumpet fra default 0 til eksplicit OBSERVER_PRIORITIES-værdi.

- **STATE_MANAGEMENT** (data-mutating): file-uploads, paste/sample/excel-uploads, restore/discard session, column-name-changes, table-edits, add-row
- **AUTO_DETECT**: auto_detect_columns
- **DATA_PROCESSING**: ai_task result, selected_sample
- **UI_SYNC**: png_preset, png_dimensions
- **STATUS_UPDATES**: navigation-knapper (start_wizard, goto_*, back_to_*, continue_to_export, edit/add modal-buttons, clear_saved, trigger_file_upload, toggle_sample_dropdown, go_back)
- **LOGGING**: 3 analytics-consent observers

### #539 data_updated cycles
Auditeret. Multi-observer-pattern er bevidst:
- STATE_MANAGEMENT cache-clear → strategy-handler → LOWEST y-axis-reset
- Auto-save observers debounced, deler ikke reactive-flush

Tilføjet kommentar i utils_server_events_data.R der dokumenterer dette.

## Test plan
- [x] testthat suite (column|paste|wizard|export|landing|server_management|analytics|column_input): 769 PASS, 6 SKIP, 0 FAIL

Fixes #535
Refs #539