### PR TITLE
docs(archive): bevar multi-tab-conflict-detection openspec før review/program-base sletning

### DIFF
--- a/docs/archive/multi-tab-conflict-detection-bugged/README.md
+++ b/docs/archive/multi-tab-conflict-detection-bugged/README.md
@@ -1,0 +1,46 @@
+# Multi-tab conflict detection (ARKIVERET — KENDT BUG)
+
+**Status:** Arkiveret 2026-05-10. Aldrig merget til develop. Indeholder kendt bug.
+
+## Hvorfor arkiveret
+
+Denne OpenSpec-proposal blev udarbejdet i Cycle B (2026-05-09) som deferred work efter at have addresseret de 3 main reactive-state-persistence-fund. Codex fanget under bonus-review at proposal har **runtime-broken specification**.
+
+## Codex bonus-fund (2026-05-09)
+
+> The new requirement defines legacy and forward-incompatible payloads using `schema_version`, but the current persistence contract stores the schema in `version` (`LOCAL_STORAGE_SCHEMA_VERSION` is written as `version` in the saved app state).
+>
+> If engineers implement tests and migration logic from this spec, real 3.0 localStorage payloads will not match the documented migration path; they may be treated as missing/unknown version and cleared or skipped rather than migrated. That is exactly the data-loss class this change is meant to prevent.
+
+## Konkret bug
+
+`spec.md` linje 47-55 bruger field-navn `schema_version` i alle scenarios — men real persistence-payload (`R/utils_local_storage.R::autoSaveAppState()`) bruger `version`-key.
+
+Implementation per spec ville:
+1. Tjekke `payload$schema_version` (returns NULL fordi field hedder `version`)
+2. Behandle alle eksisterende 3.0-payloads som "unknown schema"
+3. Clear/skip migration → silent data-loss
+4. (Ironisk: præcis det denne change skulle FORHINDRE)
+
+## Hvis aktivering ønskes senere
+
+**FORETRUKKET:** Re-create proposal fra scratch med korrekt `version`-key. Bedre end at fixe bug i denne arkiverede version (kontekst-ændringer kan kræve helt nye specs).
+
+**ALTERNATIV:** Hvis du genbruger denne proposal:
+1. Find/replace `schema_version` → `version` i alle 3 filer
+2. Verificer mod faktisk `LOCAL_STORAGE_SCHEMA_VERSION`-konstant + `autoSaveAppState`-payload-shape
+3. Tilføj fixture-test der bygger en real 3.0-payload (ej hand-written pseudo-payload) og kører gennem migration
+4. Re-run Codex adversarial-review for at fange yderligere drift
+
+## Reference
+
+- Cycle B reconciled report: `docs/reviews/02-reactive-state-persistence.md`
+- Codex bonus-finding dokumenteret: `docs/reviews/03-observability-gates.md` (cycle F off-target Codex-pass)
+- Memory-entry: `~/.claude/projects/<project>/memory/feedback_post_merge_ci_gotchas.md`
+- Cycle G H_NEW: addresserede AI-disable via eksplicit feature-flag (parallel pattern for hvad multi-tab kunne lære fra)
+
+## Filer i denne mappe
+
+- `proposal.md` — Cycle B udkast med `schema_version`-bug
+- `spec.md` — Session-persistence requirement med field-mismatch
+- `tasks.md` — Implementation-tasks der ville have opdaget bug ved første test-run

