### PR TITLE
fix(excel): tilføj freeze_position til SPC-analyse-arket (cycle C H1)

### DIFF
--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -120,6 +120,20 @@ setup_wizard_gates <- function(input, output, app_state, session) {
         # Hvis kaldet fejler eller returnerer NULL, springes SPC-analyse-arket
         # over (build_spc_excel() haandterer NULL graciously).
         qic_data <- NULL
+
+        # Cycle C H1 (Codex 2026-05-10): ekstraher freeze_position fra data
+        # + metadata$frys_column saa SPC-analyse-arket Sektion A 'Frozen til
+        # raekke' populeres per spec. extract_freeze_position returnerer NULL
+        # hvis ingen frys_column eller ingen markeringer findes — gracefully
+        # haandteret af build_spc_analysis_sheet.
+        # NB: phase_names er IKKE sat (Codex anbefaling): qic_data$part er
+        # auto-genereret integer-IDs, ej user-labels. Implementer kun naar
+        # eksplicit label-source-kontrakt eksisterer.
+        freeze_position <- tryCatch(
+          extract_freeze_position(data, metadata$frys_column),
+          error = function(e) NULL # nolint: swallowed_error_linter
+        )
+
         analysis_options <- list(
           pkg_versions = list(
             biSPCharts = tryCatch(as.character(utils::packageVersion("biSPCharts")),
@@ -129,7 +143,8 @@ setup_wizard_gates <- function(input, output, app_state, session) {
               error = function(e) ""
             )
           ),
-          computed_at = Sys.time()
+          computed_at = Sys.time(),
+          freeze_position = freeze_position
         )
         spc_for_export <- tryCatch(
           build_export_plot(

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1567,3 +1567,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-10'
   rationale: Cycle D H3 (Codex 2026-05-10) regression-tests for admission-specifik heuristik i handle_paste_data. Verificerer pure prose afvises, normal numeric tilllades, sparse 1/5 numeric col tilllades (Codex bekymring), single-value afvises som noise.
+- file: test-spc-excel-freeze-position.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-10'
+  rationale: Cycle C H1 (Codex 2026-05-10) regression-tests for freeze_position extraction i SPC-analyse-arket. Verificerer setup_wizard_gates kalder extract_freeze_position + analysis_options inkluderer feltet. Phase_names skipped per Codex (qic_data$part = integer-IDs ej user-labels).

--- a/tests/testthat/test-spc-excel-freeze-position.R
+++ b/tests/testthat/test-spc-excel-freeze-position.R
@@ -1,0 +1,62 @@
+# test-spc-excel-freeze-position.R
+# Cycle C H1 (Codex 2026-05-10): regression-tests for freeze_position
+# extraction i SPC-analyse-arket.
+#
+# Pre-fix: spc_save_content() byggede analysis_options uden freeze_position.
+# build_spc_analysis_sheet defaulter til NULL -> Sektion A 'Frozen til
+# raekke' altid tomt. Spec-divergens (openspec/specs/excel-spc-analysis-
+# sheet/spec.md:51 SHALL angive 'Frozen til raekke').
+#
+# Post-fix: spc_save_content kalder extract_freeze_position(data,
+# metadata\$frys_column) og passerer til analysis_options.
+
+test_that("spc_save_content body kalder extract_freeze_position", {
+  # Body-introspection (R CMD check sikker) — verificer at fix-kald
+  # eksisterer i save-content-kroppen. spc_save_content er defineret som
+  # nested function inde i setup_wizard_gates, saa vi tjekker via
+  # deparse paa parent-funktionen.
+  require_internal("setup_wizard_gates", mode = "function")
+  body_text <- paste(deparse(body(setup_wizard_gates)), collapse = "\n")
+  expect_true(
+    grepl("extract_freeze_position", body_text),
+    info = "setup_wizard_gates skal kalde extract_freeze_position i spc_save_content"
+  )
+  expect_true(
+    grepl("freeze_position\\s*=\\s*freeze_position", body_text),
+    info = "analysis_options skal inkludere freeze_position-feltet"
+  )
+})
+
+test_that("extract_freeze_position returnerer NULL hvis ingen frys_column", {
+  require_internal("extract_freeze_position", mode = "function")
+  data <- data.frame(date = 1:5, value = 1:5)
+  expect_null(extract_freeze_position(data, NULL))
+  expect_null(extract_freeze_position(data, ""))
+})
+
+test_that("extract_freeze_position returnerer raekke-indeks ved frys-markering", {
+  require_internal("extract_freeze_position", mode = "function")
+  data <- data.frame(
+    date = 1:5,
+    value = 1:5,
+    Frys = c(FALSE, FALSE, TRUE, FALSE, FALSE)
+  )
+  result <- extract_freeze_position(data, "Frys")
+  expect_equal(result, 3L)
+})
+
+test_that("build_spc_analysis_sheet accepterer freeze_position via options", {
+  require_internal("build_spc_analysis_sheet", mode = "function")
+  formals_list <- formals(build_spc_analysis_sheet)
+  expect_true(
+    "options" %in% names(formals_list),
+    info = "build_spc_analysis_sheet skal acceptere options-parameter"
+  )
+
+  # Body-check: options$freeze_position bruges
+  body_text <- paste(deparse(body(build_spc_analysis_sheet)), collapse = "\n")
+  expect_true(
+    grepl("options\\$freeze_position", body_text),
+    info = "build_spc_analysis_sheet skal extracte options$freeze_position"
+  )
+})


### PR DESCRIPTION
## Summary

Cycle C **H1 (MEDIUM)** — spec-divergens. Codex peer-review verified.

\`setup_wizard_gates()\` byggede \`analysis_options\` uden \`freeze_position\` → \`build_spc_analysis_sheet()\` defaulter til NULL → Sektion A "Frozen til række" altid tomt. Spec-divergens (\`openspec/specs/excel-spc-analysis-sheet/spec.md:51\` SHALL angive 'Frozen til række').

**Codex recalibrering:** Min original \`phase_names\` recipe (\`unique(qic_data$part)\`) ville skrive integer part-IDs (1, 2, 3) som "Phase-navn" — duplikerer Part-kolonnen og ser falsk ud som user-labels. Codex empirisk: \`qic_data$part\` er auto-genereret integer, ej user-labels. **Korrekt:** Implementer kun \`freeze_position\`. Lade \`phase_names = NULL\` indtil eksplicit label-source-kontrakt eksisterer.

## Fix

- \`spc_save_content\` kalder \`extract_freeze_position(data, metadata$frys_column)\` wrapped i tryCatch (NULL ved fejl)
- \`analysis_options\` inkluderer \`freeze_position\`-feltet
- \`build_spc_analysis_sheet\` propagerer korrekt via \`options\`-parameter (verified path)

## Test plan

- [x] **7 pass, 0 fail** (\`test-spc-excel-freeze-position.R\`):
  - setup_wizard_gates body kalder extract_freeze_position ✓
  - extract_freeze_position returnerer NULL hvis ingen frys_column ✓
  - extract_freeze_position returnerer række-indeks ved frys-markering ✓
  - build_spc_analysis_sheet accepterer options + extracter freeze_position ✓
- [x] Manifest valideret
- [x] Pre-push grøn

## Refs

- \`docs/reviews/07-excel-io.md\` H1
- Codex adversarial: confirmed spec-gap + recalibreret fix-recipe