### PR TITLE
docs(adr): add retroactive ADR-003..ADR-006 (closes #531)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ observeEvent(app_state$events$data_updated,
 ```
 
 **Filer:** `global.R` (events), `R/utils_server_event_listeners.R` (`setup_event_listeners()`),
-emit API via `create_emit_api()`.
+emit API via `create_emit_api()`. **Rationale:** `docs/adr/ADR-003-unified-event-architecture.md`.
 
 ### App State Structure
 
@@ -72,6 +72,9 @@ app_state$data       # current_data, original_data, file_info
 app_state$columns    # auto_detect, mappings, ui_sync
 app_state$session    # Session state
 ```
+
+**Rationale:** `docs/adr/ADR-004-hierarchical-app-state.md`. Race-prevention
+strategi: `docs/adr/ADR-006-hybrid-anti-race-strategy.md`.
 
 ### Golem Configuration
 
@@ -92,6 +95,7 @@ Auto-save (debounce 2s data / 1s settings) + auto-restore via localStorage.
 Schema-version-gate (`LOCAL_STORAGE_SCHEMA_VERSION`). Class-preservation per
 kolonne. Detaljer: `R/utils_local_storage.R`,
 `R/utils_server_server_management.R`, `inst/app/www/local-storage.js`.
+**Rationale:** `docs/adr/ADR-005-session-persistence-localstorage.md`.
 
 ### Excel I/O
 

--- a/docs/adr/ADR-003-unified-event-architecture.md
+++ b/docs/adr/ADR-003-unified-event-architecture.md
@@ -1,0 +1,161 @@
+# ADR-003: Unified Event Architecture
+
+## Status
+Accepted (retroaktiv dokumentation, 2026-05-07)
+
+## Kontekst
+
+Tidlige iterationer af biSPCharts brugte ad-hoc `reactiveVal()`-triggers
+spredt på tværs af server-kode. Hver feature definerede egne flag-variable,
+direkte mutationer skete i blandet rækkefølge, og afhængigheder mellem
+features var implicitte. Symptomer:
+
+1. **Race conditions**: Auto-detection kunne læse `current_data` før upload
+   havde committet, fordi observer-rækkefølge var ikke-deterministisk.
+2. **Duplicate execution**: Samme handling udløst flere gange når flere
+   `reactiveVal`-triggers ændrede sig samtidigt.
+3. **Skjulte afhængigheder**: Ingen central oversigt over hvilke features
+   reagerede på hvilke ændringer — vanskelig at debugge.
+4. **Inkonsistent cleanup**: Observer-lifetimer ikke koordineret med session-end,
+   "zombie"-observers kunne hænge i Shiny's reactive graph.
+
+Behov: deterministisk event-flow, eksplicit afhængighedsgraf, stabil
+observer-prioritet, koordineret cleanup.
+
+## Beslutning
+
+Vi indfører en **central event-bus med emit-API + prioriterede observers**
+som det eneste tilladte mønster for cross-feature reaktivitet:
+
+### 1. Event-bus
+Alle events lever i `app_state$events` som `shiny::reactiveValues` med
+integer-counters. Initieres i `create_app_state()` (`R/state_management.R`):
+
+```r
+app_state$events <- shiny::reactiveValues(
+  data_updated            = 0L,
+  auto_detection_started  = 0L,
+  auto_detection_completed = 0L,
+  ui_sync_requested       = 0L,
+  navigation_changed      = 0L,
+  session_started         = 0L,
+  error_occurred          = 0L,
+  # ... 19 events total
+)
+```
+
+### 2. Emit-API
+`create_emit_api(app_state)` returnerer named list af emit-funktioner.
+Hver inkrementerer sit event-counter inde i `shiny::isolate()`:
+
+```r
+emit$data_updated(context = "upload")
+# → app_state$events$data_updated <- ... + 1L
+```
+
+`isolate()` forhindrer utilsigtede reactive-afhængigheder i kalder-koden.
+Context-argumenter input-valideres + sanitiseres.
+
+### 3. Prioriterede observers
+Listeners registreres centralt via `setup_event_listeners()`
+(`R/utils_server_event_listeners.R`) der orkestrerer 7 modulære
+register-funktioner (data, autodetect, ui, navigation, chart, wizard,
+paste). Alle observers angiver eksplicit `priority` fra
+`OBSERVER_PRIORITIES` (`R/config_observer_priorities.R`):
+
+```r
+shiny::observeEvent(app_state$events$data_updated,
+  ignoreInit = TRUE,
+  priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,  # 2000
+  { ... }
+)
+```
+
+Hierarki (wide gaps mellem niveauer):
+
+| Niveau | Værdi | Anvendelse |
+|--------|-------|------------|
+| `STATE_MANAGEMENT` | 2000 | Kritiske state-mutationer |
+| `AUTO_DETECT` | 1500 | Auto-detection |
+| `DATA_PROCESSING` | 1250 | Data operations |
+| `UI_SYNC` | 750 | UI synchronization |
+| `PLOT_GENERATION` | 600 | Plot rendering |
+| `STATUS_UPDATES` | 500 | Status indicators |
+| `CLEANUP` | 200 | Cleanup |
+| `LOGGING` | 100 | Monitoring |
+
+### 4. Observer registry + cleanup
+`setup_event_listeners()` registrerer hvert observer i en lokal
+`observer_registry` via `register_observer(name, observer)`. Ved
+session-slut kaldes `observer$destroy()` for hvert registreret observer.
+Overwrite-protection: re-registration af samme navn destruerer eksisterende
+observer først (fix for issue #487 zombie-observers).
+
+## Konsekvenser
+
+### Positive
+- **Deterministisk eksekvering**: STATE_MANAGEMENT-observers kører før
+  DATA_PROCESSING før UI_SYNC, uafhængigt af registrerings-rækkefølge.
+- **Eksplicit afhængighedsgraf**: Alle events listet centralt; hver listener
+  binder eksplicit til ét event.
+- **Konsolidering**: Tidligere `data_loaded`/`data_changed` smeltet til
+  `data_updated` med context-parameter. Færre events, mindre noise.
+- **Test-vendor**: Events kan triggeres direkte i tests (`emit$data_updated()`),
+  ingen UI-roundtrip nødvendig.
+- **Cleanup-garanti**: Session-end destruerer alle observers atomisk.
+
+### Negative
+- **Boilerplate**: Nye features kræver event-definition + emit-funktion +
+  observer-registrering — tre touch-points i stedet for én reactiveVal.
+- **Indirekte flow**: Kald-stedet (`emit$X()`) og handler er adskilt;
+  navigation kræver grep efter event-navn.
+- **Priority-disciplin**: Forkert priority kan reintroducere races.
+  Mitigeret af `OBSERVER_PRIORITIES`-konstanter (ikke magic numbers).
+
+### Mitigations
+- Modulær registrering (`register_*_events()`-funktioner per domæne)
+  begrænser monolitisk fil-vækst.
+- Legacy emit-aliases (`data_loaded()`, `data_changed()`) bevaret for
+  API-stabilitet under konsolidering — mapper til samme `data_updated`-counter.
+- DUPLICATE PREVENTION-guard i `setup_event_listeners()` blokerer parallelle
+  optimized + standard listener-systemer (jf. ADR-014).
+
+## Alternativer overvejet
+
+### A: Bevare ad-hoc reactiveVal-mønster
+Afvist: race conditions + skjulte afhængigheder skalerede dårligt med
+feature-vækst.
+
+### B: Eksternt event-bibliotek (R6-baseret eller eventstream)
+Afvist: ekstra dependency uden klar gevinst — `reactiveValues` integrerer
+nativt med Shiny's reactive graph + flush-cyclus.
+
+### C: Én central observer i stedet for emit-API
+Afvist: én monolitisk observer ville eliminere prioritets-strukturen og
+tvinge if/else-grenudvælgelse på event-typer (sværere at teste).
+
+## Implementering
+
+- **Initial implementation**: Phase 4 state-refactor (~2025-Q3)
+- **Konsolidering**: Phase 2.2 (`data_loaded` + `data_changed` → `data_updated`)
+- **Modulær split**: Phase 2d (`utils_server_event_listeners.R` 1791 LOC →
+  7 fokuserede moduler)
+- **Observer cleanup-fix**: Issue #487 (zombie-prevention)
+- **Optimized pipeline deprecation**: ADR-014 (single event-bus)
+- **Verificering**: Unit tests for emit-API + observer-prioriteter
+  (`tests/testthat/test-event-system-emit.R`,
+  `tests/testthat/test-event-system-observers.R`)
+
+## Referencer
+
+- `R/state_management.R` — `create_app_state()`, `create_emit_api()`
+- `R/utils_server_event_listeners.R` — `setup_event_listeners()`
+- `R/config_observer_priorities.R` — `OBSERVER_PRIORITIES` + helpers
+- `R/utils_server_events_*.R` — modulær per-domæne registrering
+- ADR-004 — Hierarchical app_state (relateret state-design)
+- ADR-006 — Hybrid Anti-Race Strategy (bygger ovenpå denne ADR)
+- ADR-014 — Deprecation af optimized event pipeline (følgebeslutning)
+- CLAUDE.md sektion "Unified Event Architecture"
+
+## Dato
+2026-05-07 (retroaktiv dokumentation af beslutning truffet ~2025-Q3)

--- a/docs/adr/ADR-004-hierarchical-app-state.md
+++ b/docs/adr/ADR-004-hierarchical-app-state.md
@@ -1,0 +1,147 @@
+# ADR-004: Hierarchical app_state with reactiveValues
+
+## Status
+Accepted (retroaktiv dokumentation, 2026-05-07)
+
+## Kontekst
+
+Tidlige iterationer brugte mange flade `reactiveVal`-objekter +
+session-globale `<<-`-assignments til at dele state mellem moduler. Det gav:
+
+1. **Cross-session contamination**: Globale variable delte state mellem
+   samtidige sessions i Connect Cloud-deploys (`.performance_cache`,
+   `.data_signature_cache` lakede mellem brugere før issue #529).
+2. **Scope-isolation**: Modul-lokale `reactiveVal`-objekter var ikke synlige
+   for andre moduler uden at blive passet eksplicit gennem 4-5 funktionslag.
+3. **Implicit copy-by-value**: Liste-baseret state passet til funktioner
+   blev kopieret — mutationer forsvandt ved retur.
+4. **State drift**: Samme logiske state-felt fandtes i flere moduler
+   (`module_cached_data` + `current_data` + `processed_data`).
+5. **Manglende oversigt**: Ingen single source of truth for "hvad er app'ens
+   nuværende tilstand".
+
+Behov: én central reference med session-isolation, by-reference deling,
+hierarkisk gruppering efter domæne.
+
+## Beslutning
+
+Vi indfører **`app_state` som central environment-baseret container med
+hierarkiske `reactiveValues`-sektioner**, oprettet per session i
+`create_app_state()` (`R/state_management.R`):
+
+### Top-level: environment (by-reference)
+
+```r
+app_state <- new.env(parent = emptyenv())
+```
+
+Environment vælges over list/reactiveValues fordi environments deles
+**by reference** mellem funktioner — eliminerer scope-isolation-bug og
+behøver ikke `<<-` for at mutere.
+
+### Sektioner: hierarkiske reactiveValues
+
+Hver domæne får egen reactiveValues-container med klar ansvarsgrænse:
+
+| Sektion | Indhold |
+|---------|---------|
+| `app_state$events` | Event-bus counters (jf. ADR-003) |
+| `app_state$data` | `current_data`, `original_data`, `processed_data`, `file_info`, `table_version`, ... |
+| `app_state$columns` | Nested: `auto_detect`, `mappings`, `ui_sync` |
+| `app_state$session` | `auto_save_enabled`, `file_uploaded`, `peek_result`, `active_tab`, ... |
+| `app_state$test_mode` | Test-mode konfiguration + startup-fase |
+| `app_state$ui` | Loop-protection-flags, queue-system, performance-metrics |
+| `app_state$visualization` | `plot_ready`, `anhoej_results`, `viewport_dims`, cache-guards |
+| `app_state$navigation` | Trigger-counter for eventReactive-patterns |
+| `app_state$errors` | `last_error`, `error_count`, `error_history`, recovery-state |
+| `app_state$cache` | Session-scoped: `qic`, `performance`, `data_signature` (issue #529) |
+| `app_state$infrastructure` | Non-reactive flags til `later::later()`-callbacks |
+
+### Atomic update-mønster
+Multi-felt-mutationer pakkes i `safe_operation()` for "alt eller intet":
+
+```r
+safe_operation("Update mapping", {
+  app_state$columns$mappings$x_column <- new_x
+  app_state$columns$mappings$y_column <- new_y
+  emit$ui_sync_requested()
+})
+```
+
+### Session-scoped caches (issue #529)
+`app_state$cache$performance` + `app_state$cache$data_signature` flyttet
+fra package-environment til session-scope efter cross-session-contamination
+i Connect Cloud-deploy.
+
+## Konsekvenser
+
+### Positive
+- **Session-isolation**: Hver Shiny-session får egen `app_state`. Ingen
+  cross-session-leakage.
+- **By-reference deling**: Environment passes by reference — moduler kan
+  mutere uden `<<-` eller round-trip-returns.
+- **Single source of truth**: "Hvad er nuværende dataset?" → altid
+  `app_state$data$current_data`.
+- **Domæne-grupperet**: Hierarki gør state-graf navigerbar; `app_state$columns$auto_detect$completed`
+  er selvforklarende vs. flad `auto_detect_completed`.
+- **Reactive integration**: `reactiveValues` integrerer nativt med Shiny's
+  reactive graph — ingen manuel invalidate-kald.
+- **Testbarhed**: Tests kan oprette isoleret `app_state` + manipulere felter
+  direkte uden at mocke Shiny session.
+
+### Negative
+- **Læringskurve**: Nye contributors skal lære skemaet før de finder rette
+  felt; flade reactiveVal er intuitive ved første blik.
+- **Ingen type-checking**: `reactiveValues` accepterer alt — ukorrekte
+  felt-mutationer fanges først ved konsumenter.
+- **Skema-stivhed**: Tilføje nyt felt kræver edit i `create_app_state()`;
+  glemte initialiseringer giver `NULL`-bugs.
+- **Memory overhead**: Per-session container er større end nødvendigt for
+  features der kun bruger få felter — accepteret pris for isolation.
+
+### Mitigations
+- Skema dokumenteret i `create_app_state()` roxygen + CLAUDE.md sektion
+  "App State Structure".
+- Alle nye state-felter skal initieres i `create_app_state()` (ingen
+  on-the-fly assignment) — håndhæves ved code review.
+- `safe_operation()`-wrapper for atomic updates dokumenteret i
+  `SHINY_ADVANCED_PATTERNS.md`.
+
+## Alternativer overvejet
+
+### A: Flade reactiveVal pr. modul
+Afvist: scope-isolation-problemer + implicit cross-modul kobling.
+
+### B: R6-klasser med private/public felter
+Afvist: ingen native integration med Shiny's reactive graph; ekstra wrapping
+omkring `invalidate()`.
+
+### C: Globale package-level reactiveValues
+Afvist: cross-session contamination i multi-bruger-deploys (issue #529
+demonstrerede konsekvensen).
+
+### D: External state-store (shinyStore, redis)
+Afvist: overkill for in-session state; persisteret state løses separat
+i ADR-005 (localStorage).
+
+## Implementering
+
+- **Initial implementation**: Phase 4 centraliseret state (~2025-Q3)
+- **Hierarki-refaktorering**: `columns` opdelt i `auto_detect` / `mappings` /
+  `ui_sync` sub-reactiveValues
+- **Cache session-scope migration**: Issue #529 (cross-session contamination
+  fix)
+- **Verificering**: `tests/testthat/test-phase4-centralized-state.R` +
+  integration tests for state-mutationer
+
+## Referencer
+
+- `R/state_management.R` — `create_app_state()`
+- ADR-003 — Unified Event Architecture (events lever i `app_state$events`)
+- ADR-005 — Session Persistence (persisteret subset af `app_state`)
+- ADR-006 — Hybrid Anti-Race Strategy (bygger på state-atomicity)
+- CLAUDE.md sektion "App State Structure"
+- Issue #529 — Session-scoped performance cache
+
+## Dato
+2026-05-07 (retroaktiv dokumentation af beslutning truffet ~2025-Q3)

--- a/docs/adr/ADR-005-session-persistence-localstorage.md
+++ b/docs/adr/ADR-005-session-persistence-localstorage.md
@@ -1,0 +1,161 @@
+# ADR-005: Session Persistence via Browser localStorage
+
+## Status
+Accepted (retroaktiv dokumentation, 2026-05-07)
+
+## Kontekst
+
+Klinikere på Bispebjerg + Frederiksberg Hospital arbejder typisk i sessioner
+spredt over en arbejdsdag på delte hospital-PC'er. Browser-refresh,
+utilsigtet luk af tab, eller server-reconnect kunne tidligere koste alt
+arbejde — datasæt, kolonne-mappings, chart-type, eksport-tekst. Behov:
+
+1. **Robusthed mod tilfældige reconnect**: Klinikere mister ikke flere
+   timers arbejde fordi en RConnect-session timer ud.
+2. **Klassebevarelse pr. kolonne**: Date, POSIXct (med tz), factor (med
+   levels), integer, numeric skal restoreres præcist — JSON-roundtrip
+   coercer alt til character/numeric uden metadata.
+3. **Privacy på delte PC'er**: Data må ikke ligge i browser efter en
+   klinisk arbejdsdag.
+4. **Skema-evolution**: Persisteret state-format vil ændre sig over tid —
+   ældre payloads må ikke crashe app eller producere subtile fejl.
+5. **Server-uafhængighed**: Persistens må ikke kræve database eller
+   ekstra infrastruktur — biSPCharts deployes til Connect Cloud uden
+   persistent disk per bruger.
+
+Eksterne constraints: Issue #193 dokumenterede behovet, double-encoding-bug
+i tidlig implementation (`JSON.stringify(allerede_jsonifieret)`)
+demonstrerede skørheden.
+
+## Beslutning
+
+Vi indfører **automatisk persistens af session-state i browser-localStorage**
+med eksplicit schema-versionering, klassebevarelse pr. kolonne, og TTL-baseret
+ekspirering:
+
+### 1. Auto-save (debounced)
+- **Data**: 2000 ms debounce (`get_save_interval_ms()`, override via
+  `SAVE_INTERVAL_MS` package-config)
+- **Settings (UI-state)**: 1000 ms debounce (`get_settings_save_interval_ms()`)
+- Implementation: `shiny::debounce(reactive({...}), millis)` i
+  `R/utils_server_session_helpers.R`
+- Trigger-guards: skipper auto-save under
+  `updating_table`/`table_operation_in_progress`/`restoring_session`/`!auto_save_enabled`
+
+### 2. Schema-version gate
+`LOCAL_STORAGE_SCHEMA_VERSION` (aktuelt `"3.0"`) bumpes ved payload-ændringer.
+Load-logik:
+- Ukendt eller ældre version → ryd payload (no-op load).
+- Forventede migrations (eks. 2.0 → 3.0) → silent forward-migration via
+  `migrate_time_yaxis_unit()`. Idempotent (3.0 returneres uændret).
+
+### 3. Klassebevarelse pr. kolonne
+`extract_class_info(data)` producerer named list pr. kolonne:
+`{primary, is_date, is_posixct, is_factor, levels, tz}`. Lagres sammen
+med data. Ved restore kalder `restore_column_class()` korrekte
+coercion-paths via whitelist (`ALLOWED_PRIMARY`-list — defensivt mod
+manipulerede payloads fra DevTools, jf. issue #457).
+
+### 4. TTL på client-side
+`SPC_LOCALSTORAGE_DEFAULT_TTL_MINUTES = 480` (8 timer = klinisk arbejdsdag),
+override via `window.SPC_LOCALSTORAGE_TTL_MINUTES`. `spc_expire_stale_sessions()`
+kører ved hver `$(document).ready()` — fjerner forældede payloads før
+load-logik tilgår dem. Beskytter data på delte hospital-PC'er.
+
+### 5. Brugerstyret restore (peek-pattern)
+Ved app-start sender JS et "peek"-resultat (`list(has_payload, ...)`) til
+server via `app_state$session$peek_result`. Server gating:
+- Ingen payload → standard tom session.
+- Payload tilstede → vis brugeren explicit "Genoptag tidligere session"-prompt.
+  Auto-restore kun ved bekræftet brugervalg.
+
+### 6. Auto-disable ved persistente fejl
+`autoSaveAppState()` returnerer `FALSE` ved gentagne `safe_operation()`-failures.
+Server-side `set_auto_save_enabled(app_state, FALSE)` deaktiverer videre
+forsøg + viser brugeren neutral notifikation ("Din data er stadig
+tilgængelig i appen. Automatisk lagring er midlertidigt deaktiveret.").
+
+### 7. Størrelses-cap
+`object.size(current_data) >= 1000000` (1 MB) → spring auto-save over,
+notify bruger om at downloade manuelt. localStorage-quota er typisk
+5-10 MB, vi holder konservativ buffer for metadata + andre apps på domænet.
+
+## Konsekvenser
+
+### Positive
+- **Robusthed**: Refresh/reconnect mister ikke arbejde; klinikere kan
+  fortsætte hvor de slap.
+- **Server-uafhængig**: Ingen database, ingen disk-mount — fungerer
+  identisk i Connect Cloud, lokal dev, og selvhostet RConnect.
+- **Type-præcis restore**: Date/POSIXct/factor bevares — undgår subtile
+  bugs hvor numerisk parsing fejler efter restore.
+- **Privacy-bevidst**: TTL + delte-PC-konstruktion eliminerer "glemt data
+  i browser ved hjemtid"-risiko.
+- **Forward-kompatibel evolution**: Schema-version-gate tillader frie
+  ændringer i payload-format uden at brække eksisterende brugeres state.
+
+### Negative
+- **Browser-afhængighed**: localStorage skal være enabled — privatmode +
+  visse hospital-policies kan blokere. Mitigeret af graceful degradation
+  (skipper save, app fungerer normalt).
+- **1 MB cap**: Store datasæt > ~10k rækker auto-saves ikke. Accepteret —
+  store datasæt er "skal-downloades-eksplicit"-arbejdsflow.
+- **Skema-bumps koster brugerstate**: Major schema-bump (eks. 2.0 → 3.0
+  uden migration) sletter ældre payloads. Mitigeret af forward-migrations
+  hvor det er praktisk.
+- **JSON-roundtrip-skørhed**: `NULL`-elementer fra
+  `jsonlite::fromJSON(simplifyVector = FALSE)` skal håndteres eksplicit
+  i `restore_column_class()` (NULL → NA via `unlist()`).
+- **Double-encoding-fælde**: JS må IKKE kalde `JSON.stringify()` på data
+  fra R's `jsonlite::toJSON()` (allerede en streng). Issue #193 indikerede
+  hvor let det er at brække roundtrip.
+
+### Mitigations
+- Schema-versionering eksplicit dokumenteret + bumpes synkront med
+  payload-ændringer.
+- `ALLOWED_PRIMARY` whitelist beskytter mod manipulerede class_info-payloads.
+- TTL-check kører før load-logik så stale data aldrig når R-side.
+- Tests dækker roundtrip for alle understøttede typer
+  (`tests/testthat/test-local-storage-*.R`).
+
+## Alternativer overvejet
+
+### A: Server-side session-store (RConnect persisteret disk)
+Afvist: kræver per-bruger persistent disk → ikke kompatibelt med
+Connect Cloud + lokal dev. Privacy-implikationer på delt infrastruktur.
+
+### B: Eksplicit Save/Load-knapper (ingen auto-persist)
+Afvist: dårlig UX — klinikere ville glemme at gemme før timeout.
+Manuel download bevares som komplement (Excel/CSV) til langtids-arkiv.
+
+### C: IndexedDB
+Afvist: API-kompleksitet (async + transactions) for ringe gevinst —
+1 MB-budget rammer aldrig localStorage-grænserne.
+
+### D: Cookies
+Afvist: størrelsesgrænse (~4 KB) langt under behov.
+
+## Implementering
+
+- **Initial implementation**: Issue #193 (~2025-Q4)
+- **Schema 3.0 migration**: `y_axis_unit "time"` split til
+  `time_minutes`/`time_hours`/`time_days` med silent forward-migration
+- **TTL-check**: Tilføjet for delte hospital-PC'er
+- **Whitelist hardening**: Issue #457 (ALLOWED_PRIMARY beskytter mod
+  manipulerede class_info-payloads)
+- **Verificering**: Roundtrip-tests for alle datatyper, schema-migration
+  tests, TTL-expiry tests
+
+## Referencer
+
+- `R/utils_local_storage.R` — server-side persistens, class-handling, migrations
+- `R/utils_server_server_management.R` — restore-logik + peek-handling
+- `R/utils_server_session_helpers.R` — auto-save debounce-trigger
+- `inst/app/www/local-storage.js` — client-side TTL + storage
+- ADR-004 — Hierarchical app_state (persisteret subset stammer herfra)
+- Issue #193 — Original feature-request + double-encoding-fix
+- Issue #457 — ALLOWED_PRIMARY whitelist hardening
+- CLAUDE.md sektion "Session Persistence (Issue #193)"
+
+## Dato
+2026-05-07 (retroaktiv dokumentation af beslutning truffet ~2025-Q4)

--- a/docs/adr/ADR-006-hybrid-anti-race-strategy.md
+++ b/docs/adr/ADR-006-hybrid-anti-race-strategy.md
@@ -1,0 +1,230 @@
+# ADR-006: Hybrid Anti-Race Strategy (5-Layer)
+
+## Status
+Accepted (retroaktiv dokumentation, 2026-05-07)
+
+## Kontekst
+
+Selv efter unified event-architecture (ADR-003) og hierarchical app_state
+(ADR-004) opstod race conditions i specifikke scenarier:
+
+1. **Konkurrerende observers**: Auto-detection startede mens brugeren stadig
+   redigerede tabel; resultatet blev "current_data" snapshotted i et
+   inkonsistent øjeblik.
+2. **Programmatic UI vs. user input**: `updateSelectInput()` triggede ofte
+   `input$X`-listener i samme flush-cyklus, hvilket gav uendelige loops
+   eller stale-state writes.
+3. **Burst-typing**: Hver tegn-tast i et tekstfelt udløste rebuild af
+   downstream caches, hvilket blokerede UI-thread under hurtig indtastning.
+4. **Tab-switch under processing**: Bruger skiftede til "Eksporter"-tab
+   mens et plot stadig genererede; observer for navigation_changed kunne
+   læse halv-færdig state.
+5. **Concurrent UI updates**: Flere observers kaldte `update*Input()` på
+   samme element → senest-vinder eller overlappende DOM-mutationer.
+
+Ingen enkelt mekanisme dækkede alle scenarier. Behov: lagdelt strategi
+hvor hver lag fanger en specifik race-klasse, kombineret design der sikrer
+at bortfald af et lag ikke åbner alle scenarier.
+
+## Beslutning
+
+Vi indfører en **hybrid 5-lags anti-race-strategi** hvor hvert lag dækker
+en distinkt race-kategori. Layers anvendes kombineret per feature efter
+en **feature implementation checklist** dokumenteret i
+`SHINY_ADVANCED_PATTERNS.md`.
+
+### Lag 1: Event Architecture med eksplicitte prioriteter
+
+Beskrevet i ADR-003. Sikrer deterministisk eksekverings-rækkefølge inden
+for én flush-cyklus:
+
+```r
+shiny::observeEvent(app_state$events$data_updated,
+  ignoreInit = TRUE,
+  priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT,  # 2000 — kører før priority 750
+  { ... }
+)
+```
+
+**Forhindrer**: Reactive-graph re-ordering, registrerings-rækkefølge-
+afhængighed, observer-startup-races.
+
+### Lag 2: State Atomicity via `safe_operation()`
+
+Multi-felt-mutationer pakkes i `safe_operation()`-wrapper:
+
+```r
+safe_operation("Update mapping", {
+  app_state$columns$mappings$x_column <- new_x
+  app_state$columns$mappings$y_column <- new_y
+  emit$ui_sync_requested()
+})
+```
+
+`safe_operation()` wrap'er i `tryCatch()` + logger fejl + sikrer at
+partial-update ikke efterlades synlig for konsumenter.
+
+**Forhindrer**: Konsumenter læser inkonsistent state (X opdateret, Y ikke).
+
+### Lag 3: Functional Guards på proces-flag
+
+Hver længere-løbende operation beskytter sig selv via state-flag:
+
+```r
+update_ui_state <- function(state, new_value) {
+  if (isTRUE(state$data$processing) ||
+      isTRUE(state$ui$updating) ||
+      isTRUE(state$visualization$plot_generation_in_progress)) {
+    return(invisible(NULL))  # Skip — anden operation kører
+  }
+  state$ui$current_selection <- new_value
+}
+```
+
+Konkrete flag i kodebasen:
+- `app_state$data$updating_table`
+- `app_state$data$table_operation_in_progress`
+- `app_state$session$restoring_session`
+- `app_state$ui$updating_programmatically`
+- `app_state$visualization$cache_updating`
+- `app_state$visualization$plot_generation_in_progress`
+
+**Forhindrer**: Overlappende operationer (auto-save under tabel-edit,
+auto-detect under restore, plot-gen under cache-rebuild).
+
+### Lag 4: UI Atomicity via wrapper-helpers
+
+Programmatic UI-opdateringer kanaliseres gennem `safe_programmatic_ui_update()`
+som:
+- Sætter `app_state$ui$updating_programmatically <- TRUE` før update
+- Kører update i kontrolleret kontekst
+- Resetter flag via scheduled `later::later()`-callback efter Shiny flush
+
+Konkurrerende UI-opdateringer (samme element fra flere observers)
+serialiseres via `app_state$ui$queued_updates`-kø + `process_ui_update_queue()`:
+
+```r
+# Session-global queue forhindrer DOM-overlap
+app_state$ui$queued_updates  # list of pending updates
+app_state$ui$queue_processing # mutex flag
+```
+
+**Forhindrer**:
+- Programmatic update → `input$X`-observer triggers → cirkulært loop.
+- To observers kalder `updateSelectInput()` på samme element samtidigt.
+
+### Lag 5: Input Debouncing
+
+Fritekst- og burst-inputs debounces 150-2000 ms via `DEBOUNCE_DELAYS`
+(`R/config_system_config.R`):
+
+```r
+DEBOUNCE_DELAYS <- list(
+  input_change = 150,    # dropdowns, fast typing
+  file_select  = 500,    # file selection
+  chart_update = 500,    # chart rendering
+  table_cleanup = 2000   # table operation cleanup
+)
+
+# Auto-save data: 2000ms (get_save_interval_ms())
+# Auto-save settings: 1000ms (get_settings_save_interval_ms())
+```
+
+**Forhindrer**: Burst-input invaliderer caches/triggrer beregning per
+tegn.
+
+### Feature implementation checklist
+
+Hver ny feature der ændrer state vurderes mod de 5 lag:
+
+- [ ] Emit via event-bus (lag 1)
+- [ ] Observer med eksplicit prioritet (lag 1)
+- [ ] Atomic mutation via `safe_operation()` (lag 2)
+- [ ] Guard mod konflikt-flag (lag 3)
+- [ ] UI-update via `safe_programmatic_ui_update()` hvis programmatic (lag 4)
+- [ ] Debounce input hvis fritekst/burst (lag 5)
+- [ ] Test concurrent operations (alle lag)
+
+## Konsekvenser
+
+### Positive
+- **Lagdelt forsvar**: Bortfald af ét lag åbner kun specifik race-klasse,
+  ikke hele systemet.
+- **Eksplicit checklist**: Hver feature evalueres mod samme 6 punkter →
+  konsistent kvalitetsnivau.
+- **Diagnose-venlig**: Race conditions kan oftest spores til hvilket lag
+  manglede (eks: glemt guard-flag → flaget ses i debug-logs).
+- **Test-fokus**: "Concurrent ops"-tests dækker scenarier der historisk
+  reproducerede races.
+
+### Negative
+- **Kognitivt overhead**: Nye contributors skal forstå alle 5 lag før de
+  kan implementere ikke-trivielle features.
+- **Verbositet**: Simple state-updates kræver flere wrappere end naivt
+  kode-design.
+- **Disciplin-afhængigt**: Glemt guard-flag eller manglende prioritet
+  kan stadig genintroducere races. Mitigeret via code review + checklist.
+- **Ydelse-omkostning**: Debounce introducerer latens (150-2000 ms);
+  acceptable for klinisk arbejde, men ikke for realtids-feedback.
+
+### Mitigations
+- Checklist dokumenteret i `SHINY_ADVANCED_PATTERNS.md` (auto-loaded i
+  CLAUDE.md Tier 2).
+- `OBSERVER_PRIORITIES`-konstanter (ikke magic numbers) reducerer
+  prioritets-fejl.
+- `safe_operation()`/`safe_programmatic_ui_update()` reducerer boilerplate
+  pr. feature.
+- Logging i hvert lag (`log_debug` med `.context = "RACE_GUARD"` el.lign.)
+  giver post-mortem data ved produktions-races.
+
+## Alternativer overvejet
+
+### A: Single-threaded queue for alle state-mutationer
+Afvist: Shiny's reactive-graph er allerede "single-threaded" inden for
+flush; problemerne ligger i cross-flush-races og UI-DOM-overlap. En
+ekstra queue ville duplikere Shiny's eksisterende infrastruktur.
+
+### B: Optimistic concurrency med version-counters per felt
+Afvist: kompleksitet langt over reelle behov for in-session app;
+traditionelt mønster fra distribuerede systemer.
+
+### C: Mutexes via R6-baseret lock-manager
+Afvist: deadlock-risiko; ingen forretnings-kritisk grund til at blokere
+hele observer-træer mens et flag holdes.
+
+### D: Aggressiv debounce kun (drop andre lag)
+Afvist: høj debounce skader UX; lav debounce fanger ikke programmatic-
+loops eller priority-races. Debounce alene løser ikke race-klassen.
+
+## Implementering
+
+- **Initial design**: Iterativ udvikling 2025-Q3 → Q4 efter observation
+  af konkrete race-bugs i produktion
+- **Lag 1+2**: Indført sammen med ADR-003+ADR-004 refactor
+- **Lag 3 (guards)**: Tilføjet incrementelt per observerede race
+  (table-update, restore-session, plot-generation)
+- **Lag 4 (UI queue)**: Indført efter rapporter om sammenfaldende
+  `updateSelectInput()`-kald gav flicker
+- **Lag 5 (debounce)**: Optimeret 2025-Q4 (input_change 300 → 150 ms,
+  chart_update 800 → 500 ms — 30-40 % perceived responsiveness)
+- **Verificering**: Concurrent-ops integration-tests
+  (`tests/testthat/test-integration-reactive-chain*.R`),
+  manual smoke-tests af tab-switch + auto-save + plot-gen scenarier
+
+## Referencer
+
+- `R/utils_state_accessors.R` — `safe_programmatic_ui_update()`,
+  `safe_operation()`
+- `R/utils_ui_form_update_service.R` — UI update queue
+- `R/utils_ui_table_update_service.R` — table-operation guards
+- `R/config_observer_priorities.R` — `OBSERVER_PRIORITIES`
+- `R/config_system_config.R` — `DEBOUNCE_DELAYS`, `LOOP_PROTECTION_DELAYS`
+- `R/zzz.R` — `get_save_interval_ms()`, `get_settings_save_interval_ms()`
+- ADR-003 — Unified Event Architecture (lag 1 fundament)
+- ADR-004 — Hierarchical app_state (lag 2-3 fundament)
+- `SHINY_ADVANCED_PATTERNS.md` — "Race Condition Prevention (5 Lag)" +
+  "Feature implementation checklist"
+- CLAUDE.md sektion "Race Condition Prevention"
+
+## Dato
+2026-05-07 (retroaktiv dokumentation af strategi udviklet 2025-Q3 → Q4)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -143,6 +143,10 @@ ADRs er **immutable** efter accept:
 |-----|-------|--------|------|
 | [ADR-001](./ADR-001-pure-bfhcharts-workflow.md) | Pure BFHcharts Workflow for SPC Calculation | Accepted | 2025-10-10 |
 | [ADR-002](./ADR-002-ui-sync-throttle-250ms.md) | UI Sync Throttle 250ms | Accepted | 2025-10-10 |
+| [ADR-003](./ADR-003-unified-event-architecture.md) | Unified Event Architecture | Accepted (retroaktiv) | 2026-05-07 |
+| [ADR-004](./ADR-004-hierarchical-app-state.md) | Hierarchical app_state with reactiveValues | Accepted (retroaktiv) | 2026-05-07 |
+| [ADR-005](./ADR-005-session-persistence-localstorage.md) | Session Persistence via Browser localStorage | Accepted (retroaktiv) | 2026-05-07 |
+| [ADR-006](./ADR-006-hybrid-anti-race-strategy.md) | Hybrid Anti-Race Strategy (5-Layer) | Accepted (retroaktiv) | 2026-05-07 |
 | [ADR-014](./ADR-014-deprecate-optimized-event-pipeline.md) | Deprecate Optimized Event Pipeline | Accepted | — |
 | [ADR-015](./ADR-015-bfhchart-migrering.md) | BFHcharts Migration (Hybrid Architecture) | Accepted | — |
 | [ADR-016](./ADR-016-gemini-integration.md) | Gemini AI Integration | Accepted | — |
@@ -150,23 +154,20 @@ ADRs er **immutable** efter accept:
 | [ADR-018](./ADR-018-minimal-public-api-surface.md) | Minimal Public API Surface | Accepted | — |
 | [ADR-019](./ADR-019-production-entrypoint-and-pkgload-boundary.md) | Production Entrypoint and pkgload Boundary | Accepted | — |
 
-### Nummereringsgap: ADR-003..ADR-013
+### Nummereringsgap: ADR-007..ADR-013
 
-ADR-numrene 003-013 er **ikke allokerede**. Følgende load-bearing
-arkitektoniske beslutninger bør retroaktivt dokumenteres som ADRs (se
-issue #531 — udskudt arbejde):
+ADR-numrene 007-013 er **ikke allokerede** og forbliver reserveret.
+De fire mest load-bearing retroaktive beslutninger er nu dokumenteret
+som ADR-003..ADR-006 (issue #531):
 
-- Unified event-architecture (event-bus + emit + prioriterede observers)
-- Centraliseret app_state-design + hierarkisk reactiveValues-struktur
-- Session-persistence via localStorage (issue #193)
-- Hybrid Anti-Race Strategy (5-lags race-prevention)
+- ADR-003 — Unified Event Architecture (event-bus + emit + prioriterede observers)
+- ADR-004 — Hierarchical app_state med reactiveValues
+- ADR-005 — Session Persistence via Browser localStorage (issue #193)
+- ADR-006 — Hybrid Anti-Race Strategy (5-Layer race-prevention)
 
-Indtil ADRs er skrevet, refererer CLAUDE.md (sektion 2) til den primære
-kode-implementation: `R/utils_server_event_listeners.R`,
-`R/state_management.R`, `R/utils_local_storage.R`.
-
-Nye ADRs efter denne note bør fortsætte fra ADR-020+ for at undgå
-forvirring med det dokumenterede gap.
+Hvis yderligere historiske beslutninger identificeres, kan de tildeles
+numre i 007-013-spannet. Nye fremad-rettede ADRs nummereres fra ADR-020+
+for at bevare visuel adskillelse fra det reserverede gap.
 
 ## Søgning i ADRs
 
@@ -209,4 +210,4 @@ Se ADR-002 for rationale og performance gains.
 ---
 
 **Maintained by**: biSPCharts Development Team
-**Last updated**: 2025-10-10
+**Last updated**: 2026-05-07


### PR DESCRIPTION
## Summary

Retroaktiv dokumentation af 4 load-bearing arkitektoniske beslutninger der eksisterede i kode men aldrig blev formaliseret som ADRs.

- **ADR-003** Unified Event Architecture — event-bus + emit-API + prioriterede observers
- **ADR-004** Hierarchical app_state med reactiveValues — environment-baseret session-isolation + domæne-grupperede sektioner
- **ADR-005** Session Persistence via Browser localStorage — auto-save, schema-versionering, klassebevarelse, TTL
- **ADR-006** Hybrid Anti-Race Strategy (5-lags) — race-prevention med feature implementation checklist

## Ændringer

- 4 nye ADR-filer i `docs/adr/`
- `docs/adr/README.md`: tabel udvidet, gap-note flyttet fra `ADR-003..013` → `ADR-007..013` (reserveret)
- `CLAUDE.md` sektion 2: cross-refs til de nye ADRs for discoverability fra primær entry-point

## Stale README-refs nævnt i issue

`ADR-003-qic-cache-invalidation-strategy` og fejlplaceret `ADR-001-ui-sync-throttle-250ms.md` blev ikke fundet i kodebasen — cleanet i tidligere PR mellem issue-oprettelse (2026-05-04) og nu. Substantielt arbejde = de 4 ADRs.

## Test plan

- [x] `grep -rn "ADR-00[3-9]\|ADR-01[0-3]"` viser kun referencer i nye ADRs/README
- [x] Ingen stale refs til `qic-cache-invalidation` eller fejlplaceret `ADR-001-ui-sync-throttle`
- [x] CLAUDE.md cross-refs peger på eksisterende filer
- [x] Pre-push gate (lintr + manifest + regressionstests) bestået

Closes #531