### PR TITLE
perf(export): preview-regenererings-fixes (#H3 + #EH0 + #EM1)

### DIFF
--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -259,6 +259,12 @@ build_cache_key <- function(data, chart_type, x_var, y_var, n_var,
         target_value = extra_params$target_value,
         centerline_value = extra_params$centerline_value,
         y_axis_unit = extra_params$y_axis_unit,
+        # Codex peer-review 2026-05-08 (#H3): target_text og chart_title bruges
+        # i BFH-kald (fct_spc_execute.R:84,86) men manglede i cache-keyen.
+        # Konsekvens: cache returnerede plot med stale labels naar bruger
+        # aendrede target-tekst eller chart-titel.
+        target_text = extra_params$target_text,
+        chart_title = extra_params$chart_title,
         multiply_by = multiply,
         # Viewport dimensions inkluderes: ellers ville plots fra export (andre dims)
         # fejlagtigt genbruges fra analysis-cache eller omvendt.

--- a/R/mod_export_analysis.R
+++ b/R/mod_export_analysis.R
@@ -7,7 +7,7 @@
 #          Handles automatic text generation for PDF export with user edit detection.
 #
 # Extracted from: mod_export_server.R (Phase 2b refactoring)
-# Depends on: export_plot reactive (from mod_export_server.R)
+# Depends on: pdf_export_plot reactive (from mod_export_server.R)
 #            input$export_format, input$pdf_improvement, input$pdf_description
 # ==============================================================================
 
@@ -19,24 +19,30 @@
 #' @param session Shiny session object
 #' @param input Input object containing UI inputs
 #' @param output Output object for rendering
-#' @param export_plot Reactive expression returning SPC plot result
+#' @param pdf_export_plot Reactive expression returning PDF-context SPC plot
+#'   result. Codex peer-review 2026-05-08 (#EH0): tidligere modtog observeren
+#'   `export_plot` (PNG-context "export_preview") selv paa PDF-mode, hvilket
+#'   trigger en uafhaengig generateSPCPlot()-koersel for PNG-context kun for
+#'   at hente bfh_qic_result. Skift til pdf_export_plot eliminerer dobbelt-
+#'   generering, da PDF-preview alligevel evaluerer samme reactive (cache-hit
+#'   paa anden eval).
 #' @param app_state Reactive values object containing column mappings
 #'
 #' @return NULL (side effect: registers observers with Shiny)
 #'
 #' @keywords internal
-register_analysis_autogen <- function(session, input, output, export_plot, app_state) {
+register_analysis_autogen <- function(session, input, output, pdf_export_plot, app_state) {
   # Sidst auto-genererede tekst læses/skrives via app_state$ui$last_auto_analysis
   # (migreret fra reactiveVal, ADR-004 — tracking-state hører i centralt app_state).
 
   # Auto-generer analysetekst når SPC-resultat er tilgængeligt.
   # Bruger observe() (ikke observeEvent) saa tab-guard evalueres FØR
-  # export_plot() -- observeEvent evaluerer altid trigger-udtrykket
+  # pdf_export_plot() -- observeEvent evaluerer altid trigger-udtrykket
   # hvilket kalder generateSPCPlot() som side-effekt (Issue #394).
   shiny::observe(
     {
       # TAB-GUARD (Issue #394): Afbryd straks hvis brugeren IKKE er paa
-      # eksporter-tab. req() forhindrer at export_plot() evalueres paa
+      # eksporter-tab. req() forhindrer at pdf_export_plot() evalueres paa
       # andre tabs og sparer CPU + Typst PDF-render i baggrunden.
       shiny::req(app_state$session$active_tab == "eksporter")
 
@@ -49,7 +55,11 @@ register_analysis_autogen <- function(session, input, output, export_plot, app_s
         return()
       }
 
-      result <- export_plot()
+      # #EH0 (Codex 2026-05-08): pdf_export_plot bruger context "export_pdf"
+      # som matcher PDF-preview, saa observeren genbruger samme cache.
+      # Tidligere kald til export_plot() (context "export_preview") forarsagede
+      # parallel generateSPCPlot()-koersel udelukkende for at hente bfh_qic_result.
+      result <- pdf_export_plot()
       if (is.null(result) || is.null(result$bfh_qic_result)) {
         return()
       }

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -75,6 +75,14 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       shiny::reactive(input$export_department %||% ""),
       millis = DEBOUNCE_DELAYS$metadata_input
     )
+    # #EM1 (Codex 2026-05-08): debounced_footnote bruges af baade PNG-preview
+    # (output$export_preview) og PDF-preview (pdf_preview_image). Flyttet op
+    # i scope saa PNG-renderPlot ikke laeser input$export_footnote direkte
+    # (per-keystroke re-render) men i stedet venter paa debounced reactive.
+    debounced_footnote <- shiny::debounce(
+      shiny::reactive(input$export_footnote %||% ""),
+      millis = DEBOUNCE_DELAYS$metadata_input
+    )
 
     # Export plot reactive - regenerates plot with export-specific dimensions
     # Issue #61: Separate plot generation with context "export_preview" (800x450px)
@@ -211,15 +219,19 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
           )
         }
 
-        # Tilfoej subtitle (hospital + afdeling) og margin til PNG preview
+        # Tilfoej subtitle (hospital + afdeling) og margin til PNG preview.
+        # #EM1 (Codex 2026-05-08): laes debounced reactives i stedet for
+        # input$ direkte. Tidligere udloeste hver keystroke i department/
+        # footnote en fuld renderPlot-cyklus (~100ms). Nu venter renderPlot
+        # paa metadata_input-debounce (1500ms) som dept/title.
         plot <- spc_result$plot
 
-        dept_text <- trimws(input$export_department %||% "")
+        dept_text <- trimws(debounced_dept())
         if (nchar(dept_text) > 0) {
           plot <- plot + ggplot2::labs(subtitle = dept_text)
         }
 
-        footnote_text <- trimws(input$export_footnote %||% "")
+        footnote_text <- trimws(debounced_footnote())
         if (nchar(footnote_text) > 0) {
           plot <- plot + ggplot2::labs(caption = footnote_text)
         }
@@ -319,10 +331,8 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       shiny::reactive(input$export_hospital %||% ""),
       millis = DEBOUNCE_DELAYS$metadata_input
     )
-    debounced_footnote <- shiny::debounce(
-      shiny::reactive(input$export_footnote %||% ""),
-      millis = DEBOUNCE_DELAYS$metadata_input
-    )
+    # NOTE: debounced_footnote er flyttet til top-of-server-scope (#EM1) saa
+    # PNG-preview kan dele samme debouncer. Definition: se efter debounced_dept.
 
     pdf_preview_image <- shiny::reactive({
       # TAB-GUARD (Issue #644): Typst→PNG-render er dyr (~2s) og maa ej koere

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -473,7 +473,12 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # Placeret efter reactive-definitioner for at undgaa forward references
 
     # Analysis auto-generation (mod_export_analysis.R)
-    register_analysis_autogen(session, input, output, export_plot, app_state)
+    # #EH0 (Codex 2026-05-08): pass pdf_export_plot (PDF-context) i stedet for
+    # export_plot (PNG-context). Auto-gen bruges kun paa PDF-mode (format-guard
+    # i mod_export_analysis.R), og pdf_export_plot deler cache-key med
+    # PDF-preview, saa observer-evaluering bliver cache-hit i stedet for ekstra
+    # generateSPCPlot()-koersel.
+    register_analysis_autogen(session, input, output, pdf_export_plot, app_state)
 
     # AI suggestion integration (mod_export_ai.R)
     register_ai_button_state(session, input, output, app_state)

--- a/R/utils_spc_cache.R
+++ b/R/utils_spc_cache.R
@@ -172,6 +172,12 @@ generate_spc_cache_key <- function(data, config) {
         target_value = config$target_value,
         centerline_value = config$centerline_value,
         y_axis_unit = config$y_axis_unit,
+        # Codex peer-review 2026-05-08 (#H3): target_text og chart_title bruges
+        # i BFH-kald (fct_spc_execute.R:84,86) men manglede i config_signature.
+        # Konsekvens: cache returnerede plot med stale labels naar bruger
+        # aendrede target-tekst eller chart-titel.
+        target_text = config$target_text,
+        chart_title = config$chart_title,
         multiply_by = config$multiply_by %||% 1,
         # CRITICAL: Include viewport dimensions for context-aware caching
         # Different plot contexts (analysis, export_preview, export_pdf) have

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1064,6 +1064,14 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-04'
   rationale: Regression-test for #482 cache-key freeze/part/cl/notes — tilfoejet manuelt.
+- file: test-cache-key-target-text-chart-title.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Regression-test for #H3 cache-key target_text + chart_title — tilfoejet manuelt.
 - file: test-llm-context-truncation-489.R
   audit_category: post-audit
   type: unit

--- a/tests/testthat/test-cache-key-target-text-chart-title.R
+++ b/tests/testthat/test-cache-key-target-text-chart-title.R
@@ -1,0 +1,83 @@
+# test-cache-key-target-text-chart-title.R
+# Regression-tests for backend cache-key #H3 (Codex peer-review 2026-05-08):
+# build_cache_key skal differentiere paa target_text og chart_title fordi
+# begge bruges i BFH-kald (fct_spc_execute.R:84,86) og paavirker plot-output.
+# Foer fix returnerede cachen plot med stale labels naar bruger aendrede
+# target-tekst eller chart-titel.
+
+test_that("build_cache_key differentierer paa extra_params$chart_title", {
+  data <- data.frame(
+    Dato = as.Date("2024-01-01") + 0:9,
+    Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
+  )
+
+  base_args <- list(
+    data = data, chart_type = "i", x_var = "Dato", y_var = "Vaerdi",
+    n_var = NULL, multiply = 1, use_cache = TRUE
+  )
+
+  key_no_title <- do.call(build_cache_key, c(base_args, list(extra_params = list())))
+  key_title_a <- do.call(build_cache_key, c(base_args, list(extra_params = list(chart_title = "Ventetid Q1"))))
+  key_title_b <- do.call(build_cache_key, c(base_args, list(extra_params = list(chart_title = "Ventetid Q2"))))
+
+  expect_false(identical(key_no_title, key_title_a))
+  expect_false(identical(key_title_a, key_title_b))
+
+  # Identiske kald -> deterministisk
+  key_title_a_repeat <- do.call(build_cache_key, c(base_args, list(extra_params = list(chart_title = "Ventetid Q1"))))
+  expect_identical(key_title_a, key_title_a_repeat)
+})
+
+test_that("build_cache_key differentierer paa extra_params$target_text", {
+  data <- data.frame(
+    Dato = as.Date("2024-01-01") + 0:9,
+    Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
+  )
+
+  base_args <- list(
+    data = data, chart_type = "i", x_var = "Dato", y_var = "Vaerdi",
+    n_var = NULL, multiply = 1, use_cache = TRUE
+  )
+
+  ep_no_text <- list(target_value = 12)
+  ep_text_a <- list(target_value = 12, target_text = "Maal: 12")
+  ep_text_b <- list(target_value = 12, target_text = "Maximum")
+
+  key_no_text <- do.call(build_cache_key, c(base_args, list(extra_params = ep_no_text)))
+  key_text_a <- do.call(build_cache_key, c(base_args, list(extra_params = ep_text_a)))
+  key_text_b <- do.call(build_cache_key, c(base_args, list(extra_params = ep_text_b)))
+
+  expect_false(identical(key_no_text, key_text_a))
+  expect_false(identical(key_text_a, key_text_b))
+
+  # Identiske kald -> deterministisk
+  key_text_a_repeat <- do.call(build_cache_key, c(base_args, list(extra_params = ep_text_a)))
+  expect_identical(key_text_a, key_text_a_repeat)
+})
+
+test_that("build_cache_key behandler chart_title og target_text uafhaengigt", {
+  data <- data.frame(
+    Dato = as.Date("2024-01-01") + 0:9,
+    Vaerdi = c(10, 12, 11, 14, 13, 15, 11, 12, 14, 13)
+  )
+
+  base_args <- list(
+    data = data, chart_type = "i", x_var = "Dato", y_var = "Vaerdi",
+    n_var = NULL, multiply = 1, use_cache = TRUE
+  )
+
+  # Forskellig kombination af chart_title + target_text giver forskellige keys
+  key_combo_1 <- do.call(build_cache_key, c(base_args, list(
+    extra_params = list(chart_title = "A", target_text = "X")
+  )))
+  key_combo_2 <- do.call(build_cache_key, c(base_args, list(
+    extra_params = list(chart_title = "B", target_text = "X")
+  )))
+  key_combo_3 <- do.call(build_cache_key, c(base_args, list(
+    extra_params = list(chart_title = "A", target_text = "Y")
+  )))
+
+  expect_false(identical(key_combo_1, key_combo_2))
+  expect_false(identical(key_combo_1, key_combo_3))
+  expect_false(identical(key_combo_2, key_combo_3))
+})


### PR DESCRIPTION
## Summary

Tre relaterede fixes fra Codex peer-review 2026-05-08 — alle adresserer redundant SPC-plot-genererering i export-flow + cache-stale-labels.

### #H3 — Cache-key inkluderer target_text + chart_title

**Problem:** Backend cache-key i `build_cache_key()` og `generate_spc_cache_key()` manglede `target_text` + `chart_title` selv om begge bruges i BFH-kald (`fct_spc_execute.R:84,86`). Konsekvens: cache returnerede plot med stale labels når brugeren ændrede target-tekst eller chart-titel.

Højere lag (`mod_spc_chart_compute.R`) inkluderede dem i sin egen cache-key og kompenserede, men eksport-vej og direkte facade-kald var sårbare.

- `R/fct_spc_bfh_facade.R`: tilføj `target_text` + `chart_title` til `cache_config`
- `R/utils_spc_cache.R`: tilføj dem til `config_signature`-whitelist
- `tests/testthat/test-cache-key-target-text-chart-title.R`: 9 nye tests

### #EH0 — Fjern PDF-mode dobbeltgenerering

**Problem:** `register_analysis_autogen()` modtog `export_plot` (context "export_preview") og kaldte den på PDF-mode for at hente `bfh_qic_result` til auto-genereret analysetekst. Da PDF-preview alligevel evaluerer `pdf_export_plot` (context "export_pdf"), forårsagede det to uafhængige `generateSPCPlot()`-kørseler per PDF-metadata-ændring (~100-200ms ekstra + cache-pressure med duplikerede entries).

Format-guarden i observeren returnerer på PNG-mode, så skift til `pdf_export_plot` er semantisk korrekt: observer kalder kun reactive på PDF-mode, og `pdf_export_plot` deler cache-key med PDF-preview → andet kald bliver cache-hit.

- `R/mod_export_analysis.R`: rename param `export_plot` → `pdf_export_plot`
- `R/mod_export_server.R`: pass `pdf_export_plot` ved register-kald

### #EM1 — Debounce PNG-preview footnote + department

**Problem:** `output$export_preview`-renderPlot læste tidligere `input$export_department` og `input$export_footnote` direkte i body, hvilket trigger fuld renderPlot-cyklus per keystroke (~100ms per render). Inkonsistent med PDF-preview-pattern hvor alle metadata-inputs er debounced 1500ms.

Reducerer PNG-preview-renders fra ~10/sek til ~1 per 1.5s under aktiv typing i metadata-felter.

- `R/mod_export_server.R`: flyt `debounced_footnote` til top-of-server-scope så både PNG- og PDF-preview deler samme debouncer

## Verifikation

- [x] Codex-claims verificeret empirisk på develop-baseline (chart_title/target_text bruges i `fct_spc_execute.R:84,86`; `register_analysis_autogen` modtager export_plot + kalder det; `input$export_department/footnote` læses direkte i renderPlot)
- [x] 9/9 regression-tests pass for #H3
- [x] Pre-push gate (lintr + manifest + hurtige tests) OK på 66s

## Test plan

- [ ] Re-deploy til Connect Cloud + manuel test: ændring i target_text/chart_title invaliderer cache
- [ ] Manuel test: typing i export_footnote/department → ingen flicker i PNG-preview
- [ ] Manuel test: PDF-preview metadata-ændring → kun ÉN `generateSPCPlot`-koersel i log