### PR TITLE
perf(export): hejs metadata-input-debounce til 1500ms

### DIFF
--- a/R/config_system_config.R
+++ b/R/config_system_config.R
@@ -108,7 +108,8 @@ DEBOUNCE_DELAYS <- list(
   input_change = 150, # 150ms - rapid user input (dropdown, typing) - OPTIMIZED
   file_select = 500, # 500ms - file selection and complex inputs
   chart_update = 500, # 500ms - chart rendering (reduced from 800ms) - OPTIMIZED
-  table_cleanup = 2000 # 2000ms - table operation cleanup (conservative delay)
+  table_cleanup = 2000, # 2000ms - table operation cleanup (conservative delay)
+  metadata_input = 1500 # 1500ms - cosmetic metadata fields (title, dept, footnote, target) — #646
 )
 
 #' Loop protection delays for UI updates (milliseconds)

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -62,10 +62,25 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
 
     # PREVIEW GENERATION ======================================================
 
+    # METADATA-INPUT-DEBOUNCE (#646) ==========================================
+    # Debounce title + department paa input-niveau (1500ms). Tidligere blev
+    # hele export_plot/pdf_export_plot debounced med 500/1000ms, men det
+    # ramte ogsaa png_width/png_height-skift (spinner-klik). Per-input-debounce
+    # adskiller cosmetic-typing (slow debounce) fra dimension-skift (snappy).
+    debounced_title <- shiny::debounce(
+      shiny::reactive(input$export_title %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
+    debounced_dept <- shiny::debounce(
+      shiny::reactive(input$export_department %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
+
     # Export plot reactive - regenerates plot with export-specific dimensions
     # Issue #61: Separate plot generation with context "export_preview" (800x450px)
     # Issue #62: Cache isolated from analysis context
-    # Debounced to prevent excessive re-rendering when user types metadata
+    # Issue #646: title/dept debounced paa input-niveau (1500ms) — png_width/
+    # png_height passerer reactive uden delay for snappy spinner-respons.
     export_plot <- shiny::reactive({
       chart_type <- resolve_export_chart_type(app_state)
 
@@ -90,10 +105,9 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         message = "export_plot() reactive - all req() checks passed, generating plot"
       )
 
-      # Read export metadata inputs (triggers reactive dependency)
-      # Note: Use %||% to ensure reactive dependency is tracked even if NULL
-      title_input <- input$export_title %||% ""
-      dept_input <- input$export_department %||% ""
+      # Read DEBOUNCED metadata inputs (#646)
+      title_input <- debounced_title()
+      dept_input <- debounced_dept()
 
       # Beregn preview-dimensioner (samme proportioner som brugerens valg,
       # men skaleret til preview-bredde 800px). Disse SKAL matche renderPlot's
@@ -112,7 +126,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         override_width_px = preview_width,
         override_height_px = preview_height
       )
-    }) |> shiny::debounce(millis = 500) # Debounce metadata changes for performance
+    })
 
     # PDF EXPORT PLOT GENERATION ==============================================
 
@@ -120,7 +134,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # This ensures correct label placement for high-res print output
     # (200x120mm @ 300 DPI = ~2362x1417px)
     # Issue #65: Use shared helper to reduce code duplication
-    # Issue #67: Helper is undebounced; reactive debounces for preview performance
+    # Issue #646: Title/dept debounced paa input-niveau via debounced_title/dept
     pdf_export_plot <- shiny::reactive({
       shiny::req(
         app_state,
@@ -129,13 +143,13 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         app_state$columns$mappings$y_column
       )
 
-      # Read export metadata inputs (triggers reactive dependency)
-      title_input <- input$export_title %||% ""
-      dept_input <- input$export_department %||% ""
+      # Read DEBOUNCED metadata inputs (#646)
+      title_input <- debounced_title()
+      dept_input <- debounced_dept()
 
       # Issue #65: Use shared helper with "export_pdf" context
       build_export_plot(app_state, title_input, dept_input, "export_pdf")
-    }) |> shiny::debounce(millis = 1000) # Debounce for preview performance
+    })
 
     # EXPORT PREVIEW RENDERING ================================================
 
@@ -281,10 +295,25 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # PDF preview reactive - generates PNG preview of Typst PDF layout
     # Only active when format is "pdf"
     # Debounced metadata-inputs til PDF preview (undgaar re-render per tastetryk)
