### PR TITLE
chore(events): fjern column_choices_changed orphan emit (cycle B M1)

### DIFF
--- a/R/state_management.R
+++ b/R/state_management.R
@@ -74,7 +74,8 @@ create_app_state <- function() {
     # UI SYNKRONISERING (CONSOLIDATED) -------------------------------------
     ui_sync_requested = 0L, # Consolidates: ui_sync_needed + ui_update_needed + form_update_needed
     ui_sync_completed = 0L, # Remains: completion tracking
-    column_choices_changed = 0L,
+    # Cycle B M1 (Codex 2026-05-09): column_choices_changed slettet — emit'et men
+    # aldrig observeret. Verificeret med rg-grep + Codex peer-review.
     navigation_changed = 0L,
 
     # SESSION LIVSCYKLUS ---------------------------------------------------
@@ -560,10 +561,11 @@ create_emit_api <- function(app_state) {
         app_state$events$ui_sync_requested <- app_state$events$ui_sync_requested + 1L
       })
     },
+    # Cycle B M1 (Codex 2026-05-09): column_choices_changed-emit slettet —
+    # emit'et men aldrig observeret. Bevarer NULL-stub for backward-compat
+    # i kald-sites; fjern alle kald i fremtidig PR.
     column_choices_changed = function() {
-      shiny::isolate({
-        app_state$events$column_choices_changed <- app_state$events$column_choices_changed + 1L
-      })
+      invisible(NULL)
     },
     form_reset_needed = function() {
       shiny::isolate({

--- a/R/utils_server_column_input.R
+++ b/R/utils_server_column_input.R
@@ -113,21 +113,10 @@ handle_column_input <- function(col_name, new_value, app_state, emit) {
   # ============================================================================
   # STEP 4: EVENT EMISSION (BATCHED)
   # ============================================================================
-
-  if (exists("column_choices_changed", envir = as.environment(emit))) {
-    if (exists("schedule_batched_update", mode = "function")) {
-      schedule_batched_update(
-        update_fn = function() {
-          emit$column_choices_changed()
-        },
-        delay_ms = 50,
-        app_state = app_state,
-        batch_key = "column_choices"
-      )
-    } else {
-      emit$column_choices_changed()
-    }
-  }
+  # Cycle B M1 (Codex 2026-05-09): column_choices_changed-emit fjernet helt
+  # — det blev emit'et men aldrig observeret. Plot-update kommer via direkte
+  # input$<column>-observers + spc_inputs-debounce-cascade i mod_spc_chart.
+  # Tidligere batched-emit var dead code med 50ms timer-overhead per kald.
 
   invisible(NULL)
 }

--- a/tests/testthat/test-column-observer-consolidation.R
+++ b/tests/testthat/test-column-observer-consolidation.R
@@ -53,8 +53,11 @@ test_that("normalize_column_input handles vector with multiple elements", {
 # UNIT TESTS: handle_column_input()
 # ============================================================================
 
-test_that("handle_column_input emits event for user input", {
-  # Setup mock app_state
+test_that("handle_column_input updates state + cache for user input", {
+  # Cycle B M1 (Codex 2026-05-09): column_choices_changed-emit fjernet helt
+  # da det aldrig blev observeret. Test verificerer nu kun state + cache update;
+  # plot-update kommer via direkte input$<column>-observer + spc_inputs-cascade,
+  # ej via dette emit.
   app_state <- new.env()
   app_state$ui <- list(
     performance_metrics = reactiveValues(tokens_consumed = 0L)
@@ -62,14 +65,8 @@ test_that("handle_column_input emits event for user input", {
   app_state$columns <- reactiveValues(mappings = reactiveValues())
   app_state$ui_cache <- list()
 
-  # NO programmatic token (simulates user input)
-
-  # Mock emit API
+  # Mock emit API (handler skal ej fejle uden column_choices_changed-key)
   emit <- new.env()
-  emit_called <- FALSE
-  emit$column_choices_changed <- function() {
-    emit_called <<- TRUE
-  }
 
   # Call handler
   isolate(handle_column_input("x_column", "dato", app_state, emit))
@@ -79,17 +76,6 @@ test_that("handle_column_input emits event for user input", {
 
   # Verify cache updated
   expect_identical(app_state$ui_cache$x_column_input, "dato")
-
-  # Verify event emission for user input.
-  # NOTE: handle_column_input bruger schedule_batched_update() når den
-  # er tilgængelig — batched emission sker 50ms senere, ikke synkront.
-  # Derfor testes kun at emit-callbacket er stillet i kø (ikke kaldt).
-  # Direct emission verificeres i integration tests.
-  skip_if(
-    exists("schedule_batched_update", mode = "function"),
-    "Event emission er batched via schedule_batched_update (50ms delay) — kan ikke verificeres synkront i unit test"
-  )
-  expect_true(emit_called)
 })
 
 test_that("handle_column_input normalizes input value", {


### PR DESCRIPTION
## Summary

Cycle B M1 cleanup: `column_choices_changed` emit'es i utils_server_column_input.R men aldrig observeres. Verificeret af baade Cycle A perf-review OG Cycle B Codex peer-review.

Plot-update kommer faktisk via direkte `input$<column>`-observers + spc_inputs-debounce-cascade i mod_spc_chart, ej via dette event. 50ms batched-update-timer var dead code.

## Aendringer

- `R/state_management.R`: NULL-stub paa emit-API (backward-compat) + kommentar paa events-init
- `R/utils_server_column_input.R`: fjern batched-update-call helt

## Tests

- 133 PASS i event-context + column-input regression-suite

## Cycle B M8 noting (DISMISSED)

Test_data_loaded → load-classifier blev anset som problem af subagent. Empirisk verificeret: regex 'load|upload|file|paste|new' matcher 'test_data_loaded' korrekt. Subagent missede.