### PR TITLE
fix(export): session-scoped temp-PNG-sti for PDF preview (cycle E NEW1)

### DIFF
--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -400,6 +400,15 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       safe_operation(
         operation_name = "Generate PDF preview PNG",
         code = {
+          # Cycle E NEW1 (Codex 2026-05-10): brug session-scoped PNG-sti der
+          # overskrives per render i stedet for tempfile() der akkumulerer.
+          # Per Connect-long-session kan tempfile()-pattern lagre 100MB+ pga.
+          # ~40 previews/min worst case under typing.
+          session_preview_path <- file.path(
+            tempdir(),
+            paste0("bfh_preview_session_", session$token, ".png")
+          )
+
           preview_path <- shiny::withProgress(
             message = "Genererer preview...",
             value = 0.5,
@@ -407,7 +416,8 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
               generate_pdf_preview(
                 bfh_qic_result = pdf_result$bfh_qic_result,
                 metadata = metadata,
-                dpi = 150
+                dpi = 150,
+                preview_path = session_preview_path
               )
             }
           )

--- a/R/utils_memory_management.R
+++ b/R/utils_memory_management.R
@@ -51,6 +51,32 @@ setup_session_cleanup <- function(session, app_state = NULL, observers = NULL) {
       }
     }
 
+    # Cycle E NEW1 (Codex 2026-05-10): cleanup tempdir-PNG-akkumulation.
+    # Defense-in-depth — explicit preview_path-fix i mod_export_server.R
+    # holder filerne under én sti, men hvis legacy tempfile()-callers (eller
+    # tests) lægger PNGs udenfor, fanger denne pattern dem.
+    safe_operation(
+      "Cleanup PDF preview temp PNGs",
+      code = {
+        png_files <- list.files(
+          tempdir(),
+          pattern = "^bfh_preview_",
+          full.names = TRUE
+        )
+        if (length(png_files) > 0) {
+          unlink(png_files, recursive = FALSE, force = TRUE)
+          log_debug(
+            sprintf("Cleaned up %d temp PNG file(s)", length(png_files)),
+            .context = "MEMORY_MGMT"
+          )
+        }
+      },
+      fallback = function(e) {
+        log_warn(paste("Temp PNG cleanup failed:", e$message), "MEMORY_MGMT")
+      },
+      error_type = "processing"
+    )
+
     # Force garbage collection
     gc(verbose = FALSE)
 

