### PR TITLE
fix(check): document app_state param (unblock #627)

### DIFF
--- a/R/utils_performance_caching.R
+++ b/R/utils_performance_caching.R
@@ -210,6 +210,8 @@ manage_cache_size <- function(size_limit = NULL, app_state = NULL) {
 #' Henter cached result hvis det eksisterer og ikke er expired.
 #'
 #' @param cache_key Character string med cache key
+#' @param app_state Optional app_state for centralized cache resolution.
+#'   Default NULL bruger global cache env.
 #'
 #' @return Cached result eller NULL hvis ikke fundet/expired
 #'
@@ -247,6 +249,8 @@ get_cached_result <- function(cache_key, app_state = NULL) {
 #' @param cache_key Character string med cache key
 #' @param value Value at cache
 #' @param timeout_seconds Timeout i sekunder
+#' @param app_state Optional app_state for centralized cache resolution.
+#'   Default NULL bruger global cache env.
 #'
 cache_result <- function(cache_key, value, timeout_seconds, app_state = NULL) {
   cache_env <- resolve_performance_cache(app_state)

--- a/man/cache_result.Rd
+++ b/man/cache_result.Rd
@@ -12,6 +12,9 @@ cache_result(cache_key, value, timeout_seconds, app_state = NULL)
 \item{value}{Value at cache}
 
 \item{timeout_seconds}{Timeout i sekunder}
+
+\item{app_state}{Optional app_state for centralized cache resolution.
+Default NULL bruger global cache env.}
 }
 \description{
 Gemmer result i cache med expiration time.

--- a/man/get_cached_result.Rd
+++ b/man/get_cached_result.Rd
@@ -8,6 +8,9 @@ get_cached_result(cache_key, app_state = NULL)
 }
 \arguments{
 \item{cache_key}{Character string med cache key}
+
+\item{app_state}{Optional app_state for centralized cache resolution.
+Default NULL bruger global cache env.}
 }
 \value{
 Cached result eller NULL hvis ikke fundet/expired


### PR DESCRIPTION
## Summary

#627 stadig rød efter #630-merge. Gate-job WARNING:

\`\`\`
Undocumented arguments in Rd file 'cache_result.Rd': 'app_state'
Undocumented arguments in Rd file 'get_cached_result.Rd': 'app_state'
\`\`\`

### Root cause

#630 kørte \`devtools::document()\` der regenererede Rd-filer matchende code-signatur (inklusive \`app_state\`-arg). Roxygen source havde dog ikke \`@param app_state\` for de to funktioner — så Rd-filerne manglede tilsvarende \`\\item{app_state}{...}\` blocks.

R CMD check \`checking Rd \\usage sections\` fejler på undocumented args.

### Fix

Tilføj \`@param app_state\` til roxygen for \`cache_result\` + \`get_cached_result\`. Regenereret via \`devtools::document()\`.

## Test plan

- [x] Full suite: 2054 tests pass, 0 fail, 0 error
- [x] Pre-push gate: passed (62s)
- [ ] CI gate (tests + warnings) skal nu være grøn på develop efter merge

## Related

- Unblocker #627