### PR TITLE
fix(csv): tilføj encoding-arg til auto-detect-strategi (cycle D L1)

### DIFF
--- a/R/utils_csv_delimiter_detection.R
+++ b/R/utils_csv_delimiter_detection.R
@@ -43,10 +43,18 @@ detect_csv_delimiter <- function(path, encoding = "UTF-8", n_max = 5L) {
       name = "auto-detect",
       delimiter = NA_character_, # Lader readr bestemme
       fn = function() {
+        # Cycle D L1 (Codex 2026-05-10): tilføj encoding-arg matching
+        # andre strategier. Tidligere defaultede readr til system-locale
+        # encoding ved auto-detect-strategi -> latin1-headers kunne
+        # mojibake'es ved fallback fra semikolon-strategi.
         readr::read_delim(
           path,
           delim = NULL,
-          locale = readr::locale(decimal_mark = ",", grouping_mark = "."),
+          locale = readr::locale(
+            decimal_mark = ",",
+            grouping_mark = ".",
+            encoding = encoding
+          ),
           n_max = n_max,
           show_col_types = FALSE,
           trim_ws = TRUE,


### PR DESCRIPTION
## Summary

Cycle D **L1 (LOW)** — defensive parity-fix.

\`detect_csv_delimiter()\` har 3 strategier (semikolon, auto-detect, komma). Strategi 1 + 3 passerede \`encoding = encoding\` til \`readr::locale()\`. Strategi 2 (auto-detect) gjorde IKKE → defaulter til system-locale.

## Konsekvens (lav)

Hvis semikolon-strategi fejler (fx tab-separator) og auto-detect skal håndtere latin1-headers, kunne header-preview-parsing misfortolke æøå.

Lav reel impact da semikolon/komma-strategier dækker primary fallback. Defensive parity-fix.

## Fix

Tilføj \`encoding = encoding\` til auto-detect's \`readr::locale()\`-kald.

## Test plan

- [x] Verified all 3 strategies har nu encoding-arg
- [x] Pre-push grøn

## Refs

- \`docs/reviews/06-data-validation.md\` L1