### PR TITLE
fix(events): slet direct emit$navigation_changed fra file-load-paths (cycle B M2)

### DIFF
--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -360,8 +360,11 @@ handle_excel_upload <- function(file_path, session, app_state, emit, ui_service 
     apply_state_transition(app_state, transition_upload_to_ready(parsed))
     set_current_data(app_state, parsed$data)
 
+    # Cycle B M2 (Codex 2026-05-09): Slet direct emit$navigation_changed \u2014
+    # data_updated cascade fyrer navigation_changed via auto_detection_completed
+    # \u2192 ui_sync_completed. Direct emit forarsagede pre-autodetect render med
+    # stale columns + andet render efter UI-sync (visible glitch).
     emit$data_updated("file_loaded")
-    emit$navigation_changed()
 
     besked <- paste0(
       "Data indl\u00e6st: ", nrow(parsed$data), " r\u00e6kker \u2014 ",
@@ -372,8 +375,8 @@ handle_excel_upload <- function(file_path, session, app_state, emit, ui_service 
     apply_state_transition(app_state, transition_upload_to_ready(parsed))
     set_current_data(app_state, parsed$data)
 
+    # Cycle B M2: same fix som ovenfor
     emit$data_updated("file_loaded")
-    emit$navigation_changed()
 
     besked <- NULL # notify_upload_success vises nedenfor
   }
@@ -489,8 +492,9 @@ handle_csv_upload <- function(file_path, app_state, session_id = NULL, emit = NU
   set_current_data(app_state, parsed$data)
 
   # Emit unified data_updated event (replaces legacy data_loaded)
+  # Cycle B M2 (Codex 2026-05-09): direct navigation_changed slettet —
+  # cascade fyrer den via ui_sync_completed.
   emit$data_updated(context = "session_file_loaded")
-  emit$navigation_changed()
 
   log_info("Data loaded event emitted successfully",
     .context = "FILE_UPLOAD_FLOW",
@@ -624,8 +628,9 @@ handle_paste_data <- function(text_data, app_state, session_id = NULL, emit = NU
   set_current_data(app_state, parsed_from_paste$data)
 
   # Emit events
+  # Cycle B M2 (Codex 2026-05-09): direct navigation_changed slettet —
+  # cascade fyrer den via ui_sync_completed.
   emit$data_updated(context = "paste_data")
-  emit$navigation_changed()
 
   notify_upload_success("Indsatte data", data)
 

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1448,3 +1448,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-07'
   rationale: Tilfoejet manuelt — fil oprettet ifm. Issue #610 (viewport_ready signal).
+- file: test-navigation-no-double-emit.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Cycle B M2 (Codex 2026-05-09) regression-test mod double-emit navigation_changed fra file-load-paths.

--- a/tests/testthat/test-navigation-no-double-emit.R
+++ b/tests/testthat/test-navigation-no-double-emit.R
@@ -1,0 +1,54 @@
+# test-navigation-no-double-emit.R
+# Cycle B M2 (Codex 2026-05-09): regression-test for double-emit
+# navigation_changed fra file-load-paths.
+#
+# Pre-fix: fct_file_operations.R emitter baade data_updated("file_loaded")
+# OG direct emit$navigation_changed() umiddelbart efter. Det forarsagede
+# pre-autodetect render med stale columns + andet render efter UI-sync
+# (visible glitch).
+#
+# Post-fix: kun data_updated emit; cascade fyrer navigation_changed via
+# auto_detection_completed -> ui_sync_completed.
+
+test_that("fct_file_operations.R indeholder ikke direct emit$navigation_changed efter data_updated", {
+  source_file <- testthat::test_path("..", "..", "R", "fct_file_operations.R")
+  skip_if_not(file.exists(source_file), "fct_file_operations.R ikke fundet")
+
+  source_lines <- readLines(source_file, warn = FALSE)
+
+  # Find alle linjer med data_updated-emit + navigation_changed-emit
+  data_updated_lines <- grep("emit\\$data_updated", source_lines)
+  nav_changed_lines <- grep("emit\\$navigation_changed", source_lines)
+
+  # Ingen navigation_changed maa fyre INDEN for 5 linjer efter data_updated
+  # (det indikerer double-emit-pattern hvor cascade haandterer navigation)
+  for (du_line in data_updated_lines) {
+    nearby_nav <- nav_changed_lines[
+      nav_changed_lines > du_line & nav_changed_lines <= du_line + 5
+    ]
+    msg <- sprintf(
+      "Linje %d emitter data_updated; linje(r) %s emitter navigation_changed kort efter (double-emit-pattern). Cycle B M2: cascade fyrer navigation via ui_sync_completed.",
+      du_line,
+      paste(nearby_nav, collapse = ", ")
+    )
+    expect(length(nearby_nav) == 0, failure_message = msg)
+  }
+})
+
+test_that("file-load contexts (file_loaded, session_file_loaded, paste_data) er klassificeret korrekt", {
+  # Verificer at classify_update_context routes load-contexts til 'load'-class
+  # som handle_load_context derefter trigger autodetect_started -> cascade
+  require_internal("classify_update_context", mode = "function")
+
+  load_contexts <- c("file_loaded", "session_file_loaded", "paste_data")
+  for (ctx in load_contexts) {
+    result <- classify_update_context(list(context = ctx))
+    expect_equal(
+      result, "load",
+      info = sprintf(
+        "Context '%s' burde route til 'load'-class. Hvis nej, cascade kan miste navigation_changed.",
+        ctx
+      )
+    )
+  }
+})


### PR DESCRIPTION
## Summary

Cycle B reconciled (Codex 2026-05-09 verificeret): `fct_file_operations.R` emitter baade `data_updated('file_loaded')` OG direct `emit$navigation_changed()` umiddelbart efter. **Codex bekraeftede dette er reel UX-bug, ej counter-nit:** pre-autodetect navigation-invalidering → render med stale/incomplete columns → derefter andet render efter UI-sync. Bruger ser glitch.

## Cascade-flow (korrekt)

```
data_updated('file_loaded')
  → handle_load_context
    → emit$auto_detection_started
      → autodetect_engine
        → emit$auto_detection_completed
          → emit$ui_sync_needed (debounced)
            → sync_ui_with_columns_unified
              → emit$ui_sync_completed
                → emit$navigation_changed   ← navigation fyrer her
```

Direct emit i fct_file_operations forarsager FORLØBIG navigation FØR autodetect, hvilket trigger plot-render med tomme/forkerte mappings.

## Aendringer

- `R/fct_file_operations.R:364, 376, 493, 632`: slet 4× direct `emit$navigation_changed()`
- `tests/testthat/test-navigation-no-double-emit.R`: regression-test scanner source for double-emit-pattern
- `dev/audit-output/test-classification.yaml`: manifest-entry

## Test plan

- [x] Ny regression-test: 8 PASS (scanner fct_file_operations.R + verificerer load-context-classification)
- [x] Pre-push gate bestaaet
- [ ] Manual test: upload Excel-fil, verificer ingen visuelle glitches under load
- [ ] Manual test: paste data fra clipboard, verificer ingen visuelle glitches