--- a/docs/archive/multi-tab-conflict-detection-bugged/proposal.md
+++ b/docs/archive/multi-tab-conflict-detection-bugged/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+Cycle B reactive-state-+-persistence-review (`docs/reviews/02-reactive-state-persistence.md`) identificerede silent data-loss-risk i localStorage-persistence-laget, verificeret empirisk af Codex peer-review:
+
+`saveAppState()` skriver altid til `spc_app_current_session`-key uden tab-UUID, compare-and-swap, `storage`-event-handling eller newer-save-warning. To tabs af samme app paa samme domæne → silent last-write-wins. Bruger der restorer eller editter parallelt i to tabs kan overskrive nyere session uden warning.
+
+**Real-world-frekvens lav,** men silent data-loss = brittle. Ingen mitigation eller dokumentation findes i dag.
+
+## What Changes
+
+### JS-side (`inst/app/www/local-storage.js`)
+- Generer per-tab UUID ved load (`crypto.randomUUID()`)
+- Inkluder UUID + `last_modified` (epoch-ms) i hver `saveAppState()`-payload
+- Lyt til `window.storage`-event for at detektere skriv fra anden tab
+- Ved storage-event: hvis other-tab's UUID ≠ current og `last_modified` > vores `session_loaded_at`: trigger advarsel via `Shiny.setInputValue("multi_tab_conflict_detected", ...)`
+
+### R-side
+- Ny observer i `R/utils_server_server_management.R`: håndterer `input$multi_tab_conflict_detected` → vis `shinyalert::shinyalert()` modal med valg:
+  - **Behold mit arbejde** (overrider next save, ignorerer warning indtil næste konflikt)
+  - **Overtag andens arbejde** (clear current state, restore fra localStorage)
+- Pre-save-check: hvis localStorage-modifikation efter `session_loaded_at` → block save + show konflikt-modal
+
+### Test changes
+- Ny `tests/testthat/test-multi-tab-conflict.R`:
+  - Mock JS storage-event → verificer R-observer triggers modal
+  - Verificer payload-struktur indeholder UUID + timestamp
+  - Verificer pre-save-check blokerer ved konflikt
+
+### Documentation
+- Opdatér `docs/adr/ADR-005-session-persistence-localstorage.md` med multi-tab-section
+- Tilføj user-guide-note i `docs/CONTRIBUTING.md` (eller relevant doc)
+
+## Impact
+
+- **Affected specs:** `session-persistence` (MODIFIED — udvider med multi-tab-handling)
+- **Affected code:**
+  - Modificeret: `inst/app/www/local-storage.js` (UUID + storage-event + payload-format)
+  - Modificeret: `R/utils_local_storage.R` (payload-format-validation)
+  - Modificeret: `R/utils_server_server_management.R` (observer + modal-handler)
+  - Ny: `tests/testthat/test-multi-tab-conflict.R`
+  - Modificeret: `docs/adr/ADR-005-session-persistence-localstorage.md`
+
+- **Behavioral impact:**
+  - Ny modal når multi-tab-konflikt detekteres
+  - Payload-format-skift = schema-version-bump (LOCAL_STORAGE_SCHEMA_VERSION 3.0 → 4.0) — kræver migration
+  - Eksisterende sessioner uden UUID: behandles som "anonymous tab" (warn én gang, herefter normal)
+
+- **Risk:**
+  - Modal-spam hvis bruger har 3+ tabs aabne samtidig (mitigation: rate-limit modal til 1 per 30s)
+  - Migration-edge-case: 3.0 payloads uden UUID skal kunne læses
+
+## Related
+
+- Cycle B-review: `docs/reviews/02-reactive-state-persistence.md` (M5)
+- Codex empirisk verifikation: 2026-05-09
+- ADR-005 (session-persistence localStorage)