--- a/R/utils_server_export.R
+++ b/R/utils_server_export.R
@@ -279,7 +279,8 @@ get_hospital_name_for_export <- function() {
 #' @keywords internal
 generate_pdf_preview <- function(bfh_qic_result,
                                  metadata,
-                                 dpi = 150) {
+                                 dpi = 150,
+                                 preview_path = NULL) {
   # Valid\u00e9r dpi inden safe_operation -- kaster export_input_error ved ugyldig vaerdi
   validate_export_dpi(dpi)
 
@@ -385,8 +386,13 @@ generate_pdf_preview <- function(bfh_qic_result,
           # uden at vi ville vide hvad der faktisk skete.
           assets_injected <- isTRUE(inject_template_assets(file.path(temp_dir, "bfh-template")))
 
-          # 5. Compile Typst directly to PNG (more efficient than PDF->PNG)
-          temp_png <- tempfile(fileext = ".png")
+          # 5. Compile Typst directly to PNG (more efficient than PDF->PNG).
+          # Cycle E NEW1 (Codex 2026-05-10): brug preview_path hvis caller
+          # leverer den (typisk session-scoped sti der overskrives per render).
+          # Falder tilbage til tempfile() for bagudkompatibilitet — men dette
+          # akkumulerer PNGs paa Connect-long-sessions; foretraek eksplicit
+          # path naar muligt.
+          temp_png <- preview_path %||% tempfile(fileext = ".png")
 
           # Use quarto typst compile with PNG format.
           # --ignore-system-fonts: undgaar at Typst picker system-Mari-varianter

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1511,3 +1511,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
   rationale: Cycle F H3 (Codex 2026-05-09) unit-tests for has_value()-baseret merge_with_existing der bevarer manuelle felter ogsaa for unreviewed entries. Forhindrer silent overskrivning af rationale/merge_with/handling.
+- file: test-pdf-preview-temp-png.R
+  audit_category: post-audit
+  type: policy-guard
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle E NEW1 (Codex 2026-05-10) regression-tests for temp-PNG-akkumulation-fix. Verificerer preview_path-parameter, session-scoped sti via session$token, og setup_session_cleanup unlinker bfh_preview_*-pattern.

--- a/man/generate_pdf_preview.Rd
+++ b/man/generate_pdf_preview.Rd
@@ -4,7 +4,7 @@
 \alias{generate_pdf_preview}
 \title{Generate PDF Preview Image}
 \usage{
-generate_pdf_preview(bfh_qic_result, metadata, dpi = 150)
+generate_pdf_preview(bfh_qic_result, metadata, dpi = 150, preview_path = NULL)
 }
 \arguments{
 \item{bfh_qic_result}{bfh_qic_result object from BFHcharts::bfh_qic() or generateSPCPlot()$bfh_qic_result.}

--- a/tests/testthat/test-pdf-preview-temp-png.R
+++ b/tests/testthat/test-pdf-preview-temp-png.R
@@ -1,0 +1,65 @@
+# test-pdf-preview-temp-png.R
+# Cycle E NEW1 (Codex 2026-05-10): regression-tests for temp-PNG-akkumulation-fix.
+#
+# Pre-fix: generate_pdf_preview() kaldte tempfile(fileext='.png') hver gang.
+# renderImage(deleteFile=FALSE) ryddede ikke filen. Paa Connect-long-sessions
+# akkumuleres ~40 PNGs/min worst case under typing -> 100MB+ per session.
+#
+# Post-fix:
+#   1. generate_pdf_preview() har preview_path-parameter
+#   2. mod_export_server.R passer session-scoped sti der overskrives
+#   3. setup_session_cleanup() unlinker bfh_preview_*-pattern paa session-end
+
+test_that("generate_pdf_preview() har preview_path-parameter", {
+  require_internal("generate_pdf_preview", mode = "function")
+  formals_list <- formals(generate_pdf_preview)
+  expect_true(
+    "preview_path" %in% names(formals_list),
+    info = "Cycle E NEW1: generate_pdf_preview() skal have preview_path-arg"
+  )
+  # Default skal vaere NULL for bagudkompatibilitet
+  expect_true(
+    is.null(formals_list$preview_path),
+    info = "preview_path default skal vaere NULL for bagudkompatibilitet"
+  )
+})
+
+test_that("generate_pdf_preview() bruger preview_path naar leveret", {
+  require_internal("generate_pdf_preview", mode = "function")
+  body_text <- paste(deparse(body(generate_pdf_preview)), collapse = "\n")
+  # Verificer at preview_path bruges (via %||% fallback eller direkte)
+  expect_true(
+    grepl("preview_path", body_text),
+    info = "generate_pdf_preview body skal referere preview_path-arg"
+  )
+})
+
+test_that("mod_export_server.R caller passer session-scoped preview_path", {
+  require_internal("mod_export_server", mode = "function")
+  body_text <- paste(deparse(body(mod_export_server)), collapse = "\n")
+  expect_true(
+    grepl("session_preview_path|preview_path\\s*=\\s*session", body_text),
+    info = paste(
+      "mod_export_server skal kalde generate_pdf_preview() med",
+      "session-scoped preview_path (Cycle E NEW1)"
+    )
+  )
+  # Verificer at sti bruger session-token for unikhed
+  expect_true(
+    grepl("session\\$token", body_text),
+    info = "session_preview_path skal inkludere session$token for unikhed mellem samtidige sessions"
+  )
+})
+
+test_that("setup_session_cleanup() unlinker bfh_preview_*-PNGs paa session-end", {
+  require_internal("setup_session_cleanup", mode = "function")
+  body_text <- paste(deparse(body(setup_session_cleanup)), collapse = "\n")
+  expect_true(
+    grepl("bfh_preview_", body_text),
+    info = "setup_session_cleanup skal cleanup bfh_preview_*-pattern (NEW1 defense-in-depth)"
+  )
+  expect_true(
+    grepl("unlink", body_text),
+    info = "Cleanup skal kalde unlink"
+  )
+})


### PR DESCRIPTION
## Summary

Cycle E **NEW1 (MEDIUM)** — Codex peer-review verified empirisk.

`generate_pdf_preview()` kaldte `tempfile(fileext='.png')` hver render. `renderImage(deleteFile=FALSE)` ryddede ikke filen. På Connect-long-sessions akkumuleres ~40 PNGs/min worst case under typing → **100MB+ per session** (Codex simulerede 1000-fil-akkumulation).

## Fix

1. **`R/utils_server_export.R`** `generate_pdf_preview()` får `preview_path`-parameter (default NULL for bagudkompatibilitet)
2. **`R/mod_export_server.R`** caller passer session-scoped sti: `file.path(tempdir(), paste0('bfh_preview_session_', session$token, '.png'))` — én PNG per session, overskrives in-place
3. **`R/utils_memory_management.R`** `setup_session_cleanup()` unlinker `bfh_preview_*`-pattern på session-end (defense-in-depth)

**Codex recalibrering:** Min original `session$token`-snippet ville fejle runtime fordi `generate_pdf_preview()` har ej `session` i scope. Korrekt fix er explicit `preview_path`-parameter — implementeret her.

## Test plan

- [x] `test-pdf-preview-temp-png.R`: **7 pass, 0 fail** (preview_path-param, body-reference, session_preview_path-pattern, cleanup-hook)
- [x] `devtools::document()` regen'd `man/generate_pdf_preview.Rd`
- [x] Manifest valideret
- [x] Pre-push self-test grøn

## Refs

- `docs/reviews/05-export-pipeline.md` NEW1
- Codex adversarial review: confirmed (recommend explicit param over session$token in scope)