### PR TITLE
feat(ai): explicit ai.enabled-flag enforcement (cycle G H_NEW)

### DIFF
--- a/R/mod_export_ai.R
+++ b/R/mod_export_ai.R
@@ -35,8 +35,21 @@ register_ai_button_state <- function(session, input, output, app_state) {
     app_state$session$bfhllm_available
   }
 
-  # Manage AI button state based on data and API key availability
+  # Manage AI button state based on enabled-flag, data, and API key availability
   shiny::observe({
+    # Cycle G H_NEW (2026-05-09): Check eksplicit ai.enabled flag FOERST.
+    # Hvis disabled i golem-config: skip alle subsequent checks + behold
+    # button hidden. Forhindrer fragile reliance paa CSS-display:none alene.
+    ai_enabled <- isTRUE(get_ai_config()$enabled)
+    if (!ai_enabled) {
+      shinyjs::hide("ai_generate_suggestion")
+      log_debug(
+        .context = "EXPORT_MODULE",
+        message = "AI button hidden: ai.enabled=false in golem-config"
+      )
+      return(invisible(NULL))
+    }
+
     # Check prerequisites
     has_data <- !is.null(app_state$data$current_data) &&
       nrow(app_state$data$current_data) > 0
@@ -47,10 +60,11 @@ register_ai_button_state <- function(session, input, output, app_state) {
     # Validate BFHllm API setup (cached per session)
     api_ready <- get_bfhllm_available()
 
-    # Button enabled only when both prerequisites met
+    # Button enabled only when all prerequisites met
     can_use_ai <- has_spc_data && api_ready
 
-    # Toggle button state
+    # Show + toggle button state
+    shinyjs::show("ai_generate_suggestion")
     shinyjs::toggleState("ai_generate_suggestion", can_use_ai)
 
     # Update tooltip based on state
@@ -145,6 +159,13 @@ register_ai_suggestion_handler <- function(session, input, output, app_state) {
   # ---- Klik-handler -----------------------------------------------------------
   shiny::observeEvent(input$ai_generate_suggestion,
     {
+      # Cycle G H_NEW (2026-05-09): Defense-in-depth \u2014 afvis AI-kald hvis
+      # ai.enabled=false. Selv hvis nogen omgaar UI-hide (devtools-edit /
+      # custom JS), blokerer denne req() server-side egress.
+      shiny::req(isTRUE(get_ai_config()$enabled),
+        cancelOutput = TRUE
+      )
+
       # Valider foruds\u00e6tninger
       shiny::req(
         app_state$data$current_data,

--- a/R/mod_export_ui.R
+++ b/R/mod_export_ui.R
@@ -227,10 +227,12 @@ mod_export_ui <- function(id) {
                 " Auto-genereret analyse \u2014 rediger for at tilpasse"
               ),
             ),
-            # AI Suggestion Button -- midlertidigt skjult, genaktiveres senere
-            # Funktionaliteten er intakt i mod_export_server.R og fct_ai_improvement_suggestions.R
+            # AI Suggestion Button.
+            # Cycle G H_NEW (2026-05-09): Synlighed styres af golem-config
+            # ai.enabled-flag via register_ai_button_state() (mod_export_ai.R).
+            # Production har enabled=false -> shinyjs::hide() ved boot.
+            # Erstatter tidligere fragile CSS display:none-hide.
             shiny::div(
-              style = "display: none;",
               shiny::actionButton(
                 ns("ai_generate_suggestion"),
                 label = "Gener\u00e9r forslag med AI",

--- a/R/utils_bfhllm_integration.R
+++ b/R/utils_bfhllm_integration.R
@@ -42,10 +42,12 @@ get_ai_config <- function() {
 
   # Default values.
   # NB (Cycle A 2026-05-09): model droppes som default — biSPCharts foelger
-  # BFHllm's default (Gemini 3.1 Flash-Lite). Hvis golem-config har eksplicit
-  # `model:`, override'es BFHllm-default.
+  # BFHllm's default (Gemini 3.1 Flash-Lite).
+  # NB (Cycle G H_NEW 2026-05-09): enabled defaults til FALSE (fail-closed).
+  # YAML-profile-overrides aktiverer eksplicit (fx development: enabled=true).
+  # Production har enabled=false (AI bevidst hidden foreloebig).
   defaults <- list(
-    enabled = TRUE,
+    enabled = FALSE,
     provider = "gemini",
     timeout_seconds = 10,
     max_response_chars = 350,
@@ -134,8 +136,10 @@ get_rag_config <- function() {
   )
 
   # Default values
+  # NB (Cycle G H_NEW 2026-05-09): enabled defaults til FALSE (fail-closed).
+  # RAG aktiveres kun naar AI er aktiveret (rag uden ai er meningsloest).
   defaults <- list(
-    enabled = TRUE,
+    enabled = FALSE,
     n_results = 3,
     method = "hybrid"
   )

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1495,6 +1495,14 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
   rationale: Cycle B M7 (Codex 2026-05-09) regression-test for save_session_on_exit final-flush.
+- file: test-ai-feature-flag-enforcement.R
+  audit_category: post-audit
+  type: policy-guard
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-09'
+  rationale: Cycle G H_NEW (Codex 2026-05-09) regression-tests for explicit ai.enabled-flag enforcement i alle AI-egress-paths. Verificerer get_ai_config/get_rag_config fail-closed defaults, button-state hide, handler-guard, production-config kill-switch.
 - file: test-classify-tests-merge.R
   audit_category: post-audit
   type: unit

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -283,10 +283,17 @@ production:
     github_sync_enabled: false    # Opt-in: kræver eksplicit konfiguration
 
   # AI configuration (production settings)
+  # Cycle G H_NEW (2026-05-09): AI-feature er BEVIDST disabled i production
+  # foreloebig. For meget i begyndelsen at give brugere adgang. Re-enable
+  # kraever:
+  #   1. Fix data_consent='explicit' i mod_export_ai.R + utils_async_helpers.R
+  #      (cycle G H0 + H3 - se docs/reviews/04-ai-rag.md)
+  #   2. Implementer shared preflight guard (PHI-check + truncate)
+  #   3. Skift enabled: true her
   ai:
-    enabled: true                   # Enable AI in production
+    enabled: false                  # DISABLED: see Cycle G H_NEW comment above
     rag:
-      enabled: true                 # Enable RAG for grounded responses
+      enabled: false                # DISABLED with AI (RAG kun nyttig naar AI aktiv)
       n_results: 3                  # Balance between context and performance
       method: "hybrid"              # Optimal search accuracy
 

--- a/tests/testthat/test-ai-feature-flag-enforcement.R
+++ b/tests/testthat/test-ai-feature-flag-enforcement.R
@@ -1,0 +1,113 @@
+# test-ai-feature-flag-enforcement.R
+# Cycle G H_NEW (2026-05-09): regression-tests for explicit ai.enabled-flag
+# enforcement i alle AI-egress-paths.
+#
+# Pre-fix: ai.enabled-flag eksisterede i golem-config.yml men checkes IKKE
+# i nogen AI-egress-path (initialize_bfhllm, register_ai_button_state,
+# click handler). Disable opnaaedes via fragile combo: hidden CSS + missing
+# API key + missing data_consent.
+#
+# Post-fix: ai.enabled enforcs i:
+#   - get_ai_config() defaults til FALSE (fail-closed)
+#   - get_rag_config() defaults til FALSE (fail-closed)
+#   - register_ai_button_state(): shinyjs::hide() hvis FALSE
+#   - register_ai_suggestion_handler(): req() guard hvis FALSE
+#   - production-config har enabled=false (eksplicit kill-switch)
+
+test_that("get_ai_config() defaults til enabled=FALSE (fail-closed)", {
+  require_internal("get_ai_config", mode = "function")
+  body_text <- paste(deparse(body(get_ai_config)), collapse = "\n")
+  # Defaults-list skal eksplicit have enabled = FALSE
+  expect_true(
+    grepl("enabled\\s*=\\s*FALSE", body_text),
+    info = "get_ai_config() defaults skal have enabled=FALSE for fail-closed-design"
+  )
+})
+
+test_that("get_rag_config() defaults til enabled=FALSE (fail-closed)", {
+  require_internal("get_rag_config", mode = "function")
+  body_text <- paste(deparse(body(get_rag_config)), collapse = "\n")
+  expect_true(
+    grepl("enabled\\s*=\\s*FALSE", body_text),
+    info = "get_rag_config() defaults skal have enabled=FALSE for fail-closed-design"
+  )
+})
+
+test_that("register_ai_button_state() checker get_ai_config()$enabled", {
+  require_internal("register_ai_button_state", mode = "function")
+  body_text <- paste(deparse(body(register_ai_button_state)), collapse = "\n")
+  expect_true(
+    grepl("get_ai_config\\(\\)\\$enabled", body_text),
+    info = "register_ai_button_state() skal checke get_ai_config()$enabled flag"
+  )
+  # Verificér hide-call ved disabled-state
+  expect_true(
+    grepl("shinyjs::hide\\(.*ai_generate_suggestion", body_text),
+    info = "register_ai_button_state() skal kalde shinyjs::hide() naar ai disabled"
+  )
+})
+
+test_that("register_ai_suggestion_handler() har enabled-guard via req()", {
+  require_internal("register_ai_suggestion_handler", mode = "function")
+  body_text <- paste(deparse(body(register_ai_suggestion_handler)), collapse = "\n")
+  expect_true(
+    grepl("req\\(.*get_ai_config\\(\\)\\$enabled", body_text),
+    info = paste(
+      "register_ai_suggestion_handler() skal bruge req(isTRUE(get_ai_config()$enabled))",
+      "som server-side defense-in-depth mod UI-bypass."
+    )
+  )
+})
+
+test_that("production-config har ai.enabled=false (eksplicit kill-switch)", {
+  config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
+  skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  expect_false(
+    isTRUE(yaml_content$production$ai$enabled),
+    info = paste(
+      "production-profile skal have ai.enabled=false. AI-feature er bevidst",
+      "hidden foreloebig (Cycle G H_NEW). Re-enable kraever H0+H3-fix foerst."
+    )
+  )
+})
+
+test_that("production-config har ai.rag.enabled=false (kobles til ai)", {
+  config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
+  skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  expect_false(
+    isTRUE(yaml_content$production$ai$rag$enabled),
+    info = "RAG uden AI er meningsloest -> RAG skal ogsaa vaere disabled i prod"
+  )
+})
+
+test_that("UI har ej laengere fragile CSS display:none-hide paa AI-knap", {
+  ui_path <- testthat::test_path("..", "..", "R", "mod_export_ui.R")
+  skip_if_not(file.exists(ui_path), "mod_export_ui.R ikke fundet")
+
+  # Lokal source-tree-test fordi UI-funktioner producerer tags-objekter
+  # der ikke nemt kan introspekteres via body() for CSS-attributter.
+  # nolint start: no_test_source_read_linter
+  ui_text <- paste(readLines(ui_path, warn = FALSE), collapse = "\n")
+  # nolint end
+
+  # Find ai_generate_suggestion-button-blokken; verificer ej omgivet af
+  # display:none paa parent-div. Letteste: tjek at strengen
+  # "display: none;" ikke staar tæt paa ai_generate_suggestion-referencen.
+  ai_block_start <- regexpr("ai_generate_suggestion", ui_text)
+  if (ai_block_start[1] > 0) {
+    # Tjek 200 tegn FOER ai_generate_suggestion for display:none-attribut
+    look_back_start <- max(1, ai_block_start[1] - 200)
+    nearby_text <- substring(ui_text, look_back_start, ai_block_start[1])
+    expect_false(
+      grepl('style\\s*=\\s*"display:\\s*none', nearby_text),
+      info = paste(
+        "AI-knap har stadig display:none-CSS-hide. Cycle G H_NEW",
+        "fjernede dette til fordel for ai.enabled-flag-enforcement."
+      )
+    )
+  }
+})


### PR DESCRIPTION
## Summary

Cycle G **H_NEW (MEDIUM, NYT)** — confirmed by Codex peer-review + bruger-kontekst.

**Bruger-kontekst (2026-05-09):** AI-feature er BEVIDST disabled foreløbig. Tidligere disable opnåedes via fragile combo:
1. `R/mod_export_ui.R style="display: none;"` (CSS-hide)
2. Missing `GEMINI_API_KEY` i prod (button auto-disabled)
3. Missing `data_consent="explicit"` i `bfh_generate_analysis`-call (de-facto kill-switch via crash; cycle G H0)

**Codex empirisk:** `ai_config$enabled` checkes IKKE i nogen AI-egress-path. Min original 2-linje default-fix ville give false confidence.

## Fix

Make AI-disable **eksplicit** via golem-config-flag med defense-in-depth-enforcement i alle paths:

1. **`inst/golem-config.yml` production:** `ai.enabled: false` + `ai.rag.enabled: false` med kommentar der dokumenterer re-enable-prerequisites.

2. **`R/utils_bfhllm_integration.R`:** `get_ai_config` + `get_rag_config` defaults skifter til `enabled = FALSE` (fail-closed). YAML-overrides aktiverer eksplicit.

3. **`R/mod_export_ai.R register_ai_button_state()`:** Tjekker `get_ai_config()$enabled` FØRST. Hvis FALSE: `shinyjs::hide()` + skip subsequent probes.

4. **`R/mod_export_ai.R` click handler:** `req(isTRUE(get_ai_config()$enabled), cancelOutput=TRUE)` som server-side defense-in-depth mod UI-bypass.

5. **`R/mod_export_ui.R`:** Fjern fragile `style="display: none;"` wrapper.

## Re-enable AI-feature kræver (FØR `ai.enabled` flips til true):

- **Cycle G H0:** Tilføj `data_consent="explicit"` i begge `bfh_generate_analysis`-call-sites
- **Cycle G H3:** Implementer shared preflight guard (PHI + truncate)
- Evt. **Cycle G H2:** Rate_limit-adapter (`max_requests_per_minute` → `rpm`)

## Test plan

- [x] `test-ai-feature-flag-enforcement.R`: **8 pass, 0 fail** (fail-closed defaults via `body()`-introspection, button-state-hide, handler-guard, prod-config kill-switch)
- [x] `test-bfhllm-config-injection.R` regression: **13 pass, 0 fail, 1 skip** (no regression)
- [x] Manifest valideret: `Rscript dev/classify_tests.R --validate` — OK
- [x] Pre-push self-test: branch push grøn

## Refs

- `docs/reviews/04-ai-rag.md` H_NEW + reconciliation
- Codex adversarial review: confirmed (recommend real enabled-gating over default-fix)