--- a/docs/archive/multi-tab-conflict-detection-bugged/spec.md
+++ b/docs/archive/multi-tab-conflict-detection-bugged/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: localStorage-payload SHALL inkludere tab-UUID og timestamp
+
+Hver `saveAppState()`-payload SHALL inkludere `tab_uuid` (per-tab unique identifier genereret ved page-load via `crypto.randomUUID()`) og `last_modified` (epoch-ms timestamp). Bruges til konflikt-detektion mellem parallelle tabs der deler samme localStorage-key.
+
+#### Scenario: Tab-UUID genereres unikt per tab
+
+- **GIVEN** bruger åbner ny tab af biSPCharts
+- **WHEN** JS-init kører
+- **THEN** `window.SPC_TAB_UUID` SHALL sættes via `crypto.randomUUID()`
+- **AND** UUID SHALL persistere kun i den tab's lifetime (ej localStorage)
+
+#### Scenario: Payload-format indeholder UUID + timestamp
+
+- **GIVEN** bruger trigger save (manual eller auto-save)
+- **WHEN** `saveAppState()` skriver til localStorage
+- **THEN** payload-JSON SHALL indeholde `tab_uuid` + `last_modified`
+- **AND** `last_modified` SHALL være `Date.now()` (epoch-ms)
+
+### Requirement: Multi-tab-konflikt SHALL detekteres og rapporteres til R
+
+JS SHALL lytte til `window.storage`-event for at detektere skriv fra anden tab. Ved konflikt (other-tab-UUID ≠ current OG other-tab-`last_modified` > current-session-`loaded_at`) SHALL JS notificere R-side via `Shiny.setInputValue("multi_tab_conflict_detected", ...)`.
+
+#### Scenario: Storage-event fra anden tab triggerer R-side notification
+
+- **GIVEN** bruger har 2 tabs af biSPCharts åbne (Tab A + Tab B)
+- **WHEN** Tab B skriver til localStorage
+- **THEN** Tab A's `window.storage`-event SHALL fyre
+- **AND** Tab A SHALL kalde `Shiny.setInputValue("multi_tab_conflict_detected", {tab_uuid: ..., last_modified: ...})`
+- **AND** R-side observer SHALL vise konflikt-modal til bruger
+
+#### Scenario: Pre-save-check blokerer overskriv af nyere data
+
+- **GIVEN** Tab A loaded session ved T=0; Tab B skrev til localStorage ved T=10
+- **WHEN** Tab A trigger save ved T=20
+- **THEN** Pre-save-check SHALL detektere `localStorage.last_modified > Tab_A.loaded_at`
+- **AND** save SHALL blokeres
+- **AND** konflikt-modal SHALL vises med valg ("Behold mit arbejde" / "Overtag")
+
+### Requirement: Schema-version SHALL bumpes til 4.0 ved payload-format-skift
+
+`LOCAL_STORAGE_SCHEMA_VERSION` SHALL bumpes fra "3.0" til "4.0" pga. ny payload-format med UUID + timestamp. Migration fra 3.0 SHALL behandle legacy-payloads som "anonymous tab" (én warning, derefter normal funktion).
+
+#### Scenario: 3.0-payload migration
+
+- **GIVEN** localStorage indeholder payload med `schema_version: "3.0"` (uden UUID/timestamp)
+- **WHEN** Tab loader payload
+- **THEN** `migrate_legacy_no_uuid_payload()` SHALL injicere `tab_uuid: "legacy-anonymous"` + `last_modified: Date.now()`
+- **AND** vise én-gangs-warning til bruger ("Session migreret fra ældre version")
+- **AND** næste save SHALL bruge 4.0-format
+
+#### Scenario: Forward-incompatible version hard-rejected
+
+- **GIVEN** localStorage indeholder `schema_version: "5.0"` (fremtidig)
+- **WHEN** Tab loader payload
+- **THEN** payload SHALL hard-rejectes
+- **AND** localStorage SHALL clear-en
+- **AND** bruger SHALL se notification ("Inkompatibel session-version, starter frisk")

