### PR TITLE
fix(upload): latin1-fallback for CSV-upload via detect_csv_encoding (cycle D H2)

### DIFF
--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -25,6 +25,33 @@ read_csv_detect_encoding <- function(file_path) {
   text
 }
 
+#' Detekter CSV file encoding via UTF-8 validity heuristik
+#'
+#' Cycle D H2 (Codex 2026-05-10): siden read_csv_detect_encoding() returnerer
+#' character-vektor (lines), introduceres separat helper der returnerer kun
+#' encoding-string. Bruges af parse_file()/parse_csv_file() til at undgaa
+#' UTF-8-only-default som rammer dansk Excel/Windows-eksport.
+#'
+#' Asymmetri-fix: paste-flow brugte allerede read_csv_detect_encoding() med
+#' fallback. Upload-flow brugte parse_file() uden encoding_hints -> defaulter
+#' til UTF-8 -> mojibake i danske headers.
+#'
+#' @param file_path Sti til CSV-fil
+#' @return Character: "UTF-8" eller "latin1" baseret paa validity-tjek.
+#'   Bruges direkte i parse_file(file_path, encoding_hints = list(encoding = ...)).
+#' @keywords internal
+#' @noRd
+detect_csv_encoding <- function(file_path) {
+  text <- tryCatch(
+    readLines(file_path, warn = FALSE, encoding = "UTF-8", n = 200L),
+    error = function(e) character(0) # nolint: swallowed_error_linter
+  )
+  if (length(text) > 0 && !all(validEnc(text))) {
+    return("latin1")
+  }
+  "UTF-8"
+}
+
 #' Upload-successnotifikation med kolonnenavne
 #' @param source_label Kildelabel (fx "CSV", "Excel", "Indsatte data")
 #' @param data Data frame der blev indlaest
@@ -438,9 +465,24 @@ handle_csv_upload <- function(file_path, app_state, session_id = NULL, emit = NU
     details = list(file_path = file_path)
   )
 
