### PR TITLE
fix(perf): session-scope cache via app_state + parse_danish_dates early-exit (#529, #538)

### DIFF
--- a/R/fct_autodetect_helpers.R
+++ b/R/fct_autodetect_helpers.R
@@ -622,38 +622,49 @@ parse_danish_dates <- function(date_strings, format) {
   # Preprocess strings for Danish month names
   processed_strings <- date_strings
 
-  # Handle Danish month abbreviations (case insensitive)
-  danish_months <- c(
-    "jan", "feb", "mar", "apr", "maj", "jun",
-    "jul", "aug", "sep", "okt", "nov", "dec"
-  )
-  english_months <- c(
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-  )
+  # PERFORMANCE (#538): Spring måneds-substitution helt over hvis ingen alfabetiske
+  # tegn er til stede. Ren-numeriske datoer (15-03-2024, 2024-03-15) udgør den
+  # almindelige autodetect-input og rammer 24 regex-substitutions per format-attempt
+  # uden behov. Kontrollér kun samplet (max 100 værdier) for hurtigere detection.
+  has_alpha <- any(grepl("[A-Za-zæøåÆØÅ]",
+    head(processed_strings, 100L),
+    perl = TRUE
+  ))
 
-  # Handle Danish full month names
-  danish_month_full <- c(
-    "januar", "februar", "marts", "april", "maj", "juni",
-    "juli", "august", "september", "oktober", "november", "december"
-  )
-  english_month_full <- c(
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December"
-  )
-
-  # TIDYVERSE: Replace Danish months using purrr::reduce2 (eliminates mutable state)
-  # Combines abbreviations + full names in single functional operation
-  processed_strings <- purrr::reduce2(
-    .x = c(danish_months, danish_month_full),
-    .y = c(english_months, english_month_full),
-    .init = processed_strings,
-    .f = ~ stringr::str_replace_all(
-      ..1,
-      pattern = stringr::regex(paste0("\\b", ..2, "\\b"), ignore_case = TRUE),
-      replacement = ..3
+  if (has_alpha) {
+    # Handle Danish month abbreviations (case insensitive)
+    danish_months <- c(
+      "jan", "feb", "mar", "apr", "maj", "jun",
+      "jul", "aug", "sep", "okt", "nov", "dec"
     )
-  )
+    english_months <- c(
+      "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+      "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    )
+
+    # Handle Danish full month names
+    danish_month_full <- c(
+      "januar", "februar", "marts", "april", "maj", "juni",
+      "juli", "august", "september", "oktober", "november", "december"
+    )
+    english_month_full <- c(
+      "January", "February", "March", "April", "May", "June",
+      "July", "August", "September", "October", "November", "December"
+    )
+
+    # TIDYVERSE: Replace Danish months using purrr::reduce2 (eliminates mutable state)
+    # Combines abbreviations + full names in single functional operation
+    processed_strings <- purrr::reduce2(
+      .x = c(danish_months, danish_month_full),
+      .y = c(english_months, english_month_full),
+      .init = processed_strings,
+      .f = ~ stringr::str_replace_all(
+        ..1,
+        pattern = stringr::regex(paste0("\\b", ..2, "\\b"), ignore_case = TRUE),
+        replacement = ..3
+      )
+    )
+  }
 
   # Use appropriate lubridate function with quiet parsing
   safe_operation(

--- a/R/state_management.R
+++ b/R/state_management.R
@@ -311,8 +311,13 @@ create_app_state <- function() {
   # Non-reactive cache objects for QIC results
   # Cache creation is delayed until first use to avoid dependency issues
   # M1: Performance counters moved to package environment (R/zzz.R) for proper isolation
+  # Issue #529: Session-scoped performance + data-signature caches
+  # Tidligere lå disse i .performance_cache + .data_signature_cache på package-niveau
+  # → cross-session contamination i multi-session Connect Cloud-deploy.
   app_state$cache <- list(
-    qic = NULL # Will be initialized lazily on first use
+    qic = NULL, # Will be initialized lazily on first use
+    performance = new.env(parent = emptyenv()),
+    data_signature = new.env(parent = emptyenv())
   )
 
   # Error State - Convert to reactiveValues for consistency

--- a/R/utils_data_signatures.R
+++ b/R/utils_data_signatures.R
@@ -3,14 +3,32 @@
 # Centralized data signature generation to reduce redundant hashing
 # Sprint 4 Fase 3 - Performance optimization
 
-#' Data Signature Cache
+#' Data Signature Cache (LEGACY fallback)
 #'
-#' Session-level cache for data signatures to avoid rehashing same data.
-#' Signatures are stored in memory during session and reused across
-#' different caching systems (QIC cache, auto-detect cache, etc.)
+#' Module-level cache. Issue #529: brug session-scoped cache via
+#' app_state$cache$data_signature i multi-session deploys for at undgå
+#' cross-session contamination.
 #'
 #' @keywords internal
 .data_signature_cache <- new.env(parent = emptyenv())
+
+#' Resolve data-signature cache environment
+#'
+#' Returnerer session-scoped cache fra app_state$cache$data_signature hvis
+#' sat, ellers module-level fallback. Issue #529.
+#'
+#' @param app_state Optional centralized app state.
+#' @return Environment til signature cache
+#' @keywords internal
+resolve_data_signature_cache <- function(app_state = NULL) {
+  if (!is.null(app_state) &&
+    !is.null(app_state$cache) &&
+    !is.null(app_state$cache$data_signature) &&
+    is.environment(app_state$cache$data_signature)) {
+    return(app_state$cache$data_signature)
+  }
+  .data_signature_cache
+}
 
 #' Generate Data Signature (Shared)
 #'
@@ -47,11 +65,13 @@
 #' }
 #'
 #' @keywords internal
-generate_shared_data_signature <- function(data, include_structure = TRUE) {
+generate_shared_data_signature <- function(data, include_structure = TRUE, app_state = NULL) {
   # Handle NULL/empty data
   if (is.null(data) || nrow(data) == 0) {
     return("empty_data")
   }
+
+  cache_env <- resolve_data_signature_cache(app_state)
 
   # Content-based lookup key (stabil på tværs af GC og sessions)
   # Bruger struktur + sample af data for hurtig identifikation.
@@ -70,8 +90,8 @@ generate_shared_data_signature <- function(data, include_structure = TRUE) {
   ), algo = "xxhash64")
 
   # Check if signature already cached
-  if (exists(data_ptr, envir = .data_signature_cache)) {
-    cached_sig <- get(data_ptr, envir = .data_signature_cache)
+  if (exists(data_ptr, envir = cache_env)) {
+    cached_sig <- get(data_ptr, envir = cache_env)
     return(cached_sig$signature)
   }
 
@@ -95,19 +115,19 @@ generate_shared_data_signature <- function(data, include_structure = TRUE) {
     signature = signature,
     timestamp = Sys.time(),
     include_structure = include_structure
-  ), envir = .data_signature_cache)
+  ), envir = cache_env)
 
   # Clean old cache entries if too large (keep last 100)
-  cache_size <- length(ls(envir = .data_signature_cache))
+  cache_size <- length(ls(envir = cache_env))
   if (cache_size > 100) {
     # Remove oldest 20 entries
-    cache_keys <- ls(envir = .data_signature_cache)
+    cache_keys <- ls(envir = cache_env)
     cache_times <- vapply(cache_keys, function(k) {
-      entry <- get(k, envir = .data_signature_cache)
+      entry <- get(k, envir = cache_env)
       as.numeric(entry$timestamp)
     }, numeric(1L))
     oldest_keys <- cache_keys[order(cache_times)][1:20]
-    rm(list = oldest_keys, envir = .data_signature_cache)
+    rm(list = oldest_keys, envir = cache_env)
   }
 
   return(signature)
@@ -149,9 +169,9 @@ generate_shared_data_signature <- function(data, include_structure = TRUE) {
 #' }
 #'
 #' @keywords internal
-generate_qic_cache_key_optimized <- function(data, params) {
+generate_qic_cache_key_optimized <- function(data, params, app_state = NULL) {
   # Use shared signature instead of rehashing
-  data_signature <- generate_shared_data_signature(data, include_structure = FALSE)
+  data_signature <- generate_shared_data_signature(data, include_structure = FALSE, app_state = app_state)
 
   # Hash parameters (lightweight)
   param_digest <- digest::digest(params, algo = "xxhash64")
@@ -172,9 +192,9 @@ generate_qic_cache_key_optimized <- function(data, params) {
 #' avoiding redundant hashing when both systems cache same data.
 #'
 #' @keywords internal
-generate_autodetect_cache_key_optimized <- function(data) {
+generate_autodetect_cache_key_optimized <- function(data, app_state = NULL) {
   # Use shared signature with structure info
-  data_signature <- generate_shared_data_signature(data, include_structure = TRUE)
+  data_signature <- generate_shared_data_signature(data, include_structure = TRUE, app_state = app_state)
 
   paste0("autodetect_", data_signature)
 }
@@ -185,8 +205,9 @@ generate_autodetect_cache_key_optimized <- function(data) {
 #' Typically called on session end or when memory needs to be freed.
 #'
 #' @keywords internal
-clear_data_signature_cache <- function() {
-  rm(list = ls(envir = .data_signature_cache), envir = .data_signature_cache)
+clear_data_signature_cache <- function(app_state = NULL) {
+  cache_env <- resolve_data_signature_cache(app_state)
+  rm(list = ls(envir = cache_env), envir = cache_env)
   log_debug("Data signature cache cleared", .context = "DATA_SIGNATURE")
 }
 
@@ -197,8 +218,9 @@ clear_data_signature_cache <- function() {
 #' @return List with cache statistics
 #'
 #' @keywords internal
-get_data_signature_cache_stats <- function() {
-  cache_keys <- ls(envir = .data_signature_cache)
+get_data_signature_cache_stats <- function(app_state = NULL) {
+  cache_env <- resolve_data_signature_cache(app_state)
+  cache_keys <- ls(envir = cache_env)
 
   if (length(cache_keys) == 0) {
     return(list(
@@ -210,7 +232,7 @@ get_data_signature_cache_stats <- function() {
 
   # vapply med POSIXct som returntype bevarer klassen (sapply stripper den)
   cache_times <- do.call(c, lapply(cache_keys, function(k) {
-    entry <- get(k, envir = .data_signature_cache)
+    entry <- get(k, envir = cache_env)
     entry$timestamp
   }))
 

--- a/R/utils_performance_caching.R
+++ b/R/utils_performance_caching.R
@@ -7,10 +7,30 @@
 #' @name performance_caching
 NULL
 
-# Module-level cache environment - brugt som fallback når session ikke er tilgængelig.
-# BEMÆRK: Denne cache deles mellem sessions i samme R-process.
-# Session-scoped caching foretrækkes via session$userData$performance_cache.
+# Module-level cache environment - LEGACY fallback når app_state ej tilgængelig
+# (test-context, batch-jobs uden session). Issue #529: session-scoped cache via
+# app_state$cache$performance er den anbefalede vej i multi-session deploys.
 .performance_cache <- new.env(parent = emptyenv())
+
+#' Resolve performance cache environment
+#'
+#' Returnerer session-scoped cache fra app_state$cache$performance hvis sat,
+#' ellers module-level fallback. Issue #529: forhindrer cross-session
+#' contamination ved multi-session Connect Cloud-deploys.
+#'
+#' @param app_state Optional centralized app state. Hvis NULL: module-level cache.
+#'
+#' @return Environment til cache storage
+#' @keywords internal
+resolve_performance_cache <- function(app_state = NULL) {
+  if (!is.null(app_state) &&
+    !is.null(app_state$cache) &&
+    !is.null(app_state$cache$performance) &&
+    is.environment(app_state$cache$performance)) {
+    return(app_state$cache$performance)
+  }
+  .performance_cache
+}
 
 #' Generate Data-Based Cache Key
 #'
@@ -83,7 +103,7 @@ cache_auto_detection_results <- function(data, app_state, force_refresh = FALSE)
   cache_key <- generate_data_cache_key(data, "autodetect", include_names = TRUE)
 
   if (!force_refresh) {
-    cached_result <- get_cached_result(cache_key)
+    cached_result <- get_cached_result(cache_key, app_state = app_state)
     if (!is.null(cached_result)) {
       log_debug(
         "Auto-detection cache hit",
@@ -109,7 +129,7 @@ cache_auto_detection_results <- function(data, app_state, force_refresh = FALSE)
   computation_time <- as.numeric(Sys.time() - start_time)
 
   # Cache results for 30 minutes (auto-detection is expensive, longer cache reduces duplicates)
-  cache_result(cache_key, results, timeout_seconds = 1800)
+  cache_result(cache_key, results, timeout_seconds = 1800, app_state = app_state)
 
   log_info(
     "Auto-detection completed and cached",
@@ -140,7 +160,7 @@ cache_auto_detection_results <- function(data, app_state, force_refresh = FALSE)
 #' @return Invisible NULL
 #'
 #' @keywords internal
-manage_cache_size <- function(size_limit = NULL) {
+manage_cache_size <- function(size_limit = NULL, app_state = NULL) {
   if (is.null(size_limit)) {
     size_limit <- tryCatch(
       CACHE_CONFIG$size_limit_entries,
@@ -148,7 +168,8 @@ manage_cache_size <- function(size_limit = NULL) {
     )
   }
 
-  cache_keys <- ls(envir = .performance_cache)
+  cache_env <- resolve_performance_cache(app_state)
+  cache_keys <- ls(envir = cache_env)
   n_entries <- length(cache_keys)
 
   if (n_entries <= size_limit) {
@@ -157,7 +178,7 @@ manage_cache_size <- function(size_limit = NULL) {
 
   # Hent last_access-tidsstempel for alle entries (LRU-orden)
   access_times <- vapply(cache_keys, function(k) {
-    entry <- get(k, envir = .performance_cache)
+    entry <- get(k, envir = cache_env)
     if (!is.null(entry$last_access)) {
       as.numeric(entry$last_access)
     } else {
@@ -169,7 +190,7 @@ manage_cache_size <- function(size_limit = NULL) {
   n_to_remove <- n_entries - size_limit
   oldest_keys <- cache_keys[order(access_times)[seq_len(n_to_remove)]]
 
-  rm(list = oldest_keys, envir = .performance_cache)
+  rm(list = oldest_keys, envir = cache_env)
 
   log_debug(
     "LRU cache eviction gennemfort",
@@ -177,7 +198,7 @@ manage_cache_size <- function(size_limit = NULL) {
   )
   log_debug_kv(
     removed_count = n_to_remove,
-    remaining_count = length(ls(envir = .performance_cache)),
+    remaining_count = length(ls(envir = cache_env)),
     .context = "PERFORMANCE_CACHE"
   )
 
@@ -192,16 +213,18 @@ manage_cache_size <- function(size_limit = NULL) {
 #'
 #' @return Cached result eller NULL hvis ikke fundet/expired
 #'
-get_cached_result <- function(cache_key) {
-  if (!exists(cache_key, envir = .performance_cache)) {
+get_cached_result <- function(cache_key, app_state = NULL) {
+  cache_env <- resolve_performance_cache(app_state)
+
+  if (!exists(cache_key, envir = cache_env)) {
     return(NULL)
   }
 
-  cached_entry <- get(cache_key, envir = .performance_cache)
+  cached_entry <- get(cache_key, envir = cache_env)
 
   # Check if expired
   if (Sys.time() > cached_entry$expires_at) {
-    rm(list = cache_key, envir = .performance_cache)
+    rm(list = cache_key, envir = cache_env)
     log_debug_kv(
       message = "Cache entry expired and removed",
       cache_key = cache_key,
@@ -212,7 +235,7 @@ get_cached_result <- function(cache_key) {
 
   # Update access time for LRU management
   cached_entry$last_access <- Sys.time()
-  assign(cache_key, cached_entry, envir = .performance_cache)
+  assign(cache_key, cached_entry, envir = cache_env)
 
   return(cached_entry)
 }
@@ -225,7 +248,8 @@ get_cached_result <- function(cache_key) {
 #' @param value Value at cache
 #' @param timeout_seconds Timeout i sekunder
 #'
-cache_result <- function(cache_key, value, timeout_seconds) {
+cache_result <- function(cache_key, value, timeout_seconds, app_state = NULL) {
+  cache_env <- resolve_performance_cache(app_state)
   cached_entry <- list(
     value = value,
     created_at = Sys.time(),
@@ -234,7 +258,7 @@ cache_result <- function(cache_key, value, timeout_seconds) {
     size_estimate = object.size(value)
   )
 
-  assign(cache_key, cached_entry, envir = .performance_cache)
+  assign(cache_key, cached_entry, envir = cache_env)
 }
 
 #' Clear Performance Cache
@@ -250,15 +274,16 @@ cache_result <- function(cache_key, value, timeout_seconds) {
 #' clear_performance_cache("autodetect_.*") # Clear kun autodetect cache
 #' }
 #' @keywords internal
-clear_performance_cache <- function(pattern = NULL) {
-  cache_keys <- ls(envir = .performance_cache)
+clear_performance_cache <- function(pattern = NULL, app_state = NULL) {
+  cache_env <- resolve_performance_cache(app_state)
+  cache_keys <- ls(envir = cache_env)
 
   if (!is.null(pattern)) {
     cache_keys <- cache_keys[grepl(pattern, cache_keys)]
   }
 
   if (length(cache_keys) > 0) {
-    rm(list = cache_keys, envir = .performance_cache)
+    rm(list = cache_keys, envir = cache_env)
 
     log_debug_kv(
       message = "Performance cache cleared",

--- a/R/utils_server_events_data.R
+++ b/R/utils_server_events_data.R
@@ -41,12 +41,12 @@ register_data_lifecycle_events <- function(app_state, emit, input, output, sessi
         # SPRINT 4: Smart QIC cache invalidation (context-aware)
         invalidate_qic_cache_smart(app_state, update_context)
 
-        # Legacy performance cache clearing
+        # Legacy performance cache clearing (#529: pass app_state for session-scope)
         if (exists("clear_performance_cache") && is.function(clear_performance_cache)) {
           safe_operation(
             "Clear performance cache on data update",
             code = {
-              clear_performance_cache()
+              clear_performance_cache(app_state = app_state)
               log_debug("Performance cache cleared due to data update", .context = "CACHE_INVALIDATION")
             },
             fallback = function(e) {

--- a/R/utils_server_events_navigation.R
+++ b/R/utils_server_events_navigation.R
@@ -97,13 +97,22 @@ register_navigation_events <- function(app_state, emit, session, register_observ
           )
         }
 
-        # Clear all caches on session reset
+        # Clear all caches on session reset (#529: pass app_state for session-scope)
         if (exists("clear_performance_cache") && is.function(clear_performance_cache)) {
           safe_operation(
             "Clear performance cache on session reset",
             code = {
-              clear_performance_cache()
+              clear_performance_cache(app_state = app_state)
               log_debug("Performance cache cleared due to session reset", .context = "CACHE_INVALIDATION")
+            }
+          )
+        }
+        if (exists("clear_data_signature_cache") && is.function(clear_data_signature_cache)) {
+          safe_operation(
+            "Clear data-signature cache on session reset",
+            code = {
+              clear_data_signature_cache(app_state = app_state)
+              log_debug("Data-signature cache cleared due to session reset", .context = "CACHE_INVALIDATION")
             }
           )
         }


### PR DESCRIPTION
## Summary

### #529 Cross-session cache contamination — CRITICAL
.performance_cache + .data_signature_cache lå på package-niveau → delt mellem alle samtidige sessions i samme R-process. Multi-session Connect Cloud-deploys risikerer at serve cached resultater fra anden bruger's data-signaturer.

**Fix:**
- Tilføjet `app_state$cache$performance` + `app_state$cache$data_signature` i state_management.R (begge `new.env(parent = emptyenv())` per session).
- `resolve_performance_cache(app_state)` + `resolve_data_signature_cache(app_state)` helpers returnerer session-scoped cache når app_state er sat, ellers module-level fallback (bagudkompatibel for tests/batch-jobs).
- Public APIs (manage_cache_size, get_cached_result, cache_result, clear_performance_cache, generate_shared_data_signature, generate_qic_cache_key_optimized, generate_autodetect_cache_key_optimized, clear_data_signature_cache, get_data_signature_cache_stats) tager nu optional app_state-parameter.
- Primære callers opdateret: cache_auto_detection_results, session_reset observer, data_updated observer.
- Session_reset ryder nu også data-signature cache (manglede før).

### #538 parse_danish_dates O(cols × 23 fmt × 24 regex)
purrr::reduce2-loop udfører 24 regex-substitutions per format-attempt, selv på rent-numeriske datoer (15-03-2024) hvor måned-substitution er no-op.

**Fix:** Early-exit. Hvis ingen alfabetiske tegn i samplet (head 100), springes hele substitution-loopet over. Pure-numeric dato-kolonner rammer 0 regex-ops i stedet for 24.

## Test plan
- [x] testthat suite (performance|cache|signature|autodetect|date): 670 PASS, 3 SKIP, 0 FAIL

Fixes #529
Fixes #538