### PR TITLE
chore(cross-repo): cycle A cleanup-fixes (M2+M3+L1+H2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@
 **Technology Stack:**
 - Shiny + Golem
 - BFHcharts (SPC visualization), BFHtheme (branding), BFHllm (AI/LLM)
-- BFHchartsAssets (privat companion-pkg med proprietære fonts/logoer; staages via `inject_template_assets()` ved runtime; kræver `GITHUB_PAT` for Connect Cloud)
+- BFHchartsAssets (privat companion-pkg med proprietære fonts/logoer; staages via `inject_template_assets()` ved runtime; lokal udvikling + CI bruger `GITHUB_PAT` til install — Connect Cloud-deploy bruger separat auth-mekanisme)
 - qicharts2 (Anhøj rules)
 - Ragnar (RAG knowledge store, via BFHllm)
 
@@ -114,7 +114,8 @@ Implementation: `R/fct_spc_file_save_load.R`, `R/fct_excel_sheet_detection.R`,
 
 ✅ **Maintainer kontrollerer fuldt:** BFHcharts (rendering), BFHtheme (branding),
 BFHllm (LLM/RAG/caching), Ragnar (knowledge store), BFHchartsAssets (proprietære
-fonts/logoer; privat repo, kræver `GITHUB_PAT`).
+fonts/logoer; privat repo, `GITHUB_PAT` til lokal install + CI; Connect Cloud-deploy
+bruger separat auth-mekanisme).
 
 ❌ **ALDRIG implementér** funktionalitet i biSPCharts som hører hjemme i ekstern
 pakke (eks: target lines, font fallback, hospital colors, embeddings, BM25,

--- a/R/app_run.R
+++ b/R/app_run.R
@@ -208,6 +208,52 @@ validate_configuration <- function() {
   invisible(TRUE)
 }
 
+#' Validate branding-policy ved boot (Cycle A H2 reconciled 2026-05-09)
+#'
+#' Tjekker `branding.require_branded_assets`-flag i aktiv golem-config-profile.
+#' Hvis TRUE og `BFHchartsAssets`-pakken mangler -> hard-fail boot.
+#'
+#' Production-profile har default `require_branded_assets: true` saa
+#' Connect Cloud-deploy uden GITHUB_PAT fanges fail-loud i stedet for at
+#' degradere silent til ubrandet UI. Dev/test-profiler har default
+#' `require_branded_assets: false` saa CI uden assets kan koere tests.
+#'
+#' @return invisible(TRUE) ved success; signalerer `bisp_config_error` ellers.
+#' @keywords internal
+validate_branding_policy <- function() {
+  branding_config <- tryCatch(
+    {
+      if (exists("get_golem_config", mode = "function")) {
+        get_golem_config("branding")
+      } else {
+        NULL
+      }
+    },
+    error = function(e) NULL # nolint: swallowed_error_linter
+  )
+
+  require_assets <- isTRUE(branding_config$require_branded_assets)
+
+  if (!require_assets) {
+    return(invisible(TRUE))
+  }
+
+  if (!requireNamespace("BFHchartsAssets", quietly = TRUE)) {
+    rlang::abort(
+      message = paste0(
+        "BFHchartsAssets-pakken mangler men branding.require_branded_assets=true. ",
+        "Production-deploy kraever proprietaere fonts/logoer. ",
+        "Installer BFHchartsAssets via GITHUB_PAT eller saet ",
+        "branding.require_branded_assets=false hvis ubrandet UI er acceptabelt."
+      ),
+      class = c("bisp_config_error", "error", "condition"),
+      details = list(missing_pkg = "BFHchartsAssets", policy = "require_branded_assets")
+    )
+  }
+
+  invisible(TRUE)
+}
+
 #' Initialize startup performance optimizations
 #'
 #' Initialize startup cache and lazy loading systems at run_app() level.
@@ -335,6 +381,10 @@ run_app <- function(port = NULL,
   # range-overskridelser i timing-konstanter, saa app ikke starter op med
   # silent broken config der foerst manifesterer sig under load.
   validate_configuration()
+
+  # Cycle A H2 reconciled (2026-05-09): branding-policy validation.
+  # Production hard-fail hvis BFHchartsAssets mangler (require_branded_assets=true).
+  validate_branding_policy()
 
   # Merge passed options directly (no feature flags needed - pure BFHcharts)
   merged_options <- options

--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -175,8 +175,20 @@ generate_pdf_export <- function(input, app_state, file) {
     inject_assets = inject_template_assets
   )
 
+  # M3 (Cycle A 2026-05-09): Tjek baade return-value, fil-eksistens OG fil-stoerrelse.
+  # Tidligere check (is.null OR !file.exists) gik glip af korrupt/incomplete PDF
+  # hvor BFHcharts retunerer non-NULL men Typst-render fejlede partway. Brugeren
+  # ville se success-message med tom/incomplete fil. Minimum-PDF-stoerrelse er
+  # >1KB (header + nogle bytes), saa fil <512 bytes er garanteret korrupt.
   if (is.null(result) || !file.exists(file)) {
     stop("PDF generation failed - file not created")
+  }
+  pdf_size <- file.info(file)$size
+  if (is.na(pdf_size) || pdf_size < 512) {
+    stop(sprintf(
+      "PDF generation failed - file appears incomplete (%d bytes, expected >512)",
+      pdf_size %||% 0L
+    ))
   }
 
   shiny::showNotification("PDF genereret og downloadet", type = "message", duration = 3)

--- a/R/utils_server_export.R
+++ b/R/utils_server_export.R
@@ -345,6 +345,10 @@ generate_pdf_preview <- function(bfh_qic_result,
           #    os til bfh_extract_spc_stats.bfh_qic_result(), som udfylder
           #    outliers_actual (seneste part, total) til tabellen. Uden dette kald
           #    ville tabellen "OBS. UDEN FOR KONTROLGRAeNSE" vaere tom i preview.
+          # M2 (Cycle A 2026-05-09): S3-dispatch afhaenger af class-name `bfh_qic_result`.
+          # Hvis BFHcharts omdoeber class -> silent fallback til default method ->
+          # forkert struktur returneres. Class-rename fanges ej af tests; manuel
+          # verifikation kraevet ved BFHcharts breaking changes.
           spc_stats <- BFHcharts::bfh_extract_spc_stats(bfh_qic_result)
 
           # 3. Merge metadata with chart title

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1423,7 +1423,14 @@ files:
   reviewed: yes
   reviewer: johanreventlow
   reviewed_date: '2026-05-03'
-  rationale: Tilfoejet manuelt — fil oprettet efter audit-baseline 2026-04-26.
+- file: test-branding-policy.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Cycle A H2 reconciled (2026-05-09) regression-tests for branding-policy boot-validation.
 - file: test-utils-server-paste-data.R
   audit_category: post-audit
   type: unit

--- a/docs/CROSS_REPO_COORDINATION.md
+++ b/docs/CROSS_REPO_COORDINATION.md
@@ -1745,8 +1745,45 @@ remotes::install_github("user/BFHcharts@v0.3.0")
 
 ---
 
+## Common API-Migration-Pitfalls
+
+### Dev-tree vs installeret pakke kan have forskellig API
+
+Real lesson fra Cycle A cross-repo wrapper-review (2026-05-09):
+
+`dev/run_dev.R` loader sibling-pakker via `devtools::load_all()` fra source-tree.
+Source-tree's `NEWS.md` kan dokumentere "(development)" breaking changes der
+**ikke** er i installeret tagged release. Eksempel:
+
+- BFHcharts 0.16.1 (installeret tagged): `get_plot()` exported, `bfh_get_plot()` IKKE
+- BFHcharts 0.16.1 (dev-tree, NEWS markeret "(development)"): `bfh_get_plot()` exported
+
+**Symptom:** Bruger med dev-loaded sibling ser ny API; CI eller production med
+installeret pakke ser gammel API. Tests grønne lokalt, fejler på CI/prod.
+
+**Fix-pattern:**
+1. Når sibling renamer public function → bump MINOR/MAJOR (ej blot "(development)")
+2. Downstream-kald: foretrukket fallback-strategi i prioriteret rækkefølge:
+   - Direkte struct-access (`result$plot`) hvis tilgaengeligt
+   - S3-method-dispatch hvis stable API
+   - Conditional fallback med version-check kun hvis nødvendigt
+3. Dokumenter i NEWS.md hvilken release-tag indeholder API-skift (ej "(development)")
+
+### Class-rename-fragility
+
+S3-dispatch på sibling-pakke-class (fx `bfh_qic_result`) er sårbar mod upstream
+class-rename. Silent fallback til default method giver forkert struktur uden
+kompileringsfejl. Mitigation:
+
+- Tilføj inline-kommentar ved S3-dispatch-call-sites
+- Class-rename SHALL bumpe sibling MAJOR-version (post-1.0)
+- Pre-1.0: dokumenter eksplicit i NEWS + koordiner downstream-PR
+
+---
+
 **Document History:**
 - **v1.0.0** (2025-10-17): Initial version
+- **v1.1.0** (2026-05-09): Tilfoejet "Common API-Migration-Pitfalls" baseret paa Cycle A cross-repo wrapper-review
 - **Next review:** 2026-01-17 (quarterly)
 
 **Feedback:**

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -287,6 +287,14 @@ production:
       n_results: 3                  # Balance between context and performance
       method: "hybrid"              # Optimal search accuracy
 
+  # Branding policy (Cycle A H2 reconciled 2026-05-09)
+  # Hard-fail boot hvis BFHchartsAssets mangler i production. Hospitals forventer
+  # brandet PDF/PNG-output (logos + Mari-fonts). Soft-fail i dev tilladt for at
+  # CI uden GITHUB_PAT kan koere tests, men prod-deploy uden assets giver
+  # degraded UI uden synligt signal.
+  branding:
+    require_branded_assets: true    # Boot fejler hvis BFHchartsAssets mangler
+
 
 # TESTING CONFIGURATION ======================================================
 # Optimized for controlled test conditions and reproducibility

--- a/tests/testthat/test-branding-policy.R
+++ b/tests/testthat/test-branding-policy.R
@@ -1,0 +1,58 @@
+# test-branding-policy.R
+# Cycle A H2 reconciled (2026-05-09): regression-tests for branding-policy
+# boot-validation.
+
+with_golem_config_active <- function(profile, code) {
+  old <- Sys.getenv("GOLEM_CONFIG_ACTIVE", unset = NA)
+  on.exit({
+    if (is.na(old)) Sys.unsetenv("GOLEM_CONFIG_ACTIVE") else Sys.setenv(GOLEM_CONFIG_ACTIVE = old)
+  })
+  Sys.setenv(GOLEM_CONFIG_ACTIVE = profile)
+  force(code)
+}
+
+test_that("validate_branding_policy() passer i default-profile (no flag)", {
+  with_golem_config_active("default", {
+    expect_true(validate_branding_policy())
+  })
+})
+
+test_that("validate_branding_policy() passer i development-profile (flag=FALSE)", {
+  with_golem_config_active("development", {
+    expect_true(validate_branding_policy())
+  })
+})
+
+test_that("validate_branding_policy() passer i production naar BFHchartsAssets findes", {
+  skip_if_not_installed("BFHchartsAssets")
+  with_golem_config_active("production", {
+    expect_true(validate_branding_policy())
+  })
+})
+
+test_that("validate_branding_policy() fejler hard hvis flag=TRUE og BFHchartsAssets mangler", {
+  if (requireNamespace("BFHchartsAssets", quietly = TRUE)) {
+    skip("BFHchartsAssets installed - cannot test missing-pkg path without unmocking")
+  }
+  with_golem_config_active("production", {
+    expect_error(
+      validate_branding_policy(),
+      class = "bisp_config_error",
+      regexp = "BFHchartsAssets-pakken mangler"
+    )
+  })
+})
+
+test_that("production-profile har require_branded_assets: true (regression-guard)", {
+  config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
+  skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  expect_true(
+    isTRUE(yaml_content$production$branding$require_branded_assets),
+    info = paste(
+      "production-profile skal have branding.require_branded_assets: true",
+      "for at hard-fail boot uden BFHchartsAssets (Cycle A H2 policy)."
+    )
+  )
+})


### PR DESCRIPTION
## Summary

Implementer cleanup-fixes fra Cycle A cross-repo wrapper-review (`docs/reviews/01-cross-repo-wrappers.md`).

Separat fra OpenSpec PR #664 (H1+H1-NEW BFHllm config-injection) — denne PR samler defensive coding + docs + policy-implementation.

### M2 — S3-dispatch-fragility doc-comment
`bfh_extract_spc_stats(bfh_qic_result)` S3-dispatch er sårbar mod upstream class-rename. Tilføjer inline-kommentar som signal til fremtidige reviewere.

### M3 — PDF-export-error-check styrket
Tidligere check missede partial-write-scenarier (BFHcharts returnerer non-NULL men Typst fejlede partway → korrupt fil + success-message). Tilføjer 512-byte minimum-size-sanity.

### L1 — CROSS_REPO_COORDINATION.md opdateret
Ny sektion "Common API-Migration-Pitfalls" dokumenterer:
- Dev-tree vs installeret-pakke API-divergens (real lesson: get_plot/bfh_get_plot)
- S3-class-rename-fragility-pattern

### H2 — Branding-policy hard-fail i prod
Bruger valgte hard-fail-policy efter Codex's reconcile (H2 → product-policy-decision):
- `inst/golem-config.yml`: production-profile får `branding.require_branded_assets: true`
- `R/app_run.R`: ny `validate_branding_policy()` fejler boot hvis flag=true og BFHchartsAssets mangler
- Default + dev-profile uændret (soft-fail) → CI uden GITHUB_PAT virker stadig

## Commits

1. `docs(s3-dispatch)`: M2 inline-comment
2. `fix(export)`: M3 fil-størrelse-sanity
3. `docs(coordination)`: L1 API-migration-pitfalls
4. `feat(branding)`: H2 hard-fail-policy + tests + manifest

## Test plan

- [x] `testthat::test_file('tests/testthat/test-branding-policy.R')` → 4 PASS, 1 SKIP
- [x] Pre-push gate: lintr + manifest-sync + regression — bestået
- [ ] Manual test prod-mode uden BFHchartsAssets: forventer hard-fail med struktureret besked
- [ ] Manual test dev-mode uden BFHchartsAssets: forventer soft-degradation som før

## Behavioral impact

⚠️ **PRODUKTION:** Boot fejler nu loud hvis BFHchartsAssets mangler. Verificer at deployment-pipeline har GITHUB_PAT konfigureret før merge til master.

## Related

- Review-rapport: `docs/reviews/01-cross-repo-wrappers.md`
- Søsterpr: #664 (H1+H1-NEW BFHllm config-injection)