### PR TITLE
fix(ci): correct apt-get line-continuation i auto-regen-manifest workflow

### DIFF
--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -103,10 +103,10 @@ jobs:
       - name: Pre-install system deps (source-pkg dev headers + chromium workaround)
         if: steps.check.outputs.deps_changed == 'true'
         run: |
-          sudo apt-get install -y \\
-            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \\
-            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \\
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \\
+          sudo apt-get install -y \
+            libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
+            zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 


### PR DESCRIPTION
## Summary

PR #690 (Promote develop to master, auto-genereret) fejlede med:
\`\`\`
E: Unable to locate package \
\`\`\`

## Root cause

\`auto-regen-manifest.yaml\`s \`apt-get install\` havde escaped backslash (\`\\\\\`) i stedet for line-continuation backslash (\`\\\`) på 4 linjer (106-109). YAML \`run: |\` parser literally → shell ser pakke-navn \`\\\` som ukendt → exit 100.

R-CMD-check.yaml havde allerede den korrekte single-backslash pattern.

## Fix

Erstat \`\\\\\` med \`\\\` på linjer 106-109 (4 linjer).

## Test plan

- [x] Verified diff = 4 insertions, 4 deletions (no other changes)
- [x] Pattern matcher nu R-CMD-check.yaml working version
- [ ] Workflow re-run efter merge skal vise grøn regen-on-deps-change

## Refs

- PR #690 (Promote develop to master) — blokeret pga. denne bug