### PR TITLE
fix(classify_tests): has_value()-baseret merge bevarer manuelle felter (cycle F H3)

### DIFF
--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1487,3 +1487,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
   rationale: Cycle B M7 (Codex 2026-05-09) regression-test for save_session_on_exit final-flush.
+- file: test-classify-tests-merge.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Cycle F H3 (Codex 2026-05-09) unit-tests for has_value()-baseret merge_with_existing der bevarer manuelle felter ogsaa for unreviewed entries. Forhindrer silent overskrivning af rationale/merge_with/handling.

--- a/dev/classify_tests_lib.R
+++ b/dev/classify_tests_lib.R
@@ -142,7 +142,44 @@ read_manifest <- function(path) {
   yaml::read_yaml(path)
 }
 
-#' Merge auto-klassifikation med eksisterende manifest, bevarer reviewed: true.
+#' Tjek om en field har en meningsfuld vaerdi (ikke NULL/empty/NA-only).
+#'
+#' Haandterer:
+#'   - NULL                      -> FALSE
+#'   - length 0                  -> FALSE
+#'   - scalar string, tom        -> FALSE
+#'   - scalar string, non-tom    -> TRUE
+#'   - vector af strings         -> TRUE hvis ENHVER ej-NA + non-tom
+#'   - liste                     -> TRUE hvis ENHVER element er meningsfuld
+#'
+#' Cycle F H3 (Codex 2026-05-09): erstatter naiv `is.character(x) && nzchar(x)`
+#' der fejler paa multi-item character-vektorer (R-fejl: "the condition has
+#' length > 1") og missede YAML-list-felter som merge_with.
+has_value <- function(x) {
+  if (is.null(x)) return(FALSE)
+  if (length(x) == 0) return(FALSE)
+  if (is.character(x)) {
+    return(any(!is.na(x) & nzchar(x)))
+  }
+  if (is.list(x)) {
+    return(any(vapply(x, has_value, logical(1))))
+  }
+  # Numeric/logical: ej-NA = meningsfuld
+  any(!is.na(x))
+}
+
+#' Merge auto-klassifikation med eksisterende manifest.
+#'
+#' Cycle F H3 (Codex 2026-05-09): field-level merge der bevarer manuelt-tilfoejede
+#' felter (rationale, merge_with, reviewer, reviewed_date, handling) uafhaengigt
+#' af `reviewed`-flag. Tidligere implementation overskrev silent alt eksisterende
+#' arbejde paa entries hvor `reviewed != TRUE`.
+#'
+#' Strategy:
+#'   - Eksisterende entry findes ej     -> brug auto
+#'   - Eksisterende entry findes        -> merge field-by-field via has_value()
+#'   - audit_category synces altid fra auto (kommer fra audit-data, ej manual)
+#'   - reviewed-flag bevares fra existing
 merge_with_existing <- function(auto_entries, existing_manifest) {
   if (is.null(existing_manifest) || is.null(existing_manifest$files)) {
     return(auto_entries)
@@ -153,14 +190,25 @@ merge_with_existing <- function(auto_entries, existing_manifest) {
     vapply(existing_manifest$files, `[[`, character(1), "file")
   )
 
+  preservable_fields <- c(
+    "rationale", "merge_with", "reviewer",
+    "reviewed_date", "handling"
+  )
+
   lapply(auto_entries, function(auto) {
     existing <- existing_by_file[[auto$file]]
-    if (is.null(existing) || !isTRUE(existing$reviewed)) {
+    if (is.null(existing)) {
       return(auto)
     }
-    # Bevar existing, men sync audit_category fra auto
-    existing$audit_category <- auto$audit_category
-    existing
+    merged <- auto
+    for (field in preservable_fields) {
+      if (has_value(existing[[field]])) {
+        merged[[field]] <- existing[[field]]
+      }
+    }
+    # reviewed-flag bevares fra existing (kan vaere TRUE eller FALSE/NULL)
+    merged$reviewed <- isTRUE(existing$reviewed)
+    merged
   })
 }
 

--- a/tests/testthat/test-classify-tests-merge.R
+++ b/tests/testthat/test-classify-tests-merge.R
@@ -1,0 +1,146 @@
+# test-classify-tests-merge.R
+# Cycle F H3 (Codex 2026-05-09): regression-tests for has_value()-baseret
+# merge_with_existing() der bevarer manuelle felter ogsaa for unreviewed entries.
+#
+# Pre-fix: classify_tests_lib.R::merge_with_existing() returnerede silent auto
+# entry hvis existing$reviewed != TRUE -> manuel rationale/merge_with/handling
+# blev silent overskrevet ved hver classify_tests-koersel.
+#
+# Post-fix: field-level merge bevarer manuelt-tilfoejede felter uafhaengigt
+# af reviewed-flag.
+
+lib_path <- testthat::test_path("..", "..", "dev", "classify_tests_lib.R")
+
+skip_if_no_lib <- function() {
+  testthat::skip_if_not(file.exists(lib_path), "classify_tests_lib.R ej fundet (R CMD check installeret-tree)")
+}
+
+source_lib <- function() {
+  skip_if_no_lib()
+  sys.source(lib_path, envir = parent.frame())
+}
+
+test_that("has_value handles NULL", {
+  source_lib()
+  expect_false(has_value(NULL))
+})
+
+test_that("has_value handles empty character", {
+  source_lib()
+  expect_false(has_value(character(0)))
+  expect_false(has_value(""))
+})
+
+test_that("has_value handles scalar string", {
+  source_lib()
+  expect_true(has_value("hello"))
+})
+
+test_that("has_value handles multi-item character vector without crashing", {
+  source_lib()
+  # Tidligere implementation: is.character(x) && nzchar(x) errored med
+  # "the condition has length > 1" paa multi-item vektor
+  expect_true(has_value(c("a", "b")))
+})
+
+test_that("has_value handles list", {
+  source_lib()
+  expect_true(has_value(list("a", "b")))
+  expect_false(has_value(list()))
+})
+
+test_that("has_value handles all-NA vector", {
+  source_lib()
+  expect_false(has_value(c(NA_character_, NA_character_)))
+  expect_true(has_value(c(NA_character_, "x")))
+})
+
+test_that("merge_with_existing preserves manual rationale on unreviewed entry", {
+  source_lib()
+  auto <- list(list(
+    file = "test-foo.R", audit_category = "unit",
+    type = "unit", handling = "keep"
+  ))
+  existing <- list(files = list(list(
+    file = "test-foo.R", audit_category = "old-category",
+    type = "unit", handling = "keep",
+    rationale = "manuel rationale",
+    reviewed = FALSE
+  )))
+  result <- merge_with_existing(auto, existing)
+  expect_equal(result[[1]]$rationale, "manuel rationale")
+  # audit_category SKAL synces fra auto (kommer fra audit-data)
+  expect_equal(result[[1]]$audit_category, "unit")
+})
+
+test_that("merge_with_existing preserves multi-item merge_with field", {
+  source_lib()
+  auto <- list(list(
+    file = "test-bar.R", audit_category = "unit",
+    type = "unit", handling = "merge-in-phase-2"
+  ))
+  existing <- list(files = list(list(
+    file = "test-bar.R", audit_category = "merge-target",
+    type = "unit", handling = "merge-in-phase-2",
+    merge_with = c("test-baz.R", "test-qux.R"),
+    rationale = "consolidated",
+    reviewed = FALSE
+  )))
+  result <- merge_with_existing(auto, existing)
+  expect_equal(result[[1]]$merge_with, c("test-baz.R", "test-qux.R"))
+  expect_equal(result[[1]]$rationale, "consolidated")
+})
+
+test_that("merge_with_existing preserves manually changed handling field", {
+  source_lib()
+  auto <- list(list(
+    file = "test-h.R", audit_category = "unit",
+    type = "unit", handling = "fix-in-phase-3"
+  ))
+  existing <- list(files = list(list(
+    file = "test-h.R", audit_category = "old",
+    type = "unit",
+    handling = "keep", # manuelt aendret fra auto-suggestion
+    reviewed = FALSE
+  )))
+  result <- merge_with_existing(auto, existing)
+  expect_equal(result[[1]]$handling, "keep")
+})
+
+test_that("merge_with_existing returns auto unchanged for new entries", {
+  source_lib()
+  auto <- list(list(
+    file = "test-new.R", audit_category = "unit",
+    type = "unit", handling = "keep"
+  ))
+  existing <- list(files = list(list(
+    file = "test-other.R", reviewed = TRUE
+  )))
+  result <- merge_with_existing(auto, existing)
+  expect_equal(result[[1]]$file, "test-new.R")
+})
+
+test_that("merge_with_existing handles NULL existing manifest", {
+  source_lib()
+  auto <- list(list(file = "test.R", audit_category = "unit"))
+  expect_identical(merge_with_existing(auto, NULL), auto)
+  expect_identical(merge_with_existing(auto, list(files = NULL)), auto)
+})
+
+test_that("merge_with_existing preserves reviewer + reviewed_date on unreviewed entry", {
+  source_lib()
+  auto <- list(list(
+    file = "test-r.R", audit_category = "unit",
+    type = "unit", handling = "keep"
+  ))
+  existing <- list(files = list(list(
+    file = "test-r.R", audit_category = "old",
+    type = "unit", handling = "keep",
+    reviewer = "alice",
+    reviewed_date = "2026-04-01",
+    reviewed = FALSE # ej afsluttet review, men reviewer-info eksisterer
+  )))
+  result <- merge_with_existing(auto, existing)
+  expect_equal(result[[1]]$reviewer, "alice")
+  expect_equal(result[[1]]$reviewed_date, "2026-04-01")
+})


### PR DESCRIPTION
## Summary

Cycle F finding **H3 (MEDIUM)** — confirmed by Codex peer-review.

`merge_with_existing()` overskrev silent manuelle felter på unreviewed entries → bruger måtte gentage manuel arbejde efter hver `classify_tests`-kørsel.

**Codex empirisk:** Min initial fix-snippet brugte `is.character(x) && nzchar(x)` som FEJLER på multi-item character-vektorer (R-fejl: "the condition has length > 1") og missede YAML-list-felter som `merge_with`.

## Fix

- `has_value()`-helper håndterer NULL, length-0, scalar string, multi-item vektor, list, all-NA-vektor uden crash
- `merge_with_existing()` field-level merge med `preservable_fields` (rationale, merge_with, reviewer, reviewed_date, handling)
- `audit_category` synces altid fra auto (kommer fra audit-data, ej manual)
- `reviewed`-flag bevares fra existing

## Test plan

- [x] `test-classify-tests-merge.R`: **19 pass, 0 fail** (12 tests covering `has_value()` edge-cases + `merge_with_existing()` regression-tests for multi-item merge_with, manuel rationale på unreviewed, manuel handling-ændring, reviewer/reviewed_date-preservation)
- [x] Manifest valideret: \`Rscript dev/classify_tests.R --validate\` — OK
- [x] Pre-push self-test: branch push grøn

## Refs

- \`docs/reviews/03-observability-gates.md\` H3
- Codex adversarial review: confirmed (recommend has_value() over naive nzchar)