### PR TITLE
feat(lintr): source-tree-read detector + fix M3 false-positive (cycle F H2+M3)

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,14 +1,26 @@
 linters: local({
-    # Source custom seed_rng_linter — §3.2 af
-    # harden-test-suite-regression-gate openspec change.
-    linter_path <- file.path(getwd(), "dev", "lintr_seed_rng.R")
+    # Source custom linters
     custom <- list()
-    if (file.exists(linter_path)) {
+    # seed_rng_linter - section 3.2 af harden-test-suite-regression-gate
+    seed_rng_path <- file.path(getwd(), "dev", "lintr_seed_rng.R")
+    if (file.exists(seed_rng_path)) {
       tryCatch({
-        sys.source(linter_path, envir = environment())
+        sys.source(seed_rng_path, envir = environment())
         custom$seed_rng_linter <- seed_rng_linter()
       }, error = function(e) {
         message("Kunne ikke source dev/lintr_seed_rng.R: ", e$message)
+      })
+    }
+    # no_test_source_read_linter - Cycle F H2 + M3 (Codex 2026-05-09)
+    # Forhindrer recurrence af readLines(test_path(...))-pattern der
+    # virker i devtools::test() men fejler/skipper i R CMD check.
+    no_test_read_path <- file.path(getwd(), "dev", "lintr_no_test_source_read.R")
+    if (file.exists(no_test_read_path)) {
+      tryCatch({
+        sys.source(no_test_read_path, envir = environment())
+        custom$no_test_source_read_linter <- no_test_source_read_linter()
+      }, error = function(e) {
+        message("Kunne ikke source dev/lintr_no_test_source_read.R: ", e$message)
       })
     }
     do.call(lintr::linters_with_defaults, c(

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1478,7 +1478,15 @@ files:
   reviewed: yes
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
-  rationale: Cycle B M2 (Codex 2026-05-09) regression-test mod double-emit navigation_changed fra file-load-paths.
+  rationale: Cycle B M2 + Cycle F M3 (Codex 2026-05-09) regression-test mod double-emit navigation_changed fra file-load-paths. Cycle F konverterede fra readLines(test_path()) til body()-introspection (silent-skip-bug i R CMD check).
+- file: test-lintr-no-test-source-read.R
+  audit_category: post-audit
+  type: policy-guard
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Cycle F H2 (Codex 2026-05-09) unit-test af custom lintr-regel der detekterer source-tree-reads i tests. Forhindrer recurrence af readLines(test_path("..", ...))-pattern.
 - file: test-flush-session-save-on-exit.R
   audit_category: post-audit
   type: unit

--- a/dev/lintr_no_test_source_read.R
+++ b/dev/lintr_no_test_source_read.R
@@ -1,0 +1,131 @@
+# ==============================================================================
+# lintr_no_test_source_read.R
+# ==============================================================================
+# Cycle F H2 + M3 (Codex peer-review 2026-05-09).
+#
+# Custom lintr-regel: no_test_source_read_linter()
+#
+# Flagger source-tree-reads i test-filer der virker i devtools::test() men
+# fejler (eller silent-skipper) i R CMD check fordi pakken installeres uden
+# plain .R-filer i source-tree-layout.
+#
+# Pattern A (direkte): readLines(test_path("..", "..", "R", "foo.R"))
+# Pattern B (variable): src <- test_path("..", "..", "R", ...); readLines(src)
+# Pattern C (hardcoded): readLines("../../R/foo.R")
+#
+# Korrekt alternativ: paste(deparse(body(funktion)), collapse = "\n")
+# Virker BAADE i devtools::test og R CMD check fordi den opererer paa
+# loaded function-bodies, ej paa filsystem.
+#
+# Heuristik: flag hvis source_expression indeholder BAADE
+#   - et test_path()-kald med ".." i argumenterne (= escape-fra-tests/), ELLER
+#     en STR_CONST der matcher "../R/" eller "../../R/", OG
+#   - et read*-kald (readLines, readRDS, read.csv, scan, etc)
+#
+# Trade-offs:
+#   + Fanger pattern A, B, C uden compleks variable-flow-tracking
+#   + Faa false positives (test_path("fixtures", ...) ej flagged)
+#   - Edge case: test_path("..", ...) brugt til non-read-formaal i samme
+#     test_that-blok som en separat readLines() vil give false-positive.
+#     Workaround: # nolint: no_test_source_read_linter
+#
+# Historik: PR #669, #675 fixede 2 instanser af pattern A. M3 (Codex 2026-05-09)
+# afsloerede 3. instans (test-navigation-no-double-emit.R) som brugte pattern B
+# under skip_if_not-cover -> silent-skip i R CMD check, false confidence i CI.
+#
+# Usage i .lintr:
+#   linter_path <- file.path(getwd(), "dev", "lintr_no_test_source_read.R")
+#   sys.source(linter_path, envir = environment())
+#   custom$no_test_source_read_linter <- no_test_source_read_linter()
+# ==============================================================================
+
+#' Linter: detekter source-tree-reads i test-filer
+#'
+#' @return En `lintr::Linter`-funktion.
+#' @noRd
+no_test_source_read_linter <- function() {
+  read_functions <- c("readLines", "readRDS", "read.csv", "read.dcf", "scan",
+                       "read.table", "read.delim")
+  path_functions <- c("test_path")  # `testthat::test_path` matcher ogsaa via .text
+
+  lintr::Linter(function(source_expression) {
+    if (is.null(source_expression$parsed_content)) {
+      return(list())
+    }
+
+    pd <- source_expression$parsed_content
+    lints <- list()
+
+    calls <- pd[pd$token == "SYMBOL_FUNCTION_CALL", , drop = FALSE]
+    if (nrow(calls) == 0) {
+      return(list())
+    }
+
+    # Find ALLE read*-kald
+    read_calls <- calls[calls$text %in% read_functions, , drop = FALSE]
+    if (nrow(read_calls) == 0) {
+      return(list())
+    }
+
+    # Tjek om source_expression indeholder source-tree-escape-markers:
+    #   1) test_path() med ".." som STR_CONST-arg
+    #   2) STR_CONST der matcher hardcoded "../R/" eller "../../R/"
+    test_path_calls <- calls[calls$text %in% path_functions, , drop = FALSE]
+    has_escape_test_path <- FALSE
+    if (nrow(test_path_calls) > 0) {
+      str_consts <- pd[pd$token == "STR_CONST", , drop = FALSE]
+      # Hvis ANY STR_CONST = '".."' → escape-markedinger
+      has_escape_test_path <- any(str_consts$text == '".."') ||
+                              any(str_consts$text == "'..'")
+    }
+
+    str_consts <- pd[pd$token == "STR_CONST", , drop = FALSE]
+    has_hardcoded_path <- FALSE
+    if (nrow(str_consts) > 0) {
+      # Match "../R/..." eller "../../R/..." i string-literals
+      has_hardcoded_path <- any(grepl("\\.\\./[^\"']*R/|\\.\\./\\.\\./R/",
+                                       str_consts$text))
+    }
+
+    if (!has_escape_test_path && !has_hardcoded_path) {
+      return(list())
+    }
+
+    # Flag hvert read*-kald i denne expression
+    for (i in seq_len(nrow(read_calls))) {
+      read_line <- read_calls$line1[i]
+      read_col <- read_calls$col1[i]
+      read_func <- read_calls$text[i]
+
+      line_text <- source_expression$lines[as.character(read_line)]
+      if (is.na(line_text) || is.null(line_text)) line_text <- ""
+
+      detail <- if (has_escape_test_path) {
+        "test_path(\"..\", ...) escape-pattern fundet i samme expression"
+      } else {
+        "hardcoded ../R/-path fundet i samme expression"
+      }
+
+      msg <- sprintf(
+        paste0(
+          "'%s()' kombineret med source-tree-escape-pattern (%s). ",
+          "Virker i devtools::test() men fejler/skipper i R CMD check ",
+          "fordi pakken installeres uden plain .R-filer. Brug i stedet: ",
+          "paste(deparse(body(funktion)), collapse = \"\\n\")"
+        ),
+        read_func, detail
+      )
+
+      lints[[length(lints) + 1L]] <- lintr::Lint(
+        filename = source_expression$filename,
+        line_number = read_line,
+        column_number = read_col,
+        type = "warning",
+        message = msg,
+        line = as.character(line_text)
+      )
+    }
+
+    lints
+  })
+}

--- a/tests/testthat/test-lintr-no-test-source-read.R
+++ b/tests/testthat/test-lintr-no-test-source-read.R
@@ -1,0 +1,85 @@
+# test-lintr-no-test-source-read.R
+# Cycle F H2 + M3 (Codex 2026-05-09): unit-test af custom lintr-regel
+# der detekterer source-tree-reads i test-filer.
+#
+# Forhindrer recurrence af readLines(test_path("..", "..", "R", ...))-pattern
+# der virker i devtools::test() men fejler/skipper i R CMD check.
+
+linter_path <- testthat::test_path("..", "..", "dev", "lintr_no_test_source_read.R")
+
+# Kun koer hvis linter-fil eksisterer (skipper i installeret pakke)
+skip_if_no_linter <- function() {
+  testthat::skip_if_not(file.exists(linter_path), "linter-fil ej fundet (R CMD check installeret-tree)")
+}
+
+run_linter <- function(code) {
+  skip_if_no_linter()
+  sys.source(linter_path, envir = environment())
+  tmp <- tempfile(fileext = ".R")
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines(code, tmp)
+  lintr::lint(tmp, linters = list(no_test_source_read_linter()))
+}
+
+test_that("Pattern A: direct readLines(test_path()) flagged", {
+  lints <- run_linter('
+test_that("a", {
+  source_lines <- readLines(test_path("..", "..", "R", "foo.R"))
+})')
+  expect_gt(length(lints), 0)
+})
+
+test_that("Pattern B: variable-assigned readLines(var) flagged when var = test_path('..', ...)", {
+  lints <- run_linter('
+test_that("b", {
+  src <- testthat::test_path("..", "..", "R", "foo.R")
+  src_lines <- readLines(src)
+})')
+  expect_gt(length(lints), 0)
+})
+
+test_that("Pattern C: hardcoded path readLines('../../R/foo.R') flagged", {
+  lints <- run_linter('
+test_that("c", {
+  txt <- readLines("../../R/foo.R")
+})')
+  expect_gt(length(lints), 0)
+})
+
+test_that("Negative: body() introspection passes (no lint)", {
+  lints <- run_linter('
+test_that("ok", {
+  body_text <- paste(deparse(body(my_fn)), collapse = "\\n")
+})')
+  expect_length(lints, 0)
+})
+
+test_that("Negative: legitimate test_path('fixtures', ...) passes (no lint)", {
+  lints <- run_linter('
+test_that("fixture", {
+  data <- readLines(test_path("fixtures", "data.csv"))
+})')
+  expect_length(lints, 0)
+})
+
+test_that("Negative: test_path used without read passes (no lint)", {
+  lints <- run_linter('
+test_that("nothing", {
+  src <- testthat::test_path("..", "..", "R", "foo.R")
+  expect_true(file.exists(src))
+})')
+  expect_length(lints, 0)
+})
+
+test_that("Multiple read functions detected: readRDS, scan, read.csv", {
+  for (fn in c("readRDS", "scan", "read.csv", "read.dcf", "read.table")) {
+    lints <- run_linter(sprintf('
+test_that("multi", {
+  src <- test_path("..", "..", "R", "foo.R")
+  data <- %s(src)
+})', fn))
+    expect_gt(length(lints), 0,
+      label = sprintf("Function %s should be detected", fn)
+    )
+  }
+})

--- a/tests/testthat/test-lintr-no-test-source-read.R
+++ b/tests/testthat/test-lintr-no-test-source-read.R
@@ -7,8 +7,11 @@
 
 linter_path <- testthat::test_path("..", "..", "dev", "lintr_no_test_source_read.R")
 
-# Kun koer hvis linter-fil eksisterer (skipper i installeret pakke)
+# Skip-betingelser:
+#  - linter-fil mangler (R CMD check installeret-tree har ej dev/-mappen)
+#  - lintr-pakken ikke installeret (lintr er kun dev-dep, ej i CI-Imports)
 skip_if_no_linter <- function() {
+  testthat::skip_if_not_installed("lintr")
   testthat::skip_if_not(file.exists(linter_path), "linter-fil ej fundet (R CMD check installeret-tree)")
 }
 

--- a/tests/testthat/test-navigation-no-double-emit.R
+++ b/tests/testthat/test-navigation-no-double-emit.R
@@ -9,30 +9,70 @@
 #
 # Post-fix: kun data_updated emit; cascade fyrer navigation_changed via
 # auto_detection_completed -> ui_sync_completed.
+#
+# Cycle F M3 (Codex 2026-05-09): Konverteret fra readLines(test_path(...))
+# til body()-introspection. Tidligere version brugte source-tree-read med
+# skip_if_not-cover -> silent-skip i R CMD check, false confidence i CI.
+# body()-introspection virker BAADE i devtools::test og R CMD check.
 
-test_that("fct_file_operations.R indeholder ikke direct emit$navigation_changed efter data_updated", {
-  source_file <- testthat::test_path("..", "..", "R", "fct_file_operations.R")
-  skip_if_not(file.exists(source_file), "fct_file_operations.R ikke fundet")
+# Hjaelper: serialise function-body til string for grep-baseret pattern-check
+body_text <- function(fn) {
+  paste(deparse(body(fn)), collapse = "\n")
+}
 
-  source_lines <- readLines(source_file, warn = FALSE)
-
-  # Find alle linjer med data_updated-emit + navigation_changed-emit
-  data_updated_lines <- grep("emit\\$data_updated", source_lines)
-  nav_changed_lines <- grep("emit\\$navigation_changed", source_lines)
-
-  # Ingen navigation_changed maa fyre INDEN for 5 linjer efter data_updated
-  # (det indikerer double-emit-pattern hvor cascade haandterer navigation)
-  for (du_line in data_updated_lines) {
-    nearby_nav <- nav_changed_lines[
-      nav_changed_lines > du_line & nav_changed_lines <= du_line + 5
-    ]
-    msg <- sprintf(
-      "Linje %d emitter data_updated; linje(r) %s emitter navigation_changed kort efter (double-emit-pattern). Cycle B M2: cascade fyrer navigation via ui_sync_completed.",
-      du_line,
-      paste(nearby_nav, collapse = ", ")
+# Fanger kontekstuel double-emit: navigation_changed-kald i kort afstand
+# (max ~200 tegn) efter et data_updated-kald i samme function-body.
+# Emitter altid expect_true paa fundet data_updated-pattern saa testthat
+# ej rapporterer "empty test" naar nav_pos er tom.
+check_no_navigation_after_data_updated <- function(fn_text, fn_name) {
+  data_pos <- gregexpr("emit\\$data_updated", fn_text)[[1]]
+  nav_pos <- gregexpr("emit\\$navigation_changed", fn_text)[[1]]
+  expect_true(
+    data_pos[1] != -1,
+    info = sprintf("Function '%s' forventet at indeholde emit$data_updated", fn_name)
+  )
+  if (nav_pos[1] == -1) {
+    expect_true(TRUE,
+      info = sprintf("Function '%s': ingen navigation_changed-emits (OK)", fn_name)
     )
-    expect(length(nearby_nav) == 0, failure_message = msg)
+    return(invisible(TRUE))
   }
+  for (du_pos in data_pos) {
+    nearby <- nav_pos[nav_pos > du_pos & nav_pos < du_pos + 200]
+    expect_length(
+      nearby, 0,
+      info = sprintf(
+        paste(
+          "Function '%s' emitter data_updated paa pos %d med nearby",
+          "navigation_changed paa pos(er) %s (double-emit-pattern).",
+          "Cycle B M2: cascade fyrer navigation via ui_sync_completed."
+        ),
+        fn_name, du_pos, paste(nearby, collapse = ", ")
+      )
+    )
+  }
+  invisible(TRUE)
+}
+
+test_that("handle_excel_upload har ikke direct emit$navigation_changed efter data_updated", {
+  require_internal("handle_excel_upload", mode = "function")
+  check_no_navigation_after_data_updated(
+    body_text(handle_excel_upload), "handle_excel_upload"
+  )
+})
+
+test_that("handle_csv_upload har ikke direct emit$navigation_changed efter data_updated", {
+  require_internal("handle_csv_upload", mode = "function")
+  check_no_navigation_after_data_updated(
+    body_text(handle_csv_upload), "handle_csv_upload"
+  )
+})
+
+test_that("handle_paste_data har ikke direct emit$navigation_changed efter data_updated", {
+  require_internal("handle_paste_data", mode = "function")
+  check_no_navigation_after_data_updated(
+    body_text(handle_paste_data), "handle_paste_data"
+  )
 })
 
 test_that("file-load contexts (file_loaded, session_file_loaded, paste_data) er klassificeret korrekt", {
@@ -46,7 +86,10 @@ test_that("file-load contexts (file_loaded, session_file_loaded, paste_data) er 
     expect_equal(
       result, "load",
       info = sprintf(
-        "Context '%s' burde route til 'load'-class. Hvis nej, cascade kan miste navigation_changed.",
+        paste(
+          "Context '%s' burde route til 'load'-class.",
+          "Hvis nej, cascade kan miste navigation_changed."
+        ),
         ctx
       )
     )


### PR DESCRIPTION
## Summary

Cycle F findings **H2 (MEDIUM)** + **M3 (MEDIUM, NYT — Codex empirisk fund)** — confirmed by Codex peer-review.

### H2 — Custom lintr-rule for source-tree-reads

Tilføjer `no_test_source_read_linter()` der detekterer 3 patterns:
- **Pattern A (direct):** `readLines(test_path("..", "..", "R", "foo.R"))`
- **Pattern B (variable-assigned):** `src <- testthat::test_path("..", ...); readLines(src)`
- **Pattern C (hardcoded):** `readLines("../../R/foo.R")`

Patterns virker i `devtools::test()` men **fejler/skipper i R CMD check** fordi pakken installeres uden plain `.R`-filer i source-tree-layout. Recurrence dokumenteret 2× i Cycle B (PR #669, #675).

**Codex argumenterede** for lintr (durable) over grep (stopgap). Min initial-snippet med pre-commit-grep ville have misset variable-assigned pattern (M3).

### M3 — Fix existing false-positive test

Codex empirisk grep afsloerede at `test-navigation-no-double-emit.R` (introduceret i Cycle B M2, 2 timer EFTER PR #669 fixede pattern) selv brugte pattern B under `skip_if_not(file.exists(...))`-cover.

**Konsekvens:** Test SKIPPEDE silent i R CMD check men passerede som beskyttelse i pre-merge CI → aktivt false confidence. Værre end ingen test.

**Fix:** Konverteret til `body()`-introspection af `handle_excel_upload` + `handle_csv_upload` + `handle_paste_data`. Virker BAADE i `devtools::test` og R CMD check.

## Tests

- [x] `test-lintr-no-test-source-read.R`: **11 pass, 0 fail** (7 unit-tests covering A/B/C + 3 negative + multi-function-detection)
- [x] `test-navigation-no-double-emit.R`: **9 pass, 0 fail** (tidligere 3 silent-skip i R CMD check)
- [x] Manifest valideret: `Rscript dev/classify_tests.R --validate` — OK
- [x] Pre-push self-test: branch push grøn

## Edge cases (documented in linter source)

False-positive: separat `test_path("..", ...)` brugt til non-read-formaal i samme `test_that`-blok som en separat `readLines()`-kald. Workaround: `# nolint: no_test_source_read_linter`.

## Refs

- `docs/reviews/03-observability-gates.md` H2 + M3
- Codex adversarial review: confirmed (recommend lintr over grep)
- Replaces broken pre-commit-grep approach from initial draft