### PR TITLE
fix(export): on.exit-baseret temp_dir-cleanup i generate_pdf_preview (cycle E NEW2)

### DIFF
--- a/R/utils_server_export.R
+++ b/R/utils_server_export.R
@@ -315,6 +315,14 @@ generate_pdf_preview <- function(bfh_qic_result,
           temp_dir <- tempfile("bfh_preview_")
           dir.create(temp_dir, recursive = TRUE)
 
+          # Cycle E NEW2 (Codex 2026-05-10): exception-safe cleanup.
+          # Tidligere unlink-kald paa linje ~417 sprunges over hvis ggsave/
+          # bfh_extract_spc_stats/bfh_create_typst_document/inject_template_
+          # assets/system2(quarto) throws -> safe_operation fallback uden
+          # cleanup -> tempdir-leak per failed preview. on.exit garantor
+          # cleanup uanset exit-path.
+          on.exit(unlink(temp_dir, recursive = TRUE), add = TRUE)
+
           log_debug(
             component = "[EXPORT]",
             message = "Genererer PDF preview via Typst PNG",
@@ -413,8 +421,8 @@ generate_pdf_preview <- function(bfh_qic_result,
             stderr = TRUE
           )
 
-          # Cleanup temp directory
-          unlink(temp_dir, recursive = TRUE)
+          # Cleanup temp directory haandteres af on.exit ovenfor (NEW2);
+          # explicit unlink her er fjernet for at undgaa double-cleanup.
 
           # Check exit status and validate PNG
           exit_status <- attr(compile_result, "status")

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1511,3 +1511,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
   rationale: Cycle F H3 (Codex 2026-05-09) unit-tests for has_value()-baseret merge_with_existing der bevarer manuelle felter ogsaa for unreviewed entries. Forhindrer silent overskrivning af rationale/merge_with/handling.
+- file: test-pdf-preview-temp-dir-cleanup.R
+  audit_category: post-audit
+  type: policy-guard
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle E NEW2 (Codex 2026-05-10) regression-tests for on.exit-baseret temp_dir-cleanup i generate_pdf_preview. Verificerer on.exit foer ggsave/system2-kald + ej double-cleanup.

--- a/tests/testthat/test-pdf-preview-temp-dir-cleanup.R
+++ b/tests/testthat/test-pdf-preview-temp-dir-cleanup.R
@@ -1,0 +1,66 @@
+# test-pdf-preview-temp-dir-cleanup.R
+# Cycle E NEW2 (Codex 2026-05-10): regression-tests for exception-safe
+# temp_dir-cleanup i generate_pdf_preview().
+#
+# Pre-fix: explicit unlink(temp_dir) paa happy-path (linje ~417). Hvis
+# ggsave/bfh_extract_spc_stats/bfh_create_typst_document/inject_template_
+# assets/system2(quarto) throws -> safe_operation fallback uden cleanup
+# -> tempdir-leak per failed preview. Bounded af R-session, men braekker
+# invariant.
+#
+# Post-fix: on.exit(unlink(temp_dir), add=TRUE) garantor cleanup uanset
+# exit-path.
+
+test_that("generate_pdf_preview() bruger on.exit for temp_dir-cleanup", {
+  require_internal("generate_pdf_preview", mode = "function")
+  body_text <- paste(deparse(body(generate_pdf_preview)), collapse = "\n")
+
+  expect_true(
+    grepl("on\\.exit\\s*\\(\\s*unlink\\s*\\(\\s*temp_dir", body_text),
+    info = paste(
+      "generate_pdf_preview skal bruge on.exit(unlink(temp_dir, ...))",
+      "for at sikre cleanup uanset exception-paths (Cycle E NEW2)."
+    )
+  )
+})
+
+test_that("generate_pdf_preview() har on.exit FOER risikable kald", {
+  require_internal("generate_pdf_preview", mode = "function")
+  body_text <- paste(deparse(body(generate_pdf_preview)), collapse = "\n")
+
+  on_exit_pos <- regexpr("on\\.exit\\s*\\(\\s*unlink", body_text)
+  ggsave_pos <- regexpr("ggsave", body_text)
+  system2_pos <- regexpr("system2", body_text)
+
+  if (on_exit_pos[1] > 0 && ggsave_pos[1] > 0) {
+    expect_lt(
+      on_exit_pos[1], ggsave_pos[1],
+      label = "on.exit skal staa FOER ggsave-kald"
+    )
+  }
+  if (on_exit_pos[1] > 0 && system2_pos[1] > 0) {
+    expect_lt(
+      on_exit_pos[1], system2_pos[1],
+      label = "on.exit skal staa FOER system2-kald"
+    )
+  }
+})
+
+test_that("generate_pdf_preview() undgaar double-cleanup (ej explicit unlink i happy-path)", {
+  require_internal("generate_pdf_preview", mode = "function")
+  body_text <- paste(deparse(body(generate_pdf_preview)), collapse = "\n")
+
+  # Taeller hvor mange unlink(temp_dir, recursive = TRUE)-kald body har.
+  # Forventer KUN 1 (i on.exit). Tidligere implementation havde 2 (explicit
+  # i happy-path + ingen i fail-path). Nu: 1 (on.exit garantor begge paths).
+  unlink_matches <- gregexpr("unlink\\s*\\(\\s*temp_dir", body_text)[[1]]
+  unlink_count <- if (unlink_matches[1] == -1) 0 else length(unlink_matches)
+
+  expect_equal(
+    unlink_count, 1,
+    info = paste(
+      "Forventer kun 1 unlink(temp_dir)-kald (i on.exit). Hvis 2:",
+      "double-cleanup (harmless men misvisende). Hvis 0: cleanup mangler."
+    )
+  )
+})


### PR DESCRIPTION
## Summary

Cycle E **NEW2 (LOW)** — defensive cleanup invariant.

\`generate_pdf_preview()\` havde explicit \`unlink(temp_dir)\` på happy-path. Hvis \`ggsave\`/\`bfh_extract_spc_stats\`/\`bfh_create_typst_document\`/\`inject_template_assets\`/\`system2(quarto)\` throws → \`safe_operation\` fallback uden cleanup → tempdir-leak per failed preview.

## Fix

1. \`on.exit(unlink(temp_dir, recursive=TRUE), add=TRUE)\` umiddelbart efter \`dir.create\`. Garantor cleanup uanset exception-path eller normal exit.
2. Fjern explicit unlink-kald på happy-path for at undgå double-cleanup.

## Test plan

- [x] \`test-pdf-preview-temp-dir-cleanup.R\`: **4 pass, 0 fail** (on.exit i body, on.exit FØR risikable kald, ikke double-cleanup)
- [x] Manifest valideret
- [x] Pre-push self-test grøn

## Refs

- \`docs/reviews/05-export-pipeline.md\` NEW2