### PR TITLE
fix(validation): danish-aware is_column_numeric() for komma-decimaler (cycle D H1)

### DIFF
--- a/R/fct_spc_helpers.R
+++ b/R/fct_spc_helpers.R
@@ -8,6 +8,11 @@
 
 #' Tjek om en kolonne primaert indeholder numeriske vaerdier
 #'
+#' Cycle D H1 (Codex 2026-05-10): bruger parse_danish_number() i stedet
+#' for as.numeric() for at acceptere danske decimal-strings ("12,5", "0,73").
+#' Tidligere afviste karakter-kolonner med komma-decimaler -> falsk Y-axis-
+#' fejl efter localStorage-roundtrip eller Excel-til-text-konvertering.
+#'
 #' @param col Vector. Kolonne at tjekke.
 #' @param threshold Numeric. Andel non-NA vaerdier der skal vaere numeriske (0-1).
 #' @return Logical. TRUE hvis kolonnen er numerisk nok.
@@ -20,7 +25,8 @@ is_column_numeric <- function(col, threshold = 0.5) {
   if (length(non_na) == 0) {
     return(TRUE)
   }
-  parsed <- suppressWarnings(as.numeric(as.character(non_na)))
+  # Danish-aware parsing: accepterer "12,5" og "12.5" som numerisk
+  parsed <- parse_danish_number(as.character(non_na))
   sum(!is.na(parsed)) / length(non_na) >= threshold
 }
 

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1535,3 +1535,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-10'
   rationale: Cycle E NEW3 (Codex 2026-05-10) regression-tests for byte-aware filename-cap. Verificerer 255-byte cap respekteres for ASCII + danske multi-byte chars (Codex empirisk afsloerede 240 ae = 480 bytes -> nchar() default counts chars ej bytes).
+- file: test-is-column-numeric-danish-aware.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle D H1 (Codex 2026-05-10) regression-tests for danish-aware is_column_numeric(). Verificerer at danske komma-decimaler ('12,5') accepteres som numeric. Pre-fix afviste disse -> falsk Y-axis-fejl efter localStorage-roundtrip.

--- a/tests/testthat/test-is-column-numeric-danish-aware.R
+++ b/tests/testthat/test-is-column-numeric-danish-aware.R
@@ -1,0 +1,62 @@
+# test-is-column-numeric-danish-aware.R
+# Cycle D H1 (Codex 2026-05-10): regression-tests for danish-aware
+# is_column_numeric().
+#
+# Pre-fix: is_column_numeric() brugte as.numeric(as.character()) der ikke
+# haandterer komma som decimal-separator. Karakter-kolonner med danske tal
+# ("12,5", "0,73") returnerede success-rate 0 -> falsk Y-axis-fejl efter
+# localStorage-roundtrip eller Excel-til-text-konvertering.
+#
+# Post-fix: parse_danish_number() bruges -> accepterer baade "12,5" og "12.5".
+
+test_that("is_column_numeric accepterer danske komma-decimaler", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_true(is_column_numeric(c("12,5", "0,73", "3,14")))
+})
+
+test_that("is_column_numeric accepterer engelske punktum-decimaler", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_true(is_column_numeric(c("12.5", "0.73", "3.14")))
+})
+
+test_that("is_column_numeric afviser ren tekst", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_false(is_column_numeric(c("foo", "bar", "baz")))
+})
+
+test_that("is_column_numeric accepterer mixed valid+text over threshold", {
+  require_internal("is_column_numeric", mode = "function")
+  # 50% numeric (default threshold) -> TRUE
+  expect_true(is_column_numeric(c("12,5", "foo")))
+})
+
+test_that("is_column_numeric afviser mixed under threshold", {
+  require_internal("is_column_numeric", mode = "function")
+  # 25% numeric (under default 50%) -> FALSE
+  expect_false(is_column_numeric(c("12,5", "foo", "bar", "baz")))
+})
+
+test_that("is_column_numeric haandterer numeric vector direkte", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_true(is_column_numeric(c(1.5, 2.5, 3.5)))
+})
+
+test_that("is_column_numeric haandterer all-NA gracefully", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_true(is_column_numeric(NA))
+  expect_true(is_column_numeric(c(NA, NA, NA)))
+})
+
+test_that("is_column_numeric haandterer integer vector", {
+  require_internal("is_column_numeric", mode = "function")
+  expect_true(is_column_numeric(1:10))
+})
+
+test_that("is_column_numeric body bruger parse_danish_number", {
+  require_internal("is_column_numeric", mode = "function")
+  body_text <- paste(deparse(body(is_column_numeric)), collapse = "\n")
+  expect_true(
+    grepl("parse_danish_number", body_text),
+    info = "is_column_numeric skal bruge parse_danish_number for danish-aware parsing"
+  )
+})


### PR DESCRIPTION
## Summary

Cycle D **H1 (HIGH)** — empirisk verificeret bug.

\`is_column_numeric(c('12,5','0,73','3,14'))\` returnerede **FALSE** pga. \`as.numeric()\` ej parser komma-decimaler.

**Klinisk konsekvens:** Y-axis-validering (\`mod_spc_chart_server.R:196\`) viste falsk fejl for karakter-kolonner med danske decimaler. Typisk efter:
- localStorage-roundtrip (JSON-serialisering preserves character-type)
- CSV-parsing falder tilbage til komma-strategi
- Excel-eksport hvor numeric blev gemt som tekst

Bruger fik tomt diagram + uklar fejl.

## Fix

Skift \`as.numeric(as.character(non_na))\` → \`parse_danish_number(as.character(non_na))\`. \`parse_danish_number()\` defineret i \`R/utils_danish_locale.R\`, bruges allerede i \`fct_autodetect_helpers.R\` for samme purpose.

## Test plan

- [x] **10 pass, 0 fail** (\`test-is-column-numeric-danish-aware.R\`):
  - Danish komma decimaler accepteres ✓
  - Engelsk punktum decimaler accepteres (no regression) ✓
  - Pure text afvises (no regression) ✓
  - Mixed valid/text + 50%-threshold logic preserved ✓
  - Numeric/integer vectors accepteres direkte (no regression) ✓
  - All-NA edge case ✓
  - Body bruger parse_danish_number ✓
- [x] Manifest valideret
- [x] Pre-push grøn

## Refs

- \`docs/reviews/06-data-validation.md\` H1
- Codex adversarial: confirmed empirisk + uafhængigt