### PR TITLE
fix(export): byte-aware filename-cap for cross-platform compatibility (cycle E NEW3)

### DIFF
--- a/R/utils_export_filename.R
+++ b/R/utils_export_filename.R
@@ -88,6 +88,19 @@ generate_export_filename <- function(format, title = "", department = "") {
     ".pdf" # default fallback
   )
 
+  # Cycle E NEW3 (Codex 2026-05-10): byte-aware truncation.
+  # NTFS/ext4 cap = 255 bytes. Title (max 200) + dept (max 250) + prefix +
+  # extension kan i teorien naa ~460 chars. Med danske karakter (UTF-8
+  # multi-byte: aeoeaaAeOeAa = 2 bytes/stk) kan 240 chars = 480 bytes.
+  # Loop char-for-char til byte-cap respekteres for at undgaa split af
+  # multi-byte code points. Reserver 5 bytes for kort buffer + extension.
+  base_name <- enc2utf8(base_name)
+  extension_bytes <- nchar(extension, type = "bytes")
+  max_base_bytes <- 250L - extension_bytes # konservativ buffer under 255
+  while (nchar(base_name, type = "bytes") > max_base_bytes && nchar(base_name) > 0) {
+    base_name <- substr(base_name, 1, nchar(base_name) - 1)
+  }
+
   # Combine base name and extension
   filename <- paste0(base_name, extension)
 

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1511,3 +1511,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-09'
   rationale: Cycle F H3 (Codex 2026-05-09) unit-tests for has_value()-baseret merge_with_existing der bevarer manuelle felter ogsaa for unreviewed entries. Forhindrer silent overskrivning af rationale/merge_with/handling.
+- file: test-export-filename-byte-cap.R
+  audit_category: post-audit
+  type: policy-guard
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle E NEW3 (Codex 2026-05-10) regression-tests for byte-aware filename-cap. Verificerer 255-byte cap respekteres for ASCII + danske multi-byte chars (Codex empirisk afsloerede 240 ae = 480 bytes -> nchar() default counts chars ej bytes).

--- a/tests/testthat/test-export-filename-byte-cap.R
+++ b/tests/testthat/test-export-filename-byte-cap.R
@@ -1,0 +1,83 @@
+# test-export-filename-byte-cap.R
+# Cycle E NEW3 (Codex 2026-05-10): regression-tests for byte-aware filename-cap.
+#
+# Pre-fix: generate_export_filename() havde ingen length-cap. Title (max 200)
+# + dept (max 250) + prefix + extension kunne naa ~460 chars. Med danske
+# karakter (UTF-8 multi-byte) kunne 240 chars = 480 bytes -> over NTFS/ext4
+# 255-byte cap.
+#
+# Post-fix: byte-aware truncation-loop reserverer plads til extension og
+# fjerner chars (NOT bytes!) en ad gangen indtil byte-cap respekteres.
+# Forhindrer split af multi-byte code points.
+#
+# Codex empirisk: 240 'æ' = 480 bytes. nchar() default = chars, ikke bytes.
+# Korrekt fix kraever nchar(x, type='bytes').
+
+test_that("filename respekterer 255-byte cap med ASCII-only inputs", {
+  require_internal("generate_export_filename", mode = "function")
+
+  long_title <- strrep("A", 200)
+  long_dept <- strrep("B", 250)
+  filename <- generate_export_filename("pdf", long_title, long_dept)
+
+  expect_lte(
+    nchar(filename, type = "bytes"), 255L,
+    label = "ASCII-only filename byte-count <= 255"
+  )
+})
+
+test_that("filename respekterer 255-byte cap med danske multi-byte chars", {
+  require_internal("generate_export_filename", mode = "function")
+
+  # Codex empirisk: æ = 2 bytes UTF-8. 240 'æ' = 480 bytes.
+  long_title <- strrep("æ", 200) # æ x 200 = 400 bytes
+  long_dept <- strrep("ø", 250) # ø x 250 = 500 bytes
+  filename <- generate_export_filename("pdf", long_title, long_dept)
+
+  expect_lte(
+    nchar(filename, type = "bytes"), 255L,
+    label = "Danish multi-byte filename byte-count <= 255"
+  )
+})
+
+test_that("filename bevarer extension efter truncation", {
+  require_internal("generate_export_filename", mode = "function")
+
+  long_title <- strrep("æ", 300)
+  filename_pdf <- generate_export_filename("pdf", long_title, "")
+  filename_png <- generate_export_filename("png", long_title, "")
+
+  expect_true(
+    grepl("\\.pdf$", filename_pdf),
+    info = "PDF-extension skal bevares efter truncation"
+  )
+  expect_true(
+    grepl("\\.png$", filename_png),
+    info = "PNG-extension skal bevares efter truncation"
+  )
+})
+
+test_that("filename ej braekker korte inputs", {
+  require_internal("generate_export_filename", mode = "function")
+
+  short_filename <- generate_export_filename("pdf", "Test", "Afdeling")
+  # Forventer noget i stil med "SPC_Afdeling_Test.pdf" -- under cap
+  expect_lt(nchar(short_filename, type = "bytes"), 100L)
+  expect_true(nchar(short_filename) > nchar(".pdf"),
+    info = "Korte inputs skal producere meningsfuldt filename"
+  )
+})
+
+test_that("body indeholder byte-aware nchar-kald", {
+  require_internal("generate_export_filename", mode = "function")
+  body_text <- paste(deparse(body(generate_export_filename)), collapse = "\n")
+
+  expect_true(
+    grepl("nchar\\([^)]*type\\s*=\\s*[\"']bytes[\"']", body_text),
+    info = "generate_export_filename skal bruge nchar(..., type='bytes') for byte-aware cap"
+  )
+  expect_true(
+    grepl("enc2utf8", body_text),
+    info = "Skal normalisere encoding via enc2utf8 foer byte-counting"
+  )
+})