+  # Cycle D H2 (Codex 2026-05-10): detekter encoding foer parse_file() for
+  # at undgaa UTF-8-only-default. Dansk Excel/Windows-eksport = Windows-1252;
+  # uden fallback giver det mojibake i \u00e6\u00f8\u00e5-headers.
+  detected_encoding <- detect_csv_encoding(file_path)
+  if (detected_encoding != "UTF-8") {
+    log_info(
+      sprintf("CSV non-UTF-8 detected: encoding=%s", detected_encoding),
+      .context = "FILE_UPLOAD"
+    )
+  }
+
   # Brug parse_file() til pure parsing \u2014 ingen app_state-mutation her
   parsed <- tryCatch(
-    parse_file(file_path, format = "csv"),
+    parse_file(
+      file_path,
+      format = "csv",
+      encoding_hints = list(encoding = detected_encoding)
+    ),
     error = function(e) {
       log_error(
         paste("CSV-parsing fejlede:", e$message),

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1535,3 +1535,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-10'
   rationale: Cycle E NEW3 (Codex 2026-05-10) regression-tests for byte-aware filename-cap. Verificerer 255-byte cap respekteres for ASCII + danske multi-byte chars (Codex empirisk afsloerede 240 ae = 480 bytes -> nchar() default counts chars ej bytes).
+- file: test-detect-csv-encoding.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle D H2 (Codex 2026-05-10) regression-tests for detect_csv_encoding helper + handle_csv_upload latin1-fallback. Verificerer UTF-8/latin1-detection paa CSV-filer + at upload-flow bruger detected encoding i parse_file-call.

--- a/tests/testthat/test-detect-csv-encoding.R
+++ b/tests/testthat/test-detect-csv-encoding.R
@@ -1,0 +1,73 @@
+# test-detect-csv-encoding.R
+# Cycle D H2 (Codex 2026-05-10): regression-tests for detect_csv_encoding()
+# helper + upload-flow latin1-fallback.
+#
+# Pre-fix: handle_csv_upload() kaldte parse_file('csv') uden encoding_hints
+# -> defaulter til UTF-8 -> mojibake i danske CSV-headers (Måned, Afdeling)
+# fra dansk Excel/Windows-eksport.
+#
+# Post-fix: detect_csv_encoding() returnerer 'UTF-8' eller 'latin1' baseret
+# paa validity-tjek; handle_csv_upload bruger den i parse_file-call.
+
+test_that("detect_csv_encoding returnerer UTF-8 for valid UTF-8 fil", {
+  require_internal("detect_csv_encoding", mode = "function")
+
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  writeLines(c("Maaned;Antal", "Jan;5", "Feb;3"), tmp)
+
+  expect_equal(detect_csv_encoding(tmp), "UTF-8")
+})
+
+test_that("detect_csv_encoding returnerer UTF-8 for valid UTF-8 med danske chars", {
+  require_internal("detect_csv_encoding", mode = "function")
+
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  # Skriv UTF-8 med danske chars
+  con <- file(tmp, "wb")
+  utf8_text <- enc2utf8("Måned;Antal\nJan;5\n")
+  writeBin(charToRaw(utf8_text), con)
+  close(con)
+
+  expect_equal(detect_csv_encoding(tmp), "UTF-8")
+})
+
+test_that("detect_csv_encoding returnerer latin1 for Windows-1252 fil", {
+  require_internal("detect_csv_encoding", mode = "function")
+
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  # Skriv latin1-encoded med danske chars
+  con <- file(tmp, "wb")
+  latin1_bytes <- iconv("Måned;Antal\nJan;5\n", to = "latin1", toRaw = TRUE)[[1]]
+  writeBin(latin1_bytes, con)
+  close(con)
+
+  expect_equal(detect_csv_encoding(tmp), "latin1")
+})
+
+test_that("detect_csv_encoding haandterer tom fil gracefully", {
+  require_internal("detect_csv_encoding", mode = "function")
+
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  file.create(tmp)
+
+  # Tom fil = ingen invalid bytes -> default UTF-8
+  expect_equal(detect_csv_encoding(tmp), "UTF-8")
+})
+
+test_that("handle_csv_upload bruger detect_csv_encoding i parse_file-call", {
+  require_internal("handle_csv_upload", mode = "function")
+  body_text <- paste(deparse(body(handle_csv_upload)), collapse = "\n")
+
+  expect_true(
+    grepl("detect_csv_encoding", body_text),
+    info = "handle_csv_upload skal kalde detect_csv_encoding for at detektere encoding"
+  )
+  expect_true(
+    grepl("encoding_hints\\s*=\\s*list\\s*\\(\\s*encoding", body_text),
+    info = "handle_csv_upload skal pasere encoding_hints med detected encoding til parse_file"
+  )
+})


### PR DESCRIPTION
## Summary

Cycle D **H2 (HIGH)** — Codex peer-review verified.

\`handle_csv_upload\` kaldte \`parse_file('csv')\` uden \`encoding_hints\` → defaulter til UTF-8 → **mojibake i danske CSV-headers** (\`Måned\`, \`Afdeling\`) fra dansk Excel/Windows-eksport.

**Asymmetri:** paste-flow brugte allerede \`read_csv_detect_encoding\` (med fallback). Upload-flow gjorde ikke.

**Codex recalibrering:** Min original recipe \`read_csv_detect_encoding(path)$encoding\` ville fejle runtime fordi funktion returnerer character-vektor (lines), ej objekt. Korrekt: separat helper.

## Fix

1. **`R/fct_file_operations.R`:** Ny `detect_csv_encoding(file_path)` helper → \`"UTF-8"\` eller \`"latin1"\` baseret på validity-tjek (læser første 200 lines).
2. **`handle_csv_upload`:** Kalder \`detect_csv_encoding\` FØR \`parse_file\` og passer \`encoding_hints = list(encoding = detected_encoding)\`.
3. Logger non-UTF-8 detection (info-niveau) for diagnostik.

Bevaret: \`read_csv_detect_encoding\` (paste-flow bruger fortsat character-vektor-return).

## Test plan

- [x] **6 pass, 0 fail** (\`test-detect-csv-encoding.R\`):
  - UTF-8 file → "UTF-8" ✓
  - UTF-8 med danske chars → "UTF-8" ✓
  - Latin1/Windows-1252 → "latin1" ✓
  - Tom fil → "UTF-8" (default) ✓
  - `handle_csv_upload` bruger `detect_csv_encoding` + `encoding_hints` ✓
- [x] No regression: \`test-csv-parsing.R\` 35 pass, 0 fail
- [x] Manifest valideret
- [x] Pre-push grøn

## Refs

- \`docs/reviews/06-data-validation.md\` H2
- Codex adversarial: confirmed asymmetri + recalibreret fix-strategi