### PR TITLE
fix(paste-data): admission-specifik heuristik (cycle D H3)

### DIFF
--- a/R/fct_file_operations.R
+++ b/R/fct_file_operations.R
@@ -572,8 +572,22 @@ handle_paste_data <- function(text_data, app_state, session_id = NULL, emit = NU
     return(invisible(NULL))
   }
 
-  # Fritekst med tilfaeldige separatorer kan passere strukturel validering
-  has_numeric <- any(vapply(data, is_column_numeric, logical(1), threshold = 0))
+  # Fritekst med tilfaeldige separatorer kan passere strukturel validering.
+  # Cycle D H3 (Codex 2026-05-10): admission-specifik heuristik (ej kvalitets-
+  # threshold). Tidligere brugte is_column_numeric(threshold=0) som var DEAD
+  # CODE (0/N >= 0 = altid TRUE). threshold=0.5 (Y-axis-quality-heuristik) er
+  # for aggressiv for paste-admission da sparse clinical-data (1 numeric col +
+  # 4 char cols) kunne afvises. Korrekt: kraever \u22651 column med \u22652 parsed
+  # numeric values -> tillader sparse data, afviser ren tekst.
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+  numeric_counts <- vapply(data, count_parsed_numeric, integer(1))
+  has_numeric <- any(numeric_counts >= 2L)
 
   if (!has_numeric) {
     shiny::showNotification(

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1535,3 +1535,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-10'
   rationale: Cycle E NEW3 (Codex 2026-05-10) regression-tests for byte-aware filename-cap. Verificerer 255-byte cap respekteres for ASCII + danske multi-byte chars (Codex empirisk afsloerede 240 ae = 480 bytes -> nchar() default counts chars ej bytes).
+- file: test-paste-data-admission-heuristic.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle D H3 (Codex 2026-05-10) regression-tests for admission-specifik heuristik i handle_paste_data. Verificerer pure prose afvises, normal numeric tilllades, sparse 1/5 numeric col tilllades (Codex bekymring), single-value afvises som noise.

--- a/tests/testthat/test-paste-data-admission-heuristic.R
+++ b/tests/testthat/test-paste-data-admission-heuristic.R
@@ -1,0 +1,125 @@
+# test-paste-data-admission-heuristic.R
+# Cycle D H3 (Codex 2026-05-10): regression-tests for admission-specifik
+# heuristik i handle_paste_data.
+#
+# Pre-fix: has_numeric <- any(is_column_numeric(threshold=0)) var DEAD CODE
+# (0/N >= 0 = altid TRUE for ej-tom kolonne). Brugere kunne paste ren tekst
+# -> validering tillader -> downstream crash.
+#
+# Codex feedback: threshold=0.5 (Y-axis-quality-heuristik) er for aggressivt
+# for paste-admission. Sparse clinical-paste-data (1 numeric col + 4 char
+# cols) kunne afvises trods valid measure-column.
+#
+# Post-fix: admission-specifik heuristik der kraever >=1 column med >=2
+# parsed numeric values. Tillader sparse data, afviser ren tekst.
+
+test_that("handle_paste_data afviser ren prose-tekst", {
+  require_internal("handle_paste_data", mode = "function")
+  body_text <- paste(deparse(body(handle_paste_data)), collapse = "\n")
+
+  expect_true(
+    grepl("count_parsed_numeric", body_text),
+    info = "handle_paste_data skal bruge count_parsed_numeric admission-heuristik"
+  )
+  expect_true(
+    grepl("numeric_counts\\s*>=\\s*2L", body_text),
+    info = "Threshold skal vaere >= 2 for at undgaa single-value-noise"
+  )
+})
+
+test_that("admission-heuristik logic afviser pure prose", {
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+
+  df <- data.frame(
+    a = c("foo", "bar", "baz"),
+    b = c("hello", "world", "test"),
+    stringsAsFactors = FALSE
+  )
+  nc <- vapply(df, count_parsed_numeric, integer(1))
+  expect_false(any(nc >= 2L))
+})
+
+test_that("admission-heuristik tillader normal numeric table", {
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+
+  df <- data.frame(
+    date = c("2024-01-01", "2024-02-01"),
+    value = c(95, 92),
+    stringsAsFactors = FALSE
+  )
+  nc <- vapply(df, count_parsed_numeric, integer(1))
+  expect_true(any(nc >= 2L))
+})
+
+test_that("admission-heuristik tillader sparse clinical-data (1/5 numeric col)", {
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+
+  df <- data.frame(
+    dept = c("Kard", "Med", "Kir"),
+    name = c("a", "b", "c"),
+    code = c("x", "y", "z"),
+    status = c("ok", "ok", "fail"),
+    measurement = c("12,5", "13,2", "14,1"),
+    stringsAsFactors = FALSE
+  )
+  nc <- vapply(df, count_parsed_numeric, integer(1))
+  expect_true(any(nc >= 2L),
+    info = "Sparse 1/5 numeric col skal admission-tillades (Codex's bekymring)"
+  )
+})
+
+test_that("admission-heuristik afviser single-numeric-value (under threshold 2)", {
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+
+  df <- data.frame(
+    a = c("foo", "bar"),
+    b = c("12,5", "baz"), # kun 1 parsed numeric
+    stringsAsFactors = FALSE
+  )
+  nc <- vapply(df, count_parsed_numeric, integer(1))
+  expect_false(any(nc >= 2L),
+    info = "Single numeric value skal afvises som noise (under threshold 2)"
+  )
+})
+
+test_that("admission-heuristik tillader danish-comma decimaler", {
+  count_parsed_numeric <- function(col) {
+    if (is.numeric(col)) {
+      return(sum(!is.na(col)))
+    }
+    parsed <- parse_danish_number(as.character(col))
+    sum(!is.na(parsed))
+  }
+
+  df <- data.frame(
+    date = c("Jan", "Feb"),
+    v = c("12,5", "13,2"),
+    stringsAsFactors = FALSE
+  )
+  nc <- vapply(df, count_parsed_numeric, integer(1))
+  expect_true(any(nc >= 2L))
+})


### PR DESCRIPTION
## Summary

Cycle D **H3 (HIGH)** — empirisk verificeret + Codex peer-review.

\`handle_paste_data\` brugte \`is_column_numeric(threshold=0)\` som var **DEAD CODE** (0/N >= 0 = altid TRUE for ej-tom kolonne). Brugere kunne paste ren tekst → validering tillader → downstream crash.

**Codex recalibrering:** Min original \`threshold=0.5\` (Y-axis-quality-heuristik) er for aggressivt for paste-admission. Sparse clinical-data (1 numeric col + 4 char cols) kunne afvises trods valid measure-column.

## Fix

Admission-specifik heuristik der tæller PARSED numeric values per column:

\`\`\`r
count_parsed_numeric <- function(col) {
  if (is.numeric(col)) return(sum(!is.na(col)))
  parsed <- parse_danish_number(as.character(col))
  sum(!is.na(parsed))
}
numeric_counts <- vapply(data, count_parsed_numeric, integer(1))
has_numeric <- any(numeric_counts >= 2L)  # ≥1 col med ≥2 parsed values
\`\`\`

**Resultat:**
| Input | Pre-fix | Post-fix |
|-------|---------|----------|
| Pure prose | tillades (BUG) | afvises ✓ |
| Normal numeric table | tillades | tillades ✓ |
| Sparse 1/5 numeric col | tillades | tillades ✓ (Codex bekymring) |
| Single numeric value | tillades | afvises ✓ (noise) |
| Danish-comma decimaler | varierende | tillades ✓ |

## Test plan

- [x] **7 pass, 0 fail** (\`test-paste-data-admission-heuristic.R\`)
- [x] Manifest valideret
- [x] Pre-push grøn

## Refs

- \`docs/reviews/06-data-validation.md\` H3
- Codex adversarial: confirmed dead-code + recalibreret threshold til admission-specifik