### PR TITLE
fix(hooks): DCF-parse manifest-sync gate (cycle F H1)

### DIFF
--- a/dev/git-hooks/pre-commit
+++ b/dev/git-hooks/pre-commit
@@ -65,13 +65,46 @@ if [ "${SKIP_NONASCII:-0}" != "1" ]; then
 fi
 
 # --- Step 0.6: Manifest-sync warning (fix-patterns: manifest-stale) ---
-# Hvis DESCRIPTION staged uden manifest.json: warn (ikke blokerende — pre-push
-# blokerer hvis stadig stale). Bypass automatisk hvis manifest.json staged.
+# Hvis DESCRIPTION staged med pakke-aendringer uden manifest.json: warn
+# (ikke blokerende — pre-push blokerer hvis stadig stale).
+#
+# Cycle F H1 (2026-05-09): Tidligere brugte vi grep mod stanza-overskrifter
+# som missede tilfoejelser under eksisterende stanza. Nu DCF-parse mod HEAD.
 desc_staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^DESCRIPTION$' || true)
 manifest_staged=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^manifest\.json$' || true)
 if [ -n "$desc_staged" ] && [ -z "$manifest_staged" ]; then
-  imports_changed=$(git diff --cached -- DESCRIPTION | grep -E '^[+-]\s*(Imports|Remotes|Depends):' || true)
-  if [ -n "$imports_changed" ]; then
+  TMP_HEAD_DESC=$(mktemp -t bispc_desc_head.XXXXXX)
+  TMP_STAGED_DESC=$(mktemp -t bispc_desc_staged.XXXXXX)
+  # shellcheck disable=SC2064
+  trap "rm -f '$TMP_HEAD_DESC' '$TMP_STAGED_DESC'" EXIT INT TERM
+
+  git show HEAD:DESCRIPTION > "$TMP_HEAD_DESC" 2>/dev/null || true
+  git show :DESCRIPTION > "$TMP_STAGED_DESC" 2>/dev/null || true
+
+  pkg_changed=$(Rscript - "$TMP_HEAD_DESC" "$TMP_STAGED_DESC" <<'REOF' 2>/dev/null
+args <- commandArgs(TRUE)
+normalize_pkg_fields <- function(path) {
+  if (!file.exists(path) || file.info(path)$size == 0) return("")
+  d <- tryCatch(
+    read.dcf(path, fields = c("Imports", "Remotes", "Depends")),
+    error = function(e) NULL
+  )
+  if (is.null(d) || nrow(d) == 0) return("")
+  vals <- as.character(d[1, ])
+  vals[is.na(vals)] <- ""
+  norm <- vapply(vals, function(v) {
+    if (!nzchar(v)) return("")
+    items <- trimws(strsplit(v, ",")[[1]])
+    items <- items[nzchar(items)]
+    paste(sort(items), collapse = ",")
+  }, character(1))
+  paste(norm, collapse = "||")
+}
+cat(if (identical(normalize_pkg_fields(args[1]), normalize_pkg_fields(args[2]))) "0" else "1")
+REOF
+)
+
+  if [ "$pkg_changed" = "1" ]; then
     echo ""
     echo "⚠ DESCRIPTION:Imports/Remotes/Depends aendret men manifest.json IKKE staged"
     echo "  Connect Cloud-deploy vil fejle hvis manifest ude af sync."

--- a/dev/git-hooks/pre-push
+++ b/dev/git-hooks/pre-push
@@ -131,14 +131,54 @@ echo "✓ Swallowed error check OK"
 # Hvis DESCRIPTION:Imports/Remotes/Depends ændret siden remote uden tilsvarende
 # manifest.json-update -> Connect Cloud deploy fejler.
 # Bypass: SKIP_MANIFEST_SYNC=1 git push
+#
+# Cycle F H1 (2026-05-09): Tidligere brugte vi grep mod stanza-overskrifter
+# (`^[+-]\s*(Imports|Remotes|Depends):`) som KUN fangede ændringer på selve
+# header-linjen. Tilføjelse af nyt pakke-navn under eksisterende stanza
+# matched IKKE -> primær use-case (ny dependency uden manifest-regen) gik
+# silent. Nu: DCF-parse + normalisér pakke-listen, sammenlign REMOTE_BASE
+# vs HEAD. Robust mod whitespace, kommentar-tilføjelser, rækkefølge.
 echo ""
 echo "[1c/4] Validerer rsconnect manifest.json sync mod DESCRIPTION ..."
 if [ "${SKIP_MANIFEST_SYNC:-0}" != "1" ]; then
   REMOTE_BASE=$(git rev-parse "@{u}" 2>/dev/null || git rev-parse "origin/develop" 2>/dev/null || echo "")
   if [ -n "$REMOTE_BASE" ]; then
