### PR TITLE
fix(cache): paste_data + session-contexts som structural clear

### DIFF
--- a/R/utils_qic_cache_invalidation.R
+++ b/R/utils_qic_cache_invalidation.R
@@ -24,6 +24,10 @@ NULL
 #' - `column_removed`: Data structure changed
 #' - `load`: Initial data load
 #' - `new`: New data created
+#' - `paste_data`: Data pasted via clipboard
+#' - `session_file_loaded`: Session-file restore via upload
+#' - `new_session`: Fresh session start
+#' - `session_restore`: localStorage-restore (cache er tom, full clear no-op-safe)
 #'
 #' **Selective Invalidation** (data value changes):
 #' - `table_cells_edited`: Only affected chart types
@@ -68,7 +72,9 @@ invalidate_qic_cache_smart <- function(app_state, update_context = NULL) {
   # STRATEGY 1: Full cache clear on structural changes
   structural_changes <- c(
     "upload", "column_added", "column_removed",
-    "load", "new", "file_upload"
+    "load", "new", "file_upload",
+    "paste_data", "session_file_loaded",
+    "new_session", "session_restore"
   )
 
   if (context %in% structural_changes) {

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -70,11 +70,44 @@ devtools::load_all(helpers = FALSE)
 # set_debug_context(c("RAG", "AI_METADATA", "AI_SUGGESTION", "GEMINI_API", "AI_CACHE", "EXPORT_MODULE"))
 # set_debug_context(c("EXPORT_MODULE"))
 # set_debug_context(c("RAG", "AI_METADATA", "AI_SUGGESTION", "GEMINI_API", "AI_CACHE"))
-set_debug_context(NULL)
-# set_debug_context(c("SESSION_RESTORE", "COLUMN_CHOICES_UNIFIED", "VISUALIZATION"))
-# set_debug_context(c("SESSION_RESTORE", "COLUMN_CHOICES_UNIFIED", "VISUALIZATION", "SPC_PIPELINE", "BFH_SERVICE"))
+# =============================================================================
+# RE-RENDER DIAGNOSE — trin 2/3 preview cascade-tracking
+# =============================================================================
+# Filtrer DEBUG til kontekster der afsloerer reactive-entry/exit, cache-hits,
+# tab-gating, debounce-aktivitet og event-flow. Drop AI/RAG/SESSION-stoej.
+set_debug_context(c(
+  "EXPORT_MODULE",       # export_plot/pdf_export_plot reactive entry + render-gate
+  "BACKEND_WRAPPER",     # generateSPCPlot CALLED
+  "BFH_SERVICE",         # SPC compute + cached=TRUE/FALSE
+  "BFH_TIMING",          # tidsforbrug pr compute
+  "SPC_CACHE",           # cache hit/miss
+  "QIC_CACHE",           # cache invalidation context
+  "AUTO_SAVE",           # debounce-cascade
+  "VIEWPORT_DIMENSIONS", # viewport_ready signal-timing
+  "EVENT_SYSTEM",        # emit$ + listener-fire
+  "FILE_UPLOAD_FLOW",    # paste/upload trigger-kilder
+  "AUTO_DETECT_CACHE",   # autodetect re-runs
+  "RENDER_PLOT",         # analyse-render entry
+  "VISUALIZATION"        # plot_object reactive
+))
 
-# Run app with test mode enabled for development
+# =============================================================================
+# REACTLOG — fuld dependency-graf efter session
+# =============================================================================
+# Efter app-luk: kald shiny::reactlogShow() i konsol for visualisering.
+# (reactlog::reactlog_show() kraever eksplicit log-argument; brug shiny-wrapperen.)
+options(shiny.reactlog = TRUE)
+if (requireNamespace("reactlog", quietly = TRUE)) {
+  reactlog::reactlog_enable()
+}
+
+# =============================================================================
+# SHINY-DIAGNOSTIK — trace + autoreload off (undgaa stoej + dobbelt-init)
+# =============================================================================
+options(shiny.trace = FALSE)        # saet TRUE for raw websocket-frames
+options(shiny.autoreload = FALSE)
+options(shiny.minified = FALSE)
+options(shiny.fullstacktrace = TRUE)
 
 # Browser-launch: RStudio viewer bruges automatisk i RStudio.
 # Firefox via 'open' kan ramme race condition — brug manuelt besøg
@@ -82,5 +115,6 @@ set_debug_context(NULL)
 # shiny::devmode(TRUE)
 options(shiny.port = 8080)
 options(shiny.launch.browser = TRUE)
-# run_app(enable_test_mode = FALSE, log_level = "DEBUG")
-run_app(enable_test_mode = FALSE, log_level = "INFO")
+
+# DEBUG-niveau for re-render diagnose. Skift tilbage til "INFO" naar faerdig.
+run_app(enable_test_mode = FALSE, log_level = "DEBUG")

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -403,5 +403,50 @@ test_that("cache invalidation is safe when cache functions don't exist", {
   }
 })
 
+# ===========================================================================
+# Issue #643: paste_data + session-contexts skal trigge structural clear,
+# ikke ramme conservative-fallback-grenen med WARN.
+# ===========================================================================
+
+test_that("invalidate_qic_cache_smart accepterer paste_data + session-contexts som structural", {
+  skip_if_not(
+    exists("invalidate_qic_cache_smart"),
+    "invalidate_qic_cache_smart not available"
+  )
+
+  # Minimal app_state med mock-cache
+  cache_cleared <- FALSE
+  mock_cache <- list(
+    clear = function() {
+      cache_cleared <<- TRUE
+    },
+    clear_prefix = function(prefix) {
+      cache_cleared <<- TRUE
+    }
+  )
+
+  build_state <- function() {
+    list(cache = list(qic = mock_cache))
+  }
+
+  whitelisted_contexts <- c(
+    "paste_data", "session_file_loaded",
+    "new_session", "session_restore"
+  )
+
+  for (ctx in whitelisted_contexts) {
+    cache_cleared <- FALSE
+    state <- build_state()
+
+    expect_no_warning(
+      invalidate_qic_cache_smart(state, list(context = ctx)),
+      message = sprintf("Context '%s' skal ikke trigge WARN-fallback", ctx)
+    )
+    expect_true(cache_cleared,
+      info = sprintf("Context '%s' skal trigge full cache-clear", ctx)
+    )
+  }
+})
+
 # Cleanup after all tests
 clear_performance_cache()


### PR DESCRIPTION
Closes #643

## Problem

QIC_CACHE-invalidation rammer conservative-fallback med WARN ved paste_data + session-contexts:
```
[QIC_CACHE] WARN: Unknown update context - clearing cache conservatively: paste_data
```

## Fix

Tilføjer `paste_data`, `session_file_loaded`, `new_session`, `session_restore` til `structural_changes`-listen i `invalidate_qic_cache_smart()`. Disse contexts repræsenterer alle strukturel data-ændring og bør trigge full clear, ej fallback.

## Test plan

- [x] Regression-test verificerer alle 4 contexts trigge structural clear uden WARN
- [x] `devtools::load_all() + testthat::test_file('test-cache.R')` grøn lokalt
- [x] Lintr/styler grøn

## Effekt

Eliminerer WARN-log under data-paste-flow. Sikrer ensartet cache-strategi paa tværs af data-load-veje.