### PR TITLE
fix(encoding): non-ASCII i UI-strings (#650 follow-up)

### DIFF
--- a/R/utils_server_column_management.R
+++ b/R/utils_server_column_management.R
@@ -229,9 +229,9 @@ show_column_mapping_modal <- function(session, app_state) {
     footer = shiny::tagList(
       shiny::actionButton(
         "auto_detect_columns",
-        label = "Auto-detektér kolonner",
+        label = "Auto-detekt\u00e9r kolonner",
         icon = shiny::icon("magic"),
-        title = "Lad appen forslå kolonne-tildelinger ud fra data",
+        title = "Lad appen forsl\u00e5 kolonne-tildelinger ud fra data",
         class = "btn-primary"
       ),
       shiny::modalButton("Luk")


### PR DESCRIPTION
## Summary

PR #653 fjernede 12 testthat-warnings, men afslørede pre-existing R CMD check warning på `R/utils_server_column_management.R:232,234`. Strings introduceret i 88f64c97 brugte rå `é`/`å` istedet for `é`/`å` — ikke-portabelt for R-pakker.

Konverterede de 2 strings til `\u`-escapes. Em-dashes i kommentarer urørte da `Encoding: UTF-8` i DESCRIPTION tolererer non-ASCII der.

## Test plan

- [x] `tools::showNonASCIIfile("R/utils_server_column_management.R")` viser kun comment-linjer
- [x] Lokalt run af label viser `Auto-detektér` + `forslå` korrekt (R parser `\u`-escapes)
- [ ] CI gate på #650 efter merge

## Refs

- #650 (release develop→master, blokeret af denne)
- #653 (merged — fjernede testthat-warnings, afslørede denne)