### PR TITLE
chore: konsolidér %||% til én null-only definition

### DIFF
--- a/R/config_plot_contexts.R
+++ b/R/config_plot_contexts.R
@@ -175,10 +175,3 @@ validate_plot_context <- function(context, stop_on_invalid = TRUE) {
 
   return(is_valid)
 }
-
-# NULL coalescing operator (hvis ikke allerede defineret)
-if (!exists("%||%")) {
-  `%||%` <- function(x, y) {
-    if (is.null(x)) y else x
-  }
-}

--- a/R/utils_analytics_pins.R
+++ b/R/utils_analytics_pins.R
@@ -103,8 +103,6 @@ read_shinylogs_all <- function(log_directory) {
   )
 }
 
-`%||%` <- function(x, y) if (is.null(x)) y else x
-
 #' Roter log-filer (komprimer gamle, slet meget gamle)
 #'
 #' @param log_directory Sti til log-mappe

--- a/R/utils_local_storage.R
+++ b/R/utils_local_storage.R
@@ -167,9 +167,6 @@ restore_column_class <- function(values, class_info) {
   )
 }
 
-# Null-coalesce helper (defineret her hvis ikke globalt tilgængelig)
-`%||%` <- function(a, b) if (is.null(a)) b else a
-
 # LOCAL STORAGE FUNKTIONER ===================================================
 
 ## Local Storage funktioner til server med datastruktur preservation

--- a/R/utils_logging.R
+++ b/R/utils_logging.R
@@ -25,11 +25,15 @@ LOG_LEVELS <- list(
 # intern hjaelper (ikke-eksporteret)
 .level_name <- function(x) {
   inv <- setNames(names(LOG_LEVELS), unlist(LOG_LEVELS, use.names = FALSE))
-  inv[as.character(x)] %||% "INFO"
+  coalesce_blank(inv[as.character(x)], "INFO")
 }
 
-# intern hjaelper (ikke-eksporteret)
-`%||%` <- function(a, b) if (is.null(a) || length(a) == 0 || identical(a, "")) b else a
+# Udvidet null-coalesce: returnerer `default` når x er NULL, length-0 eller "" (tom streng).
+# Bruges i log_debug_kv (nms[[i]]-pattern) og .level_name (character(0)-case).
+# Adskilles bevidst fra %||% (null-only) for at gøre semantik eksplicit.
+coalesce_blank <- function(x, default) {
+  if (is.null(x) || length(x) == 0L || identical(x, "")) default else x
+}
 
 #' Hent aktuel log level fra environment variabel
 #'
@@ -577,7 +581,7 @@ log_debug_kv <- function(..., .context = NULL, .list_data = NULL) {
   if (length(dots) > 0) {
     nms <- names(dots) %||% rep("", length(dots))
     for (i in seq_along(dots)) {
-      key <- nms[[i]] %||% paste0("..", i)
+      key <- coalesce_blank(nms[[i]], paste0("..", i))
       val <- .safe_format(dots[[i]])
       log_debug(paste0(key, ": ", val), .context = ctx)
     }
@@ -586,7 +590,7 @@ log_debug_kv <- function(..., .context = NULL, .list_data = NULL) {
   if (!is.null(.list_data) && is.list(.list_data)) {
     nms <- names(.list_data) %||% rep("", length(.list_data))
     for (i in seq_along(.list_data)) {
-      key <- nms[[i]] %||% paste0("..", i)
+      key <- coalesce_blank(nms[[i]], paste0("..", i))
       val <- .safe_format(.list_data[[i]])
       log_debug(paste0(key, ": ", val), .context = ctx)
     }


### PR DESCRIPTION
## Summary
Fjerner 4 duplikerede `%||%`-definitioner med divergerende semantik. `golem_utils.R` bevares som canonical (null-only, matcher rlang).

`utils_logging.R` brugte udvidet semantik (`length==0` + `""`-check) i 3 call-sites — disse migreres til ny `coalesce_blank()`-helper med klar dokumentation.

## Verifikation (fra review-agent)
- 5 definitioner kortlagt: 4 null-only + 1 udvidet (utils_logging)
- Load-order: alfabetisk last → `utils_logging.R` overskrev alle andre — stille bug fixet
- Udvidet semantik aktivt brugt 3 steder → bevaret som named helper

## Test plan
- [x] 338 PASS / 2 SKIP / 0 FAIL
- [x] Pre-push hooks bestået