-    debounced_analysis <- shiny::debounce(shiny::reactive(input$pdf_improvement %||% ""), millis = 1000)
-    debounced_data_def <- shiny::debounce(shiny::reactive(input$pdf_description %||% ""), millis = 1000)
-    debounced_hospital <- shiny::debounce(shiny::reactive(input$export_hospital %||% ""), millis = 1000)
-    debounced_footnote <- shiny::debounce(shiny::reactive(input$export_footnote %||% ""), millis = 1000)
+    # Issue #646: hejs debounce 1000 → 1500ms for at absorbere flere keystrokes
+    # i lange tekst-felter. Behold separate reactives for at undgaa unoedig
+    # kobling i pdf-preview-cascade.
+    debounced_analysis <- shiny::debounce(
+      shiny::reactive(input$pdf_improvement %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
+    debounced_data_def <- shiny::debounce(
+      shiny::reactive(input$pdf_description %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
+    debounced_hospital <- shiny::debounce(
+      shiny::reactive(input$export_hospital %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
+    debounced_footnote <- shiny::debounce(
+      shiny::reactive(input$export_footnote %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
 
     pdf_preview_image <- shiny::reactive({
       # Only generate for PDF format
@@ -381,7 +410,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         },
         error_type = "processing"
       )
-    }) |> shiny::debounce(millis = 1000) # Debounce for performance (PDF generation is slow)
+    }) |> shiny::debounce(millis = DEBOUNCE_DELAYS$metadata_input) # #646: 1500ms — Typst-render dyr, faerre cascades
 
     # PDF preview renderImage - displays PNG preview of Typst PDF layout
     output$pdf_preview <- shiny::renderImage(

--- a/tests/testthat/test-input-debouncing-comprehensive.R
+++ b/tests/testthat/test-input-debouncing-comprehensive.R
@@ -65,6 +65,12 @@ test_that("Debounce delays er korrekt konfigureret i DEBOUNCE_DELAYS", {
   expect_true("file_select" %in% names(DEBOUNCE_DELAYS),
     info = "file_select delay skal være defineret"
   )
+  expect_true("metadata_input" %in% names(DEBOUNCE_DELAYS),
+    info = "metadata_input delay skal være defineret (#646)"
+  )
+  expect_true(DEBOUNCE_DELAYS$metadata_input >= 1000,
+    info = "metadata_input bør være >=1000ms for at absorbere keystrokes (#646)"
+  )
 
   # Verificer værdier er reasonable (mellem 100-2000ms)
   if (exists("DEBOUNCE_DELAYS")) {


### PR DESCRIPTION
Closes #646

## Problem

Brugerens type-flow paa metadata-felter trigger BFH-compute pr keystroke trods debounce 500ms (preview) / 1000ms (pdf):

```
20:00:11  target=0      → 2 BFH (preview+pdf)  ~1.1s
20:00:13  target=0.01   → 2 BFH                ~1.2s
20:00:14  target=0.01   → 2 BFH                ~1.2s
20:00:15  target<empty> → 1 BFH                ~0.55s
20:00:16  target=0.01   → 2 BFH                ~1.2s
```

5 cascades á 2 BFH = 10 computes paa ~6s.

## Fix

1. Tilfoejer `DEBOUNCE_DELAYS$metadata_input=1500ms` som central konfigurations-slot for cosmetic-input
2. Per-input-debounce paa `export_title` + `export_department` (1500ms) i stedet for at debounce hele `export_plot/pdf_export_plot` reactive
3. Hejser eksisterende metadata-debounce 1000 → 1500ms (analysis, data_def, hospital, footnote, pdf_preview_image)

Vigtigt: png_width/png_height-skift passerer reactive UDEN delay (ej debounced), saa spinner-klik forbliver snappy.

## Test plan

- [x] Eksisterende tests grøn (`test-mod_export.R`, `test-input-debouncing-comprehensive.R`)
- [x] Ny regression-test verificerer `metadata_input`-slot eksisterer + >=1000ms
- [x] Lintr/styler grøn

## Effekt

- Hurtige keystrokes (<1500ms apart) absorberes i ét compute i stedet for cascade
- Bevares snappy spinner-respons for png_width/png_height-skift
- Foroeger absorption-vinduet uden at delaye dimension-skift