### PR TITLE
fix(bfh): brug bfh_result$plot direkte (BFHcharts 0.16.1 API-rename)

### DIFF
--- a/R/fct_spc_bfh_output.R
+++ b/R/fct_spc_bfh_output.R
@@ -43,14 +43,13 @@ transform_bfh_output <- function(
         stop("bfh_result must be a bfh_qic_result object from BFHcharts::bfh_qic()")
       }
 
-      # 2. Extract components from bfh_qic_result object
+      # 2. Extract components from bfh_qic_result object.
       # Structure: list(plot = ggplot, qic_data = tibble, summary = list, config = list)
-      # Use get_plot() for S3 objects, direct access for plain lists
-      plot_object <- if (BFHcharts::is_bfh_qic_result(bfh_result)) {
-        BFHcharts::get_plot(bfh_result)
-      } else {
-        bfh_result$plot
-      }
+      # NOTE: BFHcharts 0.16.1 omdoebte get_plot() -> bfh_get_plot() for at undgaa
+      # namespace-collision med ggplot2/plotly. Per BFHcharts NEWS er direkte
+      # $plot-tilgang ogsaa godkendt migration — undgaar API-version-afhaengighed
+      # og virker baade med ny og gammel BFHcharts (samt mock-objects i tests).
+      plot_object <- bfh_result$plot
       qic_data <- bfh_result$qic_data
 
       log_debug(

--- a/tests/testthat/test-bfhcharts-integration.R
+++ b/tests/testthat/test-bfhcharts-integration.R
@@ -139,7 +139,9 @@ test_that("BFHcharts to-trins workflow: bfh_qic + get_plot", {
   expect_true(inherits(bfh_result, "bfh_qic_result"))
 
   # Trin 2: Udtraek ggplot
-  plot <- BFHcharts::get_plot(bfh_result)
+  # BFHcharts 0.16.1: get_plot() omdoebt -> bfh_get_plot(); direkte $plot
+  # er ogsaa godkendt migration per BFHcharts NEWS, og er stable accross versioner.
+  plot <- bfh_result$plot
   expect_s3_class(plot, "ggplot")
 })
 


### PR DESCRIPTION
## Summary

- BFHcharts 0.16.1 omdøbte `get_plot()` → `bfh_get_plot()` for at undgå namespace-collision med ggplot2/plotly (per BFHcharts NEWS.md)
- biSPCharts kaldte stadig den gamle `BFHcharts::get_plot` → `'get_plot' is not an exported object from 'namespace:BFHcharts'`
- Resultat: Bruger så "diagrammet kan ikke genereres" empty-state ved enhver SPC-render
- Fejlen var skjult af `spc.debug.context`-filter på `log_error` (separat fix i `fix/log-error-warn-bypass-context-filter`)

## Approach

Per BFHcharts NEWS er direkte `$plot`-tilgang også godkendt migration. Direkte tilgang foretrækkes:
- Ingen API-version-afhængighed (virker både pre/post 0.16.1)
- Virker med mock-objects i tests (mock returnerer `bfh_qic_result`-class uden S3-method-export)
- Simplere kode uden conditional S3-dispatch

## Ændringer

- `R/fct_spc_bfh_output.R`: erstat `BFHcharts::get_plot(bfh_result)` med `bfh_result$plot`
- `tests/testthat/test-bfhcharts-integration.R`: opdater tilsvarende

## Test plan

- [x] `test-helper-mocks-contracts.R`: 40 PASS
- [x] `test-bfhcharts-integration.R`: 11 PASS
- [x] Pre-push gate: bestået (lintr + manifest-sync + regression-tests)
- [x] Manual verifikation: dev-loaded BFHcharts (0.16.1) → SPC computation completed successfully
- [ ] Manual app-test: source(`dev/run_dev.R`) → indlæs data → bekræft SPC plot vises

## Cross-repo notes

Følger versioning-policy §E (cross-repo bump-protokol): downstream-migration efter sibling breaking change i BFHcharts 0.16.1. DESCRIPTION krævede allerede `BFHcharts (>= 0.16.1)` men kald-stedet manglede migration.