### PR TITLE
fix(export): hejs tab-guard fra output til reactive-niveau

### DIFF
--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -67,6 +67,12 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # Issue #62: Cache isolated from analysis context
     # Debounced to prevent excessive re-rendering when user types metadata
     export_plot <- shiny::reactive({
+      # TAB-GUARD (Issue #644): hejs guard fra renderPlot til selve reactive.
+      # Tidligere fyrede export_plot paa fremmed tab fordi register_analysis_autogen
+      # observerede reactive paa tvaers af tab-skift. Reactive-niveau-guard
+      # eliminerer Typst-render + BFH-compute paa upload/analyser-tab.
+      shiny::req(app_state$session$active_tab == "eksporter")
+
       chart_type <- resolve_export_chart_type(app_state)
 
       # Single req() call for all required dependencies
@@ -122,6 +128,9 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # Issue #65: Use shared helper to reduce code duplication
     # Issue #67: Helper is undebounced; reactive debounces for preview performance
     pdf_export_plot <- shiny::reactive({
+      # TAB-GUARD (Issue #644): kun beregn pdf_export_plot paa eksporter-tab.
+      shiny::req(app_state$session$active_tab == "eksporter")
+
       shiny::req(
         app_state,
         app_state$data$current_data,
@@ -287,6 +296,11 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     debounced_footnote <- shiny::debounce(shiny::reactive(input$export_footnote %||% ""), millis = 1000)
 
     pdf_preview_image <- shiny::reactive({
+      # TAB-GUARD (Issue #644): Typst→PNG-render er dyr (~2s) og maa ej koere
+      # mens brugeren er paa upload/analyser-tab. Tidligere lakage skyldtes at
+      # output$pdf_preview kun tab-guardede output-niveauet, ikke reactive-bodyen.
+      shiny::req(app_state$session$active_tab == "eksporter")
+
       # Only generate for PDF format
       format <- input$export_format %||% "pdf"
       if (format != "pdf") {

--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -47,6 +47,13 @@ create_mock_app_state <- function() {
       plot_object = NULL,
       plot_ready = FALSE,
       last_valid_config = list(chart_type = "p")
+    ),
+
+    # Session state — TAB-GUARD (#644): export-reactives kraever
+    # active_tab=='eksporter' for at fyre. Tests af export-modulet
+    # forudsaetter at brugeren er paa eksporter-tab.
+    session = shiny::reactiveValues(
+      active_tab = "eksporter"
     )
   )
 
@@ -328,6 +335,51 @@ test_that("mod_export_server defensive checks: preview_ready aendres ved plot-st
           !is.null(app_state$visualization$plot_object)
       ),
       label = "preview_ready-logik TRUE naar plot er tilgaengeligt"
+    )
+  })
+})
+
+test_that("export-reactives respekterer active_tab tab-guard (#644)", {
+  # Verificerer at preview_ready returnerer FALSE/NULL naar active_tab
+  # ikke er 'eksporter'. Forhindrer at export_plot/pdf_export_plot/
+  # pdf_preview_image fyrer paa fremmed tab.
+  #
+  # Note: export_plot er debounced(500ms). session$elapse() avancerer
+  # debounce-timer i testServer-context.
+  app_state <- create_mock_app_state()
+  shiny::isolate(app_state$session$active_tab <- "analyser")
+
+  shiny::testServer(mod_export_server, args = list(app_state = app_state), {
+    session$flushReact()
+    session$elapse(600)
+    session$flushReact()
+
+    ready_off_export <- tryCatch(
+      session$returned$preview_ready(),
+      error = function(e) NULL
+    )
+    expect_true(
+      is.null(ready_off_export) || isFALSE(ready_off_export),
+      label = "preview_ready maa ej returnere TRUE naar active_tab != 'eksporter'"
+    )
+  })
+
+  # Verificer ogsaa for 'upload'-tab i ny session
+  app_state2 <- create_mock_app_state()
+  shiny::isolate(app_state2$session$active_tab <- "upload")
+
+  shiny::testServer(mod_export_server, args = list(app_state = app_state2), {
+    session$flushReact()
+    session$elapse(600)
+    session$flushReact()
+
+    ready_on_upload <- tryCatch(
+      session$returned$preview_ready(),
+      error = function(e) NULL
+    )
+    expect_true(
+      is.null(ready_on_upload) || isFALSE(ready_on_upload),
+      label = "preview_ready maa ej returnere TRUE naar active_tab='upload'"
     )
   })
 })


### PR DESCRIPTION
Closes #644

## Problem

Diagnose-log viste `export_plot()` + `pdf_export_plot()` reactive-entry og BFH compute mens `active_tab='upload'` eller `'analyser'`:

```
[19:58:48] settings_save: active_tab='analyser'
[19:58:48] DEBUG: [EXPORT_MODULE] export_plot() reactive
[19:58:48] BFH compute (export_preview, viewport=800x450)
[19:58:49] BFH compute (export_pdf, viewport=2362x1417)
[19:58:51] PDF preview genereret succesfuldt
```

#394/#407 fixede output-niveau-guards, men reactive-bodyen blev stadig pull't af `register_analysis_autogen` og andre observer-konsumenter.

## Fix

Hejser `req(app_state$session$active_tab == "eksporter")` fra output-niveau til selve reactive-bodyen i:
- `export_plot` (R/mod_export_server.R:69)
- `pdf_export_plot` (R/mod_export_server.R:127)
- `pdf_preview_image` (R/mod_export_server.R:298)

Reactive-niveau-guard sikrer:
- Ingen BFH-compute paa fremmed tab
- Ingen Typst→PNG-render paa fremmed tab (~2s wallclock pr render)
- Re-evaluering efter tab-skift sker korrekt (active_tab er reactive dep)

## Test plan

- [x] Eksisterende preview_ready test grøn (mock app_state opdateret med default `active_tab='eksporter'`)
- [x] Ny regression-test verificerer preview_ready returnerer FALSE/NULL naar active_tab er 'analyser' eller 'upload'
- [x] `devtools::load_all() + testthat::test_file('test-mod_export.R')` 0 fail / 92 pass
- [x] Lintr/styler grøn

## Effekt

- Eliminerer ~10 redundante BFH-computes pr data-paste-cascade (observeret i diagnose-log)
- Sparer ~2s Typst-render pr fremmed-tab-event