### PR TITLE
refactor(state): migrér current_tab/previous_tab til app_state$navigation (#532)

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -224,24 +224,21 @@ main_app_server <- function(input, output, session) {
   export_module_status <- mod_export_server("export", app_state, parent_session = session)
 
   ## Track forrige tab for kontekstuel tilbagenavigation paa hjaelpesider
-  current_tab <- shiny::reactiveVal("start")
-  previous_tab <- shiny::reactiveVal("start")
-  # Issue #536: Konsolideret main_navbar-observer.
-  # Tidligere fandtes en duplikeret observer i utils_server_event_listeners.R
-  # som emittede navigation_changed. Vi konsoliderer her med STATE_MANAGEMENT-
-  # priority for at garantere active_tab er sat FØR navigation_changed-listeners
-  # (STATUS_UPDATES = 500) afvikles. Atomisk: state-write → emit.
+  ## Issue #532: state konsolideret til app_state$navigation (single source of truth).
+  ## Issue #536: Konsolideret main_navbar-observer med STATE_MANAGEMENT-priority
+  ## for at garantere state-write FØR navigation_changed-listeners (STATUS_UPDATES = 500).
+  ## Atomisk: state-write → emit.
   shiny::observeEvent(input$main_navbar,
     ignoreInit = TRUE,
     priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,
     {
       new_tab <- input$main_navbar
-      old_tab <- current_tab()
+      old_tab <- app_state$navigation$current_tab
       help_tabs <- c("app_guide", "hjaelp")
       if (new_tab %in% help_tabs) {
-        previous_tab(old_tab)
+        app_state$navigation$previous_tab <- old_tab
       }
-      current_tab(new_tab)
+      app_state$navigation$current_tab <- new_tab
       # Opdater app_state saa eksport-observere kan gate paa aktiv tab (Issue #394)
       app_state$session$active_tab <- new_tab
       emit$navigation_changed()
@@ -249,10 +246,10 @@ main_app_server <- function(input, output, session) {
   )
 
   ## App-vejledning modul (tilbagenavigation til forrige tab)
-  mod_app_guide_server("app_guide", parent_session = session, previous_tab = previous_tab)
+  mod_app_guide_server("app_guide", parent_session = session, app_state = app_state)
 
   ## Hjaelpeside modul (tilbagenavigation til forrige tab)
-  mod_help_server("help", parent_session = session, previous_tab = previous_tab)
+  mod_help_server("help", parent_session = session, app_state = app_state)
 
   ## Landing page modul
   mod_landing_server("landing", parent_session = session, app_state = app_state)

--- a/R/mod_app_guide_server.R
+++ b/R/mod_app_guide_server.R
@@ -8,11 +8,13 @@
 #'
 #' @param id Module ID
 #' @param parent_session Shiny session. Parent session for navbar navigation.
-#' @param previous_tab ReactiveVal. Den forrige tab brugeren var på.
+#' @param app_state Centraliseret app state. Issue #532: tab-state læses fra
+#'   app_state$navigation$previous_tab (tidligere passerede vi en separat
+#'   reactiveVal).
 #' @return NULL
 #' @keywords internal
-mod_app_guide_server <- function(id, parent_session = NULL, previous_tab = NULL) {
+mod_app_guide_server <- function(id, parent_session = NULL, app_state = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
-    setup_help_back_navigation(input, parent_session, previous_tab)
+    setup_help_back_navigation(input, parent_session, app_state)
   })
 }

--- a/R/mod_help_server.R
+++ b/R/mod_help_server.R
@@ -8,11 +8,13 @@
 #'
 #' @param id Module ID
 #' @param parent_session Shiny session. Parent session for navbar navigation.
-#' @param previous_tab ReactiveVal. Den forrige tab brugeren var på.
+#' @param app_state Centraliseret app state. Issue #532: tab-state læses fra
+#'   app_state$navigation$previous_tab (tidligere passerede vi en separat
+#'   reactiveVal).
 #' @return NULL
 #' @keywords internal
-mod_help_server <- function(id, parent_session = NULL, previous_tab = NULL) {
+mod_help_server <- function(id, parent_session = NULL, app_state = NULL) {
   shiny::moduleServer(id, function(input, output, session) {
-    setup_help_back_navigation(input, parent_session, previous_tab)
+    setup_help_back_navigation(input, parent_session, app_state)
   })
 }

--- a/R/state_management.R
+++ b/R/state_management.R
@@ -263,7 +263,13 @@ create_app_state <- function() {
 
   # Navigation State - For eventReactive patterns
   app_state$navigation <- shiny::reactiveValues(
-    trigger = 0 # Counter for triggering navigation-dependent reactives
+    trigger = 0, # Counter for triggering navigation-dependent reactives
+
+    # Issue #532: current_tab/previous_tab konsolideret hertil fra ad-hoc
+    # reactiveVal i app_server_main.R. Bruges af help/app_guide-moduler til
+    # kontekstuel tilbagenavigation. Default "start" matcher landing-page.
+    current_tab = "start",
+    previous_tab = "start"
   )
 
   # Visualization State - Convert to reactiveValues for consistency

--- a/R/utils_ui_ui_helpers.R
+++ b/R/utils_ui_ui_helpers.R
@@ -105,14 +105,19 @@ help_back_link <- function(ns) {
 #'
 #' @param input Shiny input
 #' @param parent_session Parent session for navbar navigation
-#' @param previous_tab ReactiveVal med den forrige tab
+#' @param app_state Centraliseret app state. Issue #532: previous_tab læses
+#'   nu fra app_state$navigation$previous_tab i stedet for separat reactiveVal.
 #' @noRd
-setup_help_back_navigation <- function(input, parent_session, previous_tab) {
+setup_help_back_navigation <- function(input, parent_session, app_state) {
   shiny::observeEvent(input$go_back,
     priority = OBSERVER_PRIORITIES$STATUS_UPDATES,
     {
-      if (!is.null(parent_session) && !is.null(previous_tab)) {
-        dest <- previous_tab()
+      if (!is.null(parent_session) && !is.null(app_state) &&
+        !is.null(app_state$navigation)) {
+        dest <- app_state$navigation$previous_tab
+        if (is.null(dest) || !nzchar(dest)) {
+          dest <- "start"
+        }
         if (dest == "start") {
           shinyjs::runjs("document.body.classList.remove('wizard-nav-active');")
         }


### PR DESCRIPTION
## Summary

Tidligere lå `current_tab` + `previous_tab` som ad-hoc `shiny::reactiveVal()` i app_server_main.R og blev threaded som arguments til mod_app_guide_server + mod_help_server. Det fragmenterede navigation-state og krænkede single-source-of-truth-mandatet for app_state.

**Fix:**
- Konsolideret til `app_state$navigation$current_tab` og `app_state$navigation$previous_tab`
- Modulerne tager nu `app_state`-arg i stedet for previous_tab-reactiveVal
- `setup_help_back_navigation()` læser direkte fra app_state$navigation$previous_tab
- `active_tab` i `app_state$session$active_tab` forbliver uændret (eksport-gating, Issue #394) — semantisk forskellig fra navigation-state

## Skipper #537 pending profil-evidence
`#537` (flatten app_state$columns nested reactiveValues) er udskudt. Issue er spekulativ uden kvantificering af phantom-invalidations, og refactoren er bredt breaking ift. eksisterende state-accessors. Genåbnes hvis `observe({app_state$columns}); count` viser konkret problem.

## Test plan
- [x] testthat suite (navigation|help|app_guide|state_management|ui_helpers): 40 PASS, 0 FAIL
- [x] full testthat suite: ingen failures

Fixes #532
Refs #537 (deferred)