--- a/docs/archive/multi-tab-conflict-detection-bugged/tasks.md
+++ b/docs/archive/multi-tab-conflict-detection-bugged/tasks.md
@@ -1,0 +1,41 @@
+## 1. JS-side (UUID + storage-event)
+
+- [ ] 1.1 Generer per-tab UUID via `crypto.randomUUID()` ved page-load
+- [ ] 1.2 Inkluder `tab_uuid` + `last_modified` i payload-format
+- [ ] 1.3 Tilføj `window.addEventListener('storage', ...)` for cross-tab-detection
+- [ ] 1.4 Send `Shiny.setInputValue("multi_tab_conflict_detected", {...})` ved konflikt
+- [ ] 1.5 Pre-save-check: læs current localStorage-payload, sammenlign timestamp + UUID
+
+## 2. R-side observer + modal
+
+- [ ] 2.1 Ny observer i `utils_server_server_management.R` på `input$multi_tab_conflict_detected`
+- [ ] 2.2 `shinyalert::shinyalert()` modal med to valg ("Behold" / "Overtag")
+- [ ] 2.3 Rate-limit modal til 1 per 30s (forhindrer spam ved 3+ tabs)
+- [ ] 2.4 Update `R/utils_local_storage.R` med UUID-payload-validation
+
+## 3. Schema-version-migration
+
+- [ ] 3.1 Bump `LOCAL_STORAGE_SCHEMA_VERSION` fra "3.0" til "4.0"
+- [ ] 3.2 `migrate_legacy_no_uuid_payload()`: behandl 3.0-payloads som "anonymous tab"
+- [ ] 3.3 Hard-reject ved version > 4.0 (forward-incompatible)
+
+## 4. Tests
+
+- [ ] 4.1 Opret `tests/testthat/test-multi-tab-conflict.R`
+- [ ] 4.2 Mock storage-event + verificer observer trigger modal
+- [ ] 4.3 Test payload-format-validation (UUID + timestamp present)
+- [ ] 4.4 Test pre-save-check blokerer ved newer-tab-write
+- [ ] 4.5 Test 3.0-til-4.0 migration
+
+## 5. Documentation
+
+- [ ] 5.1 Opdatér ADR-005 med multi-tab-section
+- [ ] 5.2 User-guide-note om hvad der sker ved multi-tab-konflikt
+- [ ] 5.3 CHANGELOG-entry
+
+## 6. Validering
+
+- [ ] 6.1 Manual test: 2 tabs, edit i begge, verificer konflikt-modal
+- [ ] 6.2 Manual test: rate-limit virker ved 3+ tabs
+- [ ] 6.3 `openspec validate multi-tab-conflict-detection --strict`
+- [ ] 6.4 Fuld test-suite grøn


### PR DESCRIPTION
## Summary

Arkivér Cycle B deferred OpenSpec-proposal (multi-tab-conflict-detection) i \`docs/archive/multi-tab-conflict-detection-bugged/\` før \`review/program-base\` slettes.

## Hvorfor arkivere

3 filer eksisterer **kun** på \`review/program-base\` og forsvinder fra git-history hvis branchen slettes uden arkivering. Brugerens valg: arkivér til \`docs/archive/\` for fremtidig reference.

## Hvorfor "bugged" suffix

Codex bonus-review (Cycle F off-target pass) fanget runtime-broken specification: \`spec.md\` bruger \`schema_version\`-key men real localStorage-payload har \`version\`-key. Implementation per spec ville silent-clear alle 3.0-payloads i stedet for at migrere dem. **Ironisk:** præcis hvad denne change skulle forhindre.

## Indhold

- \`proposal.md\` — Cycle B udkast
- \`spec.md\` — med \`schema_version\`-bug
- \`tasks.md\` — implementation-tasks der ville have opdaget bug
- \`README.md\` — forklarer bug + foretrukket re-create-approach hvis nogensinde aktiveres

## Næste step efter merge

Slet \`review/program-base\` (lokal worktree + branch). Alle docs er nu på develop via PRs #681, #685, #701, #704. Multi-tab-archive er nu på develop via denne PR.

\`\`\`bash
# Efter merge:
git worktree remove /Users/johanreventlow/R/biSPCharts-reviews
git branch -D review/program-base
\`\`\`

## Refs

- Codex bonus-finding: \`docs/reviews/03-observability-gates.md\` (Cycle F off-target Codex-pass)
- Memory: \`feedback_post_merge_ci_gotchas.md\`
- Cycle G H_NEW (parallel pattern for hvad multi-tab kunne have lært fra): \`docs/reviews/04-ai-rag.md\`