-    DESC_DIFF=$(git diff "$REMOTE_BASE"...HEAD -- DESCRIPTION | grep -E '^[+-]\s*(Imports|Remotes|Depends):' || true)
+    TMP_BASE_DESC=$(mktemp -t bispc_desc_base.XXXXXX)
+    TMP_HEAD_DESC=$(mktemp -t bispc_desc_head.XXXXXX)
+    # shellcheck disable=SC2064
+    trap "rm -f '$TMP_BASE_DESC' '$TMP_HEAD_DESC'" EXIT INT TERM
+
+    git show "$REMOTE_BASE:DESCRIPTION" > "$TMP_BASE_DESC" 2>/dev/null || true
+    cp DESCRIPTION "$TMP_HEAD_DESC" 2>/dev/null || true
+
+    DESC_PKG_CHANGED=$(Rscript - "$TMP_BASE_DESC" "$TMP_HEAD_DESC" <<'REOF' 2>/dev/null
+args <- commandArgs(TRUE)
+normalize_pkg_fields <- function(path) {
+  if (!file.exists(path) || file.info(path)$size == 0) return("")
+  d <- tryCatch(
+    read.dcf(path, fields = c("Imports", "Remotes", "Depends")),
+    error = function(e) NULL
+  )
+  if (is.null(d) || nrow(d) == 0) return("")
+  vals <- as.character(d[1, ])
+  vals[is.na(vals)] <- ""
+  norm <- vapply(vals, function(v) {
+    if (!nzchar(v)) return("")
+    items <- trimws(strsplit(v, ",")[[1]])
+    items <- items[nzchar(items)]
+    paste(sort(items), collapse = ",")
+  }, character(1))
+  paste(norm, collapse = "||")
+}
+base_norm <- normalize_pkg_fields(args[1])
+head_norm <- normalize_pkg_fields(args[2])
+cat(if (identical(base_norm, head_norm)) "0" else "1")
+REOF
+)
+
     MANIFEST_DIFF=$(git diff "$REMOTE_BASE"...HEAD -- manifest.json || true)
-    if [ -n "$DESC_DIFF" ] && [ -z "$MANIFEST_DIFF" ]; then
+
+    if [ "$DESC_PKG_CHANGED" = "1" ] && [ -z "$MANIFEST_DIFF" ]; then
       echo ""
       echo "✗ DESCRIPTION:Imports/Remotes/Depends ændret men manifest.json uændret"
       echo "  Connect Cloud-deploy vil fejle (recurrence=4 i fix-patterns.jsonl)"


### PR DESCRIPTION
## Summary

Cycle F finding **H1 (HIGH)** — confirmed by Codex peer-review.

Pre-push:139 + pre-commit:73 brugte grep mod stanza-overskrifter (\`^[+-]\s*(Imports|Remotes|Depends):\`) som KUN matched ændringer på selve header-linjen. Tilføjelse af nyt pakke-navn under eksisterende stanza matched IKKE → primær use-case (ny dependency uden manifest-regen) gik silent.

**Recurrence=4 i \`fix-patterns.jsonl\`** for "manifest-stale Connect Cloud-deploy fejler" — gaten dækkede ikke faktisk recurrence.

## Fix

Erstat med Rscript-DCF-parse der:
- Læser DESCRIPTION via \`read.dcf()\` med \`fields = c("Imports", "Remotes", "Depends")\`
- Normaliserer (split on comma, trim, sort, rejoin)
- Sammenligner REMOTE_BASE vs HEAD (pre-push, blokkerende) eller HEAD vs staged (pre-commit, warning)

Robust mod whitespace, kommentar-tilføjelser, rækkefølge-ændringer. Genererer ikke falske positives på Author/Description-tekst-ændringer (Codex's bekymring om broad git-diff).

## Test plan

- [x] Bash syntax: \`bash -n\` OK på begge hooks
- [x] Manuel test: ny pakke under eksisterende stanza → \`changed=1\` (gammel grep: 0)
- [x] Manuel test: Author/Description-only diff → \`changed=0\` (no false positive)
- [x] Pre-push self-test: branch push grøn (63s, fast mode)
- [ ] Verificér i CI at gaten ikke triggerer false-positive på næste develop-merge

## Refs

- \`docs/reviews/03-observability-gates.md\` H1
- Codex adversarial review: confirmed (recommend DCF-parse over broad git-diff)