--- a/tests/testthat/test-utils_export_filename.R
+++ b/tests/testthat/test-utils_export_filename.R
@@ -321,15 +321,22 @@ test_that("sanitize_filename handles numeric strings", {
   expect_equal(result, "12345")
 })
 
-test_that("generate_export_filename handles very long title", {
+test_that("generate_export_filename truncates very long title til byte-cap", {
+  # Cycle E NEW3 (Codex 2026-05-10): byte-aware truncation cap'er filenames
+  # ved 250 bytes (konservativ buffer under NTFS/ext4 255-byte limit).
+  # Tidligere version havde ingen cap; test forventede fuld pass-through.
   long_title <- paste(rep("A", 300), collapse = "")
   result <- generate_export_filename(
     format = "pdf",
     title = long_title
   )
 
-  # Should include long title without truncation
-  expect_match(result, paste(rep("A", 300), collapse = ""))
+  # Filename skal respektere 255-byte cap (incl. extension)
+  expect_lte(nchar(result, type = "bytes"), 255L)
+
+  # Skal stadig indeholde substantielt antal A'er + bevare extension
+  expect_match(result, "A{200,}")
+  expect_match(result, "\\.pdf$")
 })
 
 test_that("sanitize_filename handles Unicode characters", {


### PR DESCRIPTION
## Summary

Cycle E **NEW3 (LOW)** — Codex peer-review verified empirisk.

\`generate_export_filename()\` havde ingen length-cap. Title (max 200) + dept (max 250) + prefix + extension kunne i teorien nå ~460 chars. Med danske karakterer (UTF-8 multi-byte) kunne 240 chars = 480 bytes → over NTFS/ext4 255-byte cap.

**Codex empirisk:** 240 \`æ\` = **480 bytes** (verified i R). \`nchar()\` default counts chars, ej bytes — min original \`if (nchar(base_name) > 240) substr(...)\` ville STADIG give 480-byte filename.

## Fix

Byte-aware truncation-loop:
1. \`enc2utf8()\` normaliserer encoding før byte-counting
2. Reserve \`nchar(extension, type='bytes')\` for extension-bytes
3. Konservativ buffer 250 bytes (under 255)
4. Loop char-for-char (\`substr\` opererer på chars) → byte-cap respekteret
5. Forhindrer split af multi-byte UTF-8 code points

## Test plan

- [x] \`test-export-filename-byte-cap.R\`: **8 pass, 0 fail** (ASCII 200+250-char, danske 200 \`æ\` + 250 \`ø\`, extension preserved, korte inputs unchanged, body uses byte-aware nchar + enc2utf8)
- [x] \`test-utils_export_filename.R\`: **63 pass, 0 fail** (1 pre-existing test opdateret til truncation-behavior verifikation)
- [x] Manifest valideret
- [x] Pre-push self-test grøn

## Refs

- \`docs/reviews/05-export-pipeline.md\` NEW3
- Codex adversarial review: confirmed (recommend byte-aware nchar over char-default)