### PR TITLE
refactor(viewport): simplify per code review (#610)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,19 +3,10 @@
 ## Nye features
 
 * **Eliminer dobbelt-render af analyse-graf efter data-upload (#610):**
-  Browser-side `ResizeObserver` (`inst/app/www/viewport-ready.js`) sender
-  nu et `viewport_ready`-signal til serveren først når plot-containeren
-  har fået en reel layout-måling. `spc_inputs_raw` er gated på dette
-  signal, hvilket eliminerer den syntetiske 800x600 cold-start-render
-  (Shiny's CSS-default container-størrelse rapporteres umiddelbart via
-  `session$clientData` før browseren har målt layout). Tidligere førte
-  dette til to separate analyse-renders per upload med forskellige
-  cache-keys. `spc_inputs` er nu single source of truth for viewport
-  i compute- og cache-pipelinen — tidligere eksisterede en split-brain
-  mellem `FONT_SCALING`'s viewport (clientData) og BFHcharts-kaldets
-  viewport (`get_viewport_dims(app_state)`). Fallback via
-  `later::later(2s)` sikrer at signalet flippes selv i miljøer uden
-  `ResizeObserver` (headless tests, JS deaktiveret).
+  Analyse-grafen rendres nu kun én gang efter upload. Tidligere udløste
+  Shiny's CSS-default container-størrelse (800×600) en syntetisk
+  cold-start-render før browseren havde målt det reelle viewport, hvilket
+  gav to separate beregninger med forskellige cache-keys per upload.
 
 * **Footnote-felt i PDF/PNG-eksport (#485):** Bruger kan nu tilføje
   klinisk attribution (datakilde, udtræksdato) i trin 3 (Eksport).

--- a/R/config_log_contexts.R
+++ b/R/config_log_contexts.R
@@ -119,7 +119,8 @@ LOG_CONTEXTS <- list(
     x_axis_format = "X_AXIS_FORMAT",
     y_axis_scaling = "Y_AXIS_SCALING",
     sync = "[UI_SYNC]", # Bracket format for consistency with legacy
-    y_axis_ui = "[Y_AXIS_UI]"
+    y_axis_ui = "[Y_AXIS_UI]",
+    viewport = "VIEWPORT_DIMENSIONS"
   ),
 
   # === Column Management ===

--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -64,30 +64,28 @@ create_spc_results_reactive <- function(
       inputs$config$n_col %||% "NULL"
     )
 
-    # M11: Context-aware cache key for plot isolation
-    # Issue #62: Separate cache per context to prevent dimension bleeding
-    # Issue #610: Single source of truth — vp dims fra inputs (sat via
-    # viewport_ready event), ikke get_viewport_dims(app_state). Dette
-    # forhindrer split-brain mellem cache-key og BFHcharts-kald.
-    plot_context <- "analysis" # Analyse-side always uses "analysis" context
+    # Cache key: viewport dims must come from inputs (single source) — NOT
+    # get_viewport_dims(app_state) — to stay consistent with the BFHcharts
+    # call below. target_text is included so operator-only edits invalidate.
+    plot_context <- "analysis"
 
     cache_key <- digest::digest(
       list(
-        plot_context, # NEW: Context identifier for cache isolation
+        plot_context,
         inputs$data_hash,
         inputs$chart_type,
         config_key,
         inputs$target_value,
-        inputs$target_text, # CRITICAL: Include target_text for operator invalidation
+        inputs$target_text,
         inputs$centerline_value,
         inputs$skift_hash,
         inputs$frys_hash,
         inputs$title,
         inputs$y_axis_unit,
         inputs$kommentar_column,
-        inputs$base_size, # FIX: Invalider cache ved breddeaendring/fuldskaerm
-        inputs$viewport_width_px, # Issue #610: from inputs (single source)
-        inputs$viewport_height_px # Issue #610: from inputs (single source)
+        inputs$base_size,
+        inputs$viewport_width_px,
+        inputs$viewport_height_px
       ),
       algo = "xxhash64"
     )
@@ -145,9 +143,6 @@ create_spc_results_reactive <- function(
     computation <- safe_operation(
       "Generate SPC plot",
       code = {
-        # Issue #610: Viewport dims fra inputs (single source) — ikke
-        # get_viewport_dims(app_state) som ville aabne for split-brain.
-
         # SPRINT 4: Pass QIC cache for performance optimization
         qic_cache <- if (!is.null(app_state) && !is.null(app_state$cache)) {
           get_or_init_qic_cache(app_state)
@@ -301,20 +296,16 @@ create_spc_results_reactive <- function(
   }) |>
     shiny::bindCache({
       inputs <- spc_inputs_reactive()
-      # M11: Context-aware cache binding
-      # Issue #62: Include context and viewport dimensions for cache isolation
-      # Issue #610: vp dims fra inputs (single source) — sammen med cache-key
-      # i reactive body for at undgaa split-brain.
       plot_context <- "analysis"
 
       list(
         "spc_results",
-        plot_context, # NEW: Context identifier ensures separate cache per context
+        plot_context,
         inputs$data_hash,
         inputs$chart_type,
         paste0(inputs$config$x_col %||% "NULL", "|", inputs$config$y_col %||% "NULL", "|", inputs$config$n_col %||% "NULL"),
         inputs$target_value,
-        inputs$target_text, # CRITICAL: Include target_text for operator invalidation
+        inputs$target_text,
         inputs$centerline_value,
         inputs$skift_hash,
         inputs$frys_hash,

--- a/R/mod_spc_chart_inputs.R
+++ b/R/mod_spc_chart_inputs.R
@@ -57,22 +57,16 @@ create_data_ready_reactive <- function(module_data_reactive) {
 #' to BFHcharts API parameters, handles chart type-specific configuration,
 #' and includes viewport dimensions for responsive font scaling.
 #'
-#' Issue #610: Viewport dimensions are now read from centralized
-#' `app_state$visualization$viewport_dims` (populated by the
-#' `input$viewport_ready` JS event in `register_viewport_observer`),
-#' not directly from `session$clientData`. This ensures `spc_inputs`
-#' is the single source of truth for viewport across compute + cache,
-#' eliminating the synthetic 800x600 cold-start render.
+#' Viewport is read from `app_state$visualization$viewport_dims` and gated
+#' on `app_state$visualization$viewport_ready` so cold-start evaluation
+#' waits for a real browser layout measurement.
 #'
 #' @param data_ready_reactive Reactive expression returning validated data
 #' @param chart_config Debounced reactive returning chart configuration
-#' @param session Shiny session object (retained for backward compat — unused
-#'   for viewport reads after Issue #610)
-#' @param ns Namespace function for input IDs (retained for backward compat)
-#' @param app_state Reactive values object — viewport_dims source of truth
-#' @param viewport_ready_signal `reactiveVal(FALSE)` from
-#'   `register_viewport_observer`, gates cold-start evaluation on real
-#'   browser layout measurement
+#' @param session Shiny session object (used for `clientData$pixelratio`)
+#' @param ns Namespace function for input IDs
+#' @param app_state Reactive values object — source of viewport_dims +
+#'   viewport_ready gate
 #' @param y_axis_unit_reactive Reactive expression for Y-axis unit (optional)
 #' @param target_value_reactive Reactive expression for target value (optional)
 #' @param target_text_reactive Reactive expression for target text (optional)
@@ -92,14 +86,6 @@ create_data_ready_reactive <- function(module_data_reactive) {
 #'   - title, y_axis_unit, kommentar_column
 #'   - base_size, viewport_width_px, viewport_height_px, viewport_ready
 #'
-#' @details
-#' Complex parameter mapping includes:
-#' - Chart type-specific validation (e.g., run charts with count mode clear n_col)
-#' - Viewport dimension capture for responsive font scaling
-#' - Responsive base font size calculation using geometric mean of viewport
-#' - Debug logging of configuration state transitions
-#' - Handling of optional parameters with fallback values
-#'
 #' @keywords internal
 create_spc_inputs_reactive <- function(
   data_ready_reactive,
@@ -107,7 +93,6 @@ create_spc_inputs_reactive <- function(
   session,
   ns,
   app_state,
-  viewport_ready_signal,
   y_axis_unit_reactive = NULL,
   target_value_reactive = NULL,
   target_text_reactive = NULL,
@@ -171,16 +156,10 @@ create_spc_inputs_reactive <- function(
     kommentar_value <- if (!is.null(kommentar_column_reactive)) kommentar_column_reactive() else NULL
     target_text_value <- if (!is.null(target_text_reactive)) target_text_reactive() else NULL
 
-    # VIEWPORT DIMENSIONS — Issue #610:
-    # Kraev viewport_ready_signal foer cold-start kan fortsaette. Signal
-    # flippes TRUE af enten (a) JS ResizeObserver via input$viewport_ready,
-    # eller (b) 2-sekunders timeout-fallback i register_viewport_observer.
-    # Dette eliminerer det syntetiske 800x600 cold-start render.
-    shiny::req(viewport_ready_signal())
+    # Gate cold-start on real browser layout (#610) — flipped by JS
+    # ResizeObserver event or later::later fallback in register_viewport_observer.
+    shiny::req(isTRUE(app_state$visualization$viewport_ready))
 
-    # Single source of truth: laes vp-dims fra centraliseret app_state
-    # (sat af register_viewport_observer). Tidligere blev clientData laest
-    # direkte her, samtidig med at compute.R laeste fra app_state — split-brain.
     vp_dims <- get_viewport_dims(app_state)
     width_px <- vp_dims$width
     height_px <- vp_dims$height
@@ -205,8 +184,6 @@ create_spc_inputs_reactive <- function(
     # GEOMETRIC MEAN APPROACH: sqrt(width_px * height_px) giver balanced scaling
     # baseret paa baade bredde og hoejde. Dette sikrer at fonts skalerer intuitivt
     # med den samlede plotstoerrelse, ikke kun en dimension.
-    # pixelratio bevares fra clientData — uafhaengigt af viewport-dimensioner
-    # og rapporteres korrekt af Shiny ved session-init.
     pixelratio <- session$clientData$pixelratio %||% 1
     viewport_diagonal <- sqrt(width_px * height_px)
     base_size <- max(

--- a/R/mod_spc_chart_observers.R
+++ b/R/mod_spc_chart_observers.R
@@ -6,40 +6,24 @@
 # Purpose: Register and manage reactive observers that handle side effects
 #          in the SPC chart module, including viewport dimension tracking,
 #          state synchronization, and cache invalidation.
-#
-# Extracted from: mod_spc_chart_server.R (Stage 5 of Phase 2c refactoring)
-# Depends on: app_state (centralized Shiny state)
-#            session (for clientData access)
-#            set_viewport_dims (from utils_viewport_helpers.R)
 # ==============================================================================
+
+#' Fallback delay before flipping `viewport_ready` if no JS event arrives.
+#' @keywords internal
+VIEWPORT_READY_FALLBACK_SECS <- 2
 
 #' Register Viewport Dimension Observer
 #'
-#' Tracks viewport (plot container) dimensions and ensures cold-start renders
-#' wait for a real browser layout measurement before producing a chart.
+#' Tracks viewport (plot container) dimensions and gates SPC analysis
+#' cold-start render on a real browser layout measurement.
 #'
-#' Two complementary mechanisms (Issue #610):
-#' \itemize{
-#'   \item \strong{clientData observer} — keeps writing dimensions from
-#'     `session$clientData` into `app_state$visualization$viewport_dims`.
-#'     This preserves backward-compatible behavior (resize tracking,
-#'     test environments where `mockclientdata` returns valid dims).
-#'   \item \strong{viewport_ready signal} — gates `spc_inputs_raw` on the
-#'     first real layout. The browser-side ResizeObserver
-#'     (`inst/app/www/viewport-ready.js`) fires `input$viewport_ready` once
-#'     `#visualization-spc_plot_actual` has dims > 100x100 px. This observer
-#'     mirrors the measurement into `app_state` and flips the signal TRUE.
-#'   \item \strong{Timeout fallback} — `later::later(fallback_delay_secs)`
-#'     flips the signal TRUE even if the JS event never arrives (no
-#'     ResizeObserver, headless tests, JS disabled), using clientData
-#'     dimensions written by Observer 1 or `VIEWPORT_DEFAULTS`.
-#' }
-#'
-#' Why both: clientData reports the CSS-default 800x600 immediately at
-#' startup, before the browser has measured the actual layout. spc_inputs
-#' needs to know when to start trusting the dimensions — that's the role
-#' of `viewport_ready_signal`. The clientData observer is still useful
-#' for resize tracking after first layout.
+#' Why both clientData and JS event: `session$clientData` reports the
+#' CSS-default 800x600 immediately at startup, before the browser has
+#' measured layout. The JS `ResizeObserver`
+#' (`inst/app/www/viewport-ready.js`) fires `input$viewport_ready` only
+#' once a real layout (>100x100 px) is measured, allowing
+#' `spc_inputs_raw` to gate cold-start evaluation on
+#' `app_state$visualization$viewport_ready`.
 #'
 #' @param app_state Reactive values object containing visualization state
 #' @param session Shiny session object (for clientData access)
@@ -47,14 +31,9 @@
 #' @param ns Namespace function for output IDs
 #' @param emit Emit API object from `create_emit_api(app_state)`, created once
 #'   outside the observer to avoid recreating it on every reactive invalidation.
-#' @param viewport_ready_signal `reactiveVal(FALSE)` flipped TRUE once a real
-#'   measurement is available. `spc_inputs_raw` `req()`s on this.
-#' @param fallback_delay_secs Seconds to wait before firing the timeout
-#'   fallback. Default 2s (production). Tests may pass smaller values to
-#'   exercise the fallback path quickly.
-#' @param .scheduler Function with signature `function(callback, delay)`
-#'   used to schedule the fallback timeout. Default `later::later`. Tests
-#'   may inject a synchronous scheduler to drive the fallback deterministically.
+#' @param .scheduler Function with signature `function(callback, delay)` used
+#'   to schedule the fallback timeout. Default `later::later`. Tests may
+#'   inject a synchronous scheduler for deterministic execution.
 #'
 #' @return NULL (side effect: registers observer with Shiny)
 #'
@@ -65,13 +44,10 @@ register_viewport_observer <- function(
   input,
   ns,
   emit,
-  viewport_ready_signal,
-  fallback_delay_secs = 2,
   .scheduler = later::later
 ) {
-  # === Observer 1: clientData → app_state (legacy data source) ===
-  # Continues writing dimensions on every clientData change so resize events
-  # are tracked. testServer's mockclientdata exercises this path.
+  # Observer 1: clientData → app_state. Tracks resize events. testServer's
+  # mockclientdata exercises this path.
   shiny::observe({
     width <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_width")]]
     height <- session$clientData[[paste0("output_", ns("spc_plot_actual"), "_height")]]
@@ -84,13 +60,12 @@ register_viewport_observer <- function(
     set_viewport_dims(app_state, width, height, emit)
   })
 
-  # === Observer 2: input$viewport_ready → flip signal + write app_state ===
-  # JS ResizeObserver fires this once the browser has a real layout. Until
-  # this fires, `spc_inputs_raw` is gated and won't render the synthetic
-  # 800x600 cold-start frame.
+  # Observer 2: JS ResizeObserver → flip readiness gate + write app_state.
+  # ignoreInit = FALSE so the observer is wired before the JS event arrives
+  # (initial NULL is handled by the early-return guard below).
   shiny::observeEvent(input$viewport_ready, ignoreInit = FALSE, {
     payload <- input$viewport_ready
-    if (is.null(payload) || !is.list(payload)) {
+    if (!is.list(payload)) {
       return()
     }
     width <- payload$width
@@ -99,59 +74,53 @@ register_viewport_observer <- function(
       return()
     }
 
-    set_viewport_dims(app_state, as.numeric(width), as.numeric(height), emit)
-    viewport_ready_signal(TRUE)
+    set_viewport_dims(app_state, width, height, emit)
+    app_state$visualization$viewport_ready <- TRUE
 
     log_debug(
       sprintf("viewport_ready signal received: %dx%d", round(width), round(height)),
-      .context = "VIEWPORT_DIMENSIONS"
+      .context = LOG_CONTEXTS$ui$viewport
     )
   })
 
-  # === Fallback: later::later flips signal even without JS event ===
-  # Critical for headless tests, environments without ResizeObserver, and
-  # JS-disabled browsers (Issue #610 acceptance criterion: "No regression
-  # for environments where clientData is unavailable"). Uses whatever
-  # dimensions Observer 1 has already written to app_state, or VIEWPORT_DEFAULTS.
+  # Fallback: flip the gate even if the JS event never arrives. Critical
+  # for headless tests, environments without ResizeObserver, and JS-disabled
+  # browsers (Issue #610 acceptance criterion).
   .scheduler(
     function() {
-      if (isTRUE(shiny::isolate(viewport_ready_signal()))) {
+      if (isTRUE(shiny::isolate(app_state$visualization$viewport_ready))) {
         return(invisible(NULL))
       }
 
       current <- shiny::isolate(app_state$visualization$viewport_dims)
       width <- current$width
       height <- current$height
+      have_dims <- !is.null(width) && !is.null(height) && width > 100 && height > 100
 
-      if (!is.null(width) && !is.null(height) && width > 100 && height > 100) {
-        # Observer 1 already wrote a valid dimension — just flip the signal.
-        log_warn(
-          sprintf(
-            "viewport_ready JS event missing after %ss — using clientData-derived dims: %dx%d",
-            fallback_delay_secs, round(width), round(height)
-          ),
-          .context = "VIEWPORT_DIMENSIONS"
-        )
-      } else {
-        # Nothing valid in app_state — use VIEWPORT_DEFAULTS.
+      if (!have_dims) {
         set_viewport_dims(
           app_state,
           VIEWPORT_DEFAULTS$width,
           VIEWPORT_DEFAULTS$height,
           emit
         )
-        log_warn(
-          sprintf(
-            "viewport_ready JS event missing after %ss and clientData unavailable — using VIEWPORT_DEFAULTS: %dx%d",
-            fallback_delay_secs, VIEWPORT_DEFAULTS$width, VIEWPORT_DEFAULTS$height
-          ),
-          .context = "VIEWPORT_DIMENSIONS"
-        )
+        width <- VIEWPORT_DEFAULTS$width
+        height <- VIEWPORT_DEFAULTS$height
       }
 
-      viewport_ready_signal(TRUE)
+      log_warn(
+        sprintf(
+          "viewport_ready JS event missing after %ss — using %s: %dx%d",
+          VIEWPORT_READY_FALLBACK_SECS,
+          if (have_dims) "clientData-derived dims" else "VIEWPORT_DEFAULTS",
+          round(width), round(height)
+        ),
+        .context = LOG_CONTEXTS$ui$viewport
+      )
+
+      app_state$visualization$viewport_ready <- TRUE
     },
-    delay = fallback_delay_secs
+    delay = VIEWPORT_READY_FALLBACK_SECS
   )
 
   invisible(NULL)

--- a/R/mod_spc_chart_server.R
+++ b/R/mod_spc_chart_server.R
@@ -62,20 +62,12 @@ visualizationModuleServer <- function(
     # Both options wrap the same app_state$events, so no double-fire occurs.
     module_emit <- emit %||% create_emit_api(app_state)
 
-    # Issue #610: Gate cold-start render on real browser layout.
-    # JS ResizeObserver (inst/app/www/viewport-ready.js) fires
-    # input$viewport_ready when #visualization-spc_plot_actual has a real
-    # measurement. The observer below mirrors that into app_state and
-    # flips this signal TRUE; spc_inputs_raw req()s on it.
-    viewport_ready_signal <- shiny::reactiveVal(FALSE)
-
     register_viewport_observer(
       app_state = app_state,
       session = session,
       input = input,
       ns = ns,
-      emit = module_emit,
-      viewport_ready_signal = viewport_ready_signal
+      emit = module_emit
     )
 
     # Helper functions for app_state visualization management
@@ -107,7 +99,6 @@ visualizationModuleServer <- function(
       session = session,
       ns = ns,
       app_state = app_state,
-      viewport_ready_signal = viewport_ready_signal,
       y_axis_unit_reactive = y_axis_unit_reactive,
       target_value_reactive = target_value_reactive,
       target_text_reactive = target_text_reactive,

--- a/R/state_management.R
+++ b/R/state_management.R
@@ -277,6 +277,11 @@ create_app_state <- function() {
       height = NULL,
       last_updated = NULL
     ),
+    # Issue #610: Cold-start gate. FALSE indtil first-layout signal modtages
+    # (browser ResizeObserver via input$viewport_ready, eller later::later
+    # fallback). spc_inputs_raw req()er paa denne for at undgaa syntetisk
+    # 800x600 cold-start render.
+    viewport_ready = FALSE,
     anhoej_results = list(
       # Initialize with default values instead of NULL to prevent "Beregner..." stuck state
       longest_run = NA_real_,

--- a/inst/app/www/viewport-ready.js
+++ b/inst/app/www/viewport-ready.js
@@ -67,15 +67,16 @@
     }
 
     var fired = false;
+    var fallbackTimer = null;
     var observer = new ResizeObserver(function (entries) {
       if (fired) return;
       for (var i = 0; i < entries.length; i++) {
-        var entry = entries[i];
-        var box = entry.contentRect;
+        var box = entries[i].contentRect;
         if (box.width > MIN_DIM_PX && box.height > MIN_DIM_PX) {
           if (sendReady(box.width, box.height)) {
             fired = true;
             observer.disconnect();
+            if (fallbackTimer !== null) clearTimeout(fallbackTimer);
             break;
           }
         }
@@ -85,9 +86,9 @@
     observer.observe(el);
 
     // Belt-and-suspenders: if the observer hasn't fired within 1500 ms
-    // (e.g., element hidden behind tab), measure synchronously and send
-    // best-effort. Server-side timeout (2 s) is the ultimate fallback.
-    setTimeout(function () {
+    // (e.g., element hidden behind tab), measure synchronously. Server-side
+    // timeout (2 s) is the ultimate fallback.
+    fallbackTimer = setTimeout(function () {
       if (fired) return;
       var rect = el.getBoundingClientRect();
       if (rect.width > MIN_DIM_PX && rect.height > MIN_DIM_PX) {

--- a/tests/testthat/test-viewport-ready-signal.R
+++ b/tests/testthat/test-viewport-ready-signal.R
@@ -1,83 +1,46 @@
 # test-viewport-ready-signal.R
 # Issue #610: Tests for viewport_ready signal that gates SPC analysis
 # cold-start render until browser has produced a real layout measurement.
-#
-# Key invariants verified:
-#   1. spc_inputs_raw is gated on viewport_ready_signal (cold-start blocking)
-#   2. JS event input$viewport_ready flips signal + writes app_state dims
-#   3. later::later(2s) timeout fallback flips signal even without JS event
-#   4. Legitim 800x600 viewport from JS is NOT filtered (no hardcoded ban)
-#   5. Single source of truth: spc_inputs reads viewport from app_state,
-#      not from session$clientData directly
 
 library(shiny)
 library(testthat)
 
-# Helper aligned with test-mod-spc-chart-comprehensive.R
-create_mock_app_state <- function() {
-  app_state <- new.env(parent = emptyenv())
-  app_state$events <- reactiveValues(
-    visualization_update_needed = 0L,
-    navigation_changed = 0L
+vp_module_args <- function(app_state) {
+  list(
+    column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
+    chart_type_reactive = reactive("i"),
+    target_value_reactive = reactive(NULL),
+    target_text_reactive = reactive(NULL),
+    centerline_value_reactive = reactive(NULL),
+    skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
+    frys_config_reactive = reactive(NULL),
+    app_state = app_state
   )
-  app_state$data <- reactiveValues(current_data = NULL, updating_table = FALSE)
-  app_state$visualization <- reactiveValues(
-    module_cached_data = NULL,
-    module_data_cache = NULL,
-    cache_updating = FALSE,
-    plot_ready = FALSE,
-    plot_warnings = character(0),
-    is_computing = FALSE,
-    plot_generation_in_progress = FALSE,
-    plot_object = NULL,
-    anhoej_results = NULL,
-    last_centerline_value = NULL,
-    viewport_dims = list(width = NULL, height = NULL, last_updated = NULL)
+}
+
+vp_test_data <- function() {
+  data.frame(
+    Dato = as.Date("2024-01-01") + 0:9,
+    Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
   )
-  app_state$columns <- reactiveValues(
-    auto_detect = reactiveValues(
-      in_progress = FALSE, completed = FALSE,
-      results = NULL, frozen_until_next_trigger = FALSE
-    ),
-    mappings = reactiveValues(x_column = NULL, y_column = NULL, n_column = NULL)
-  )
-  app_state$ui <- reactiveValues(hide_anhoej_rules = FALSE)
-  app_state
 }
 
 describe("Issue #610: viewport_ready signal", {
-  it("input$viewport_ready event flips signal + writes app_state dims", {
+  it("input$viewport_ready event flipper gate + skriver app_state dims", {
     require_internal("visualizationModuleServer", mode = "function")
     skip_if_not_installed("later")
 
-    app_state <- create_mock_app_state()
+    app_state <- create_app_state()
 
-    testServer(
-      visualizationModuleServer,
-      args = list(
-        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
-        chart_type_reactive = reactive("i"),
-        target_value_reactive = reactive(NULL),
-        target_text_reactive = reactive(NULL),
-        centerline_value_reactive = reactive(NULL),
-        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
-        frys_config_reactive = reactive(NULL),
-        app_state = app_state
-      ),
-      {
-        # Simuler JS-event: ResizeObserver har maalt en reel layout
-        session$setInputs(viewport_ready = list(width = 1024, height = 600, ts = 12345))
-        session$flushReact()
+    testServer(visualizationModuleServer, args = vp_module_args(app_state), {
+      session$setInputs(viewport_ready = list(width = 1024, height = 600, ts = 12345))
+      session$flushReact()
 
-        dims <- shiny::isolate(app_state$visualization$viewport_dims)
-        expect_equal(dims$width, 1024,
-          info = "viewport_ready event skal opdatere app_state width"
-        )
-        expect_equal(dims$height, 600,
-          info = "viewport_ready event skal opdatere app_state height"
-        )
-      }
-    )
+      dims <- shiny::isolate(app_state$visualization$viewport_dims)
+      expect_equal(dims$width, 1024)
+      expect_equal(dims$height, 600)
+      expect_true(shiny::isolate(app_state$visualization$viewport_ready))
+    })
   })
 
   it("legitim 800x600 viewport accepteres (ingen hardcoded ban)", {
@@ -86,174 +49,100 @@ describe("Issue #610: viewport_ready signal", {
     require_internal("visualizationModuleServer", mode = "function")
     skip_if_not_installed("later")
 
-    app_state <- create_mock_app_state()
+    app_state <- create_app_state()
 
-    testServer(
-      visualizationModuleServer,
-      args = list(
-        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
-        chart_type_reactive = reactive("i"),
-        target_value_reactive = reactive(NULL),
-        target_text_reactive = reactive(NULL),
-        centerline_value_reactive = reactive(NULL),
-        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
-        frys_config_reactive = reactive(NULL),
-        app_state = app_state
-      ),
-      {
-        # Simuler reel 800x600 browser-viewport via JS-event
-        session$setInputs(viewport_ready = list(width = 800, height = 600, ts = 99999))
-        session$flushReact()
+    testServer(visualizationModuleServer, args = vp_module_args(app_state), {
+      session$setInputs(viewport_ready = list(width = 800, height = 600, ts = 99999))
+      session$flushReact()
 
-        dims <- shiny::isolate(app_state$visualization$viewport_dims)
-        expect_equal(dims$width, 800,
-          info = "Reel 800x600 viewport skal accepteres, ikke filtreres"
-        )
-        expect_equal(dims$height, 600,
-          info = "Reel 800x600 viewport skal accepteres, ikke filtreres"
-        )
-      }
-    )
+      dims <- shiny::isolate(app_state$visualization$viewport_dims)
+      expect_equal(dims$width, 800)
+      expect_equal(dims$height, 600)
+    })
   })
 
-  it("invalid viewport_ready payload ignoreres (defensive)", {
+  it("invalid viewport_ready payload ignoreres", {
     require_internal("visualizationModuleServer", mode = "function")
     skip_if_not_installed("later")
 
-    app_state <- create_mock_app_state()
-    # Pre-set kendt vaerdi for at kunne detektere uoenskede skrivninger
+    app_state <- create_app_state()
     app_state$visualization$viewport_dims <- list(
       width = 600, height = 400, last_updated = Sys.time()
     )
 
-    testServer(
-      visualizationModuleServer,
-      args = list(
-        column_config_reactive = reactive(list(x_col = "Dato", y_col = "Tæller", n_col = NULL)),
-        chart_type_reactive = reactive("i"),
-        target_value_reactive = reactive(NULL),
-        target_text_reactive = reactive(NULL),
-        centerline_value_reactive = reactive(NULL),
-        skift_config_reactive = reactive(list(show_phases = FALSE, skift_column = NULL)),
-        frys_config_reactive = reactive(NULL),
-        app_state = app_state
-      ),
-      {
-        # NULL payload — observer skal ignorere
-        session$setInputs(viewport_ready = NULL)
-        session$flushReact()
+    testServer(visualizationModuleServer, args = vp_module_args(app_state), {
+      session$setInputs(viewport_ready = NULL)
+      session$flushReact()
+      session$setInputs(viewport_ready = list(width = 50, height = 400, ts = 1))
+      session$flushReact()
 
-        # Width <= 100 — observer skal ignorere
-        session$setInputs(viewport_ready = list(width = 50, height = 400, ts = 1))
-        session$flushReact()
-
-        # mockclientdata vil dog skrive 600x400 via Observer 1, saa vi
-        # kan ikke direkte teste at viewport_ready-payload blev ignoreret.
-        # Indirekte test: signalet flippes IKKE af invalid payload alene.
-        # (Vi kan ikke direkte assert paa det interne signal her — men hvis
-        # observer-logikken var brudt, ville set_viewport_dims overskrive
-        # med invalid vaerdier hvilket vi tjekker for.)
-        dims <- shiny::isolate(app_state$visualization$viewport_dims)
-        expect_true(is.null(dims$width) || dims$width >= 100,
-          info = "Invalid viewport_ready-payload (width<100) maa ikke skrive til app_state"
-        )
-      }
-    )
+      dims <- shiny::isolate(app_state$visualization$viewport_dims)
+      expect_true(is.null(dims$width) || dims$width >= 100)
+    })
   })
 
-  it("spc_inputs uses viewport from app_state, not clientData (single source)", {
-    # Issue #610 single-source-invariant: efter denne PR laeses viewport
-    # i create_spc_inputs_reactive fra get_viewport_dims(app_state), IKKE
-    # fra session$clientData direkte. Verificerer ved at saette kendt
-    # vaerdi i app_state og bekraefte at compute-pipelinen bruger den.
+  it("spc_inputs laeser viewport fra app_state (single source)", {
     require_internal("create_spc_inputs_reactive", mode = "function")
 
-    app_state <- create_mock_app_state()
-    # Saet kendte dims i app_state
+    app_state <- create_app_state()
     app_state$visualization$viewport_dims <- list(
       width = 1280, height = 720, last_updated = Sys.time()
     )
+    app_state$visualization$viewport_ready <- TRUE
 
-    # Reactive-baseret unit-test: byg reactive-graf direkte
-    test_data <- data.frame(
-      Dato = as.Date("2024-01-01") + 0:9,
-      Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
-    )
+    test_data <- vp_test_data()
 
     shiny::testServer(
       function(id) {
         shiny::moduleServer(id, function(input, output, session) {
-          # Simuler at viewport_ready_signal allerede er flippet
-          viewport_ready_signal <- shiny::reactiveVal(TRUE)
-
-          data_ready_reactive <- shiny::reactive(test_data)
-          chart_config_reactive <- shiny::reactive(
-            list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
-          )
-
           spc_inputs <- create_spc_inputs_reactive(
-            data_ready_reactive = data_ready_reactive,
-            chart_config = chart_config_reactive,
+            data_ready_reactive = shiny::reactive(test_data),
+            chart_config = shiny::reactive(
+              list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
+            ),
             session = session,
             ns = session$ns,
             app_state = app_state,
-            viewport_ready_signal = viewport_ready_signal,
             y_axis_unit_reactive = shiny::reactive("count")
           )
 
           observe({
-            inputs <- spc_inputs()
-            session$userData$captured_inputs <- inputs
+            session$userData$captured_inputs <- spc_inputs()
           })
         })
       },
       {
         session$flushReact()
         captured <- session$userData$captured_inputs
-        expect_false(is.null(captured),
-          info = "spc_inputs skal evaluere efter signal flippes TRUE"
-        )
-        expect_equal(captured$viewport_width_px, 1280,
-          info = "spc_inputs skal laese width fra app_state, ikke clientData"
-        )
-        expect_equal(captured$viewport_height_px, 720,
-          info = "spc_inputs skal laese height fra app_state, ikke clientData"
-        )
+        expect_false(is.null(captured))
+        expect_equal(captured$viewport_width_px, 1280)
+        expect_equal(captured$viewport_height_px, 720)
       }
     )
   })
 
-  it("spc_inputs blocks until viewport_ready_signal flips TRUE (cold-start gate)", {
+  it("spc_inputs blokeres indtil viewport_ready flippes TRUE (cold-start gate)", {
     require_internal("create_spc_inputs_reactive", mode = "function")
 
-    app_state <- create_mock_app_state()
+    app_state <- create_app_state()
     app_state$visualization$viewport_dims <- list(
       width = 1024, height = 600, last_updated = Sys.time()
     )
+    # viewport_ready starter FALSE (default fra create_app_state)
 
-    test_data <- data.frame(
-      Dato = as.Date("2024-01-01") + 0:9,
-      Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
-    )
+    test_data <- vp_test_data()
 
     shiny::testServer(
       function(id) {
         shiny::moduleServer(id, function(input, output, session) {
-          # Signal starter FALSE — som i prod cold-start
-          viewport_ready_signal <- shiny::reactiveVal(FALSE)
-
-          data_ready_reactive <- shiny::reactive(test_data)
-          chart_config_reactive <- shiny::reactive(
-            list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
-          )
-
           spc_inputs <- create_spc_inputs_reactive(
-            data_ready_reactive = data_ready_reactive,
-            chart_config = chart_config_reactive,
+            data_ready_reactive = shiny::reactive(test_data),
+            chart_config = shiny::reactive(
+              list(x_col = "Dato", y_col = "Vaerdi", n_col = NULL, chart_type = "run")
+            ),
             session = session,
             ns = session$ns,
             app_state = app_state,
-            viewport_ready_signal = viewport_ready_signal,
             y_axis_unit_reactive = shiny::reactive("count")
           )
 
@@ -268,66 +157,44 @@ describe("Issue #610: viewport_ready signal", {
             )
           })
 
-          # Eksponer eval_count + signal til outer test
           session$userData$eval_count_fn <- function() eval_count
-          session$userData$flip_signal <- function() viewport_ready_signal(TRUE)
         })
       },
       {
         session$flushReact()
-        # Signal er FALSE — req() blokker, ingen full evaluation
-        count_before <- session$userData$eval_count_fn()
-        expect_equal(count_before, 0,
-          info = "spc_inputs maa IKKE evaluere foer viewport_ready_signal er TRUE"
+        expect_equal(session$userData$eval_count_fn(), 0,
+          info = "spc_inputs maa IKKE evaluere mens viewport_ready=FALSE"
         )
 
-        # Flip signal — spc_inputs skal nu evaluere
-        session$userData$flip_signal()
+        app_state$visualization$viewport_ready <- TRUE
         session$flushReact()
 
-        count_after <- session$userData$eval_count_fn()
-        # Acceptkriterium #610: "FONT_SCALING log entry appears exactly once
-        # per upload (not twice)". Hver spc_inputs-evaluering trigger en
-        # FONT_SCALING log-linje, saa eval_count == 1 svarer til log == 1.
-        expect_equal(count_after, 1,
-          info = paste0(
-            "spc_inputs skal evaluere PRAECIS ÉN gang efter signal flippes TRUE ",
-            "(forhindrer dobbelt-render fra Issue #610). Faktisk: ",
-            count_after
-          )
+        # Acceptkriterium #610: FONT_SCALING log entry appears exactly once
+        # per upload. Hver spc_inputs-evaluering trigger en FONT_SCALING-linje.
+        expect_equal(session$userData$eval_count_fn(), 1,
+          info = "spc_inputs skal evaluere praecis én gang efter gate aabnes"
         )
       }
     )
   })
 
-  it("fallback scheduler flipper signal selv uden JS-event", {
+  it("fallback scheduler flipper gate selv uden JS-event", {
     # Acceptkriterium: "No regression for environments where clientData is
-    # unavailable". Headless/JS-disabled miljoer — fallback-timeren skal
-    # flippe signalet alligevel. Tester via injiceret synkron scheduler
-    # for deterministisk eksekvering uden afhaengighed af later::later
-    # globale koe (state-pollution mellem tests).
+    # unavailable". Tester via injiceret synkron scheduler.
     require_internal("register_viewport_observer", mode = "function")
 
-    app_state <- create_mock_app_state()
-    viewport_ready_signal <- shiny::reactiveVal(FALSE)
-
-    # Synkron scheduler — kalder callback straks
-    sync_scheduler <- function(callback, delay) {
-      callback()
-    }
+    app_state <- create_app_state()
+    sync_scheduler <- function(callback, delay) callback()
 
     shiny::testServer(
       function(id) {
         shiny::moduleServer(id, function(input, output, session) {
-          emit <- create_emit_api(app_state)
           register_viewport_observer(
             app_state = app_state,
             session = session,
             input = input,
             ns = session$ns,
-            emit = emit,
-            viewport_ready_signal = viewport_ready_signal,
-            fallback_delay_secs = 0,
+            emit = create_emit_api(app_state),
             .scheduler = sync_scheduler
           )
         })
@@ -335,15 +202,9 @@ describe("Issue #610: viewport_ready signal", {
       {
         session$flushReact()
 
-        expect_true(shiny::isolate(viewport_ready_signal()),
-          info = "Fallback-scheduler skal flippe signal TRUE selv uden JS-event"
-        )
-        # Fallback skal saette VIEWPORT_DEFAULTS i app_state naar clientData/
-        # eksisterende dims er tomme.
+        expect_true(shiny::isolate(app_state$visualization$viewport_ready))
         dims <- shiny::isolate(app_state$visualization$viewport_dims)
-        expect_false(is.null(dims$width),
-          info = "Fallback skal skrive width til app_state"
-        )
+        expect_false(is.null(dims$width))
       }
     )
   })


### PR DESCRIPTION
## Summary

Follow-up til [PR #620](https://github.com/johanreventlow/biSPCharts/pull/620) (Issue #610) — aggregeret review-fixes efter `/simplify`-pass.

- **Flyt gate til app_state**: `viewport_ready_signal` (lokal `reactiveVal`) → `app_state\$visualization\$viewport_ready` (matcher state-pattern). Eliminerer 2 parametre fra `register_viewport_observer` + `create_spc_inputs_reactive`.
- **Centralisér log-context**: `LOG_CONTEXTS\$ui\$viewport` (project-konvention).
- **Strip narrating comments**: redundante #610-referencer fjernet (hører i commit/PR).
- **Drop `fallback_delay_secs` parameter**: konstant `VIEWPORT_READY_FALLBACK_SECS = 2`. `.scheduler` injection dækker test-behov.
- **Drop `as.numeric()` casts**: defensive overkill — JS sender Number, Shiny serialiserer korrekt.
- **JS leak-fix**: `clearTimeout(fallbackTimer)` når ResizeObserver fyrer først.
- **Test cleanup**: brug real `create_app_state()` i stedet for duplikeret mock-helper. Reducerer test-fil fra 350 → 200 linjer via shared `vp_module_args` + `vp_test_data` helpers.
- **NEWS.md trim**: 15 → 5 linjer (user-vendt sammenfatning, intern arkitektur til commit/ADR).

**Net diff:** -213 linjer (377 deletions, 164 insertions). Ingen adfærdsændringer.

## Test plan

- [x] `tests/testthat/test-viewport-ready-signal.R`: 6 tests pass
- [x] Full test-suite: 2108 tests, 0 fail, 0 error, 79 skip
- [x] Pre-push gate: passed (fast mode, 63s)

## Related

- PR #620 (merged)
- Issue #610 (closed)