### PR TITLE
fix(validation): col_names=TRUE for Indstillinger-validator-parity (cycle C H3)

### DIFF
--- a/R/fct_file_validation.R
+++ b/R/fct_file_validation.R
@@ -207,11 +207,16 @@ validate_excel_file <- function(file_path) {
         safe_operation(
           "Validate biSPCharts Indstillinger sheet",
           code = {
+            # Cycle C H3 (Codex 2026-05-10): brug col_names = TRUE for parity
+            # med parser (R/fct_spc_file_save_load.R:218-227). Tidligere
+            # col_names = c("key","value") tolkede headeren som data -> et
+            # ark med kun header passerede validator. Nu fanges korrupte
+            # ark tidligt per intentionen i kommentar paa linje 189-191.
             settings <- readxl::read_excel(
               file_path,
               sheet = "Indstillinger",
               skip = INDSTILLINGER_HEADER_ROWS,
-              col_names = c("key", "value")
+              col_names = TRUE
             )
             if (ncol(settings) == 0 || nrow(settings) == 0) {
               errors <- c(errors, "Indstillinger-ark er tomt eller ugyldigt")


### PR DESCRIPTION
## Summary

Cycle C **H3 (LOW)** — validator-inkonsistens med parser.

\`validate_uploaded_file()\` brugte \`col_names = c('key','value')\` som tolker første ikke-skipped row som data → et ark med kun header passerede validator. Inkonsistent med parser i \`fct_spc_file_save_load.R:218-227\` der bruger \`col_names = TRUE\`.

## Konsekvens

Beskadiget Indstillinger-ark (kun header, ingen data) passerer validator → falder gennem til \`parse_spc_excel()\` der returnerer NULL → restore degraderer til "tabs som almindelig Excel". Graceful degradation virker, men inkonsistent med intention om at fange korrupte filer tidligt.

## Fix

Skift validator til \`col_names = TRUE\` for parity med parser. Nu fanges korrupte ark tidligt.

## Test plan

- [x] No regression: validator har samme kontrakt som parser
- [x] Pre-push grøn

## Refs

- \`docs/reviews/07-excel-io.md\` H3