### PR TITLE
fix(tests): suppress BFHcharts FONT_FALLBACK warning i test-mod_export

### DIFF
--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -183,7 +183,13 @@ test_that("mod_export_server plot_available reflects app_state (§2.3.2)", {
   app_state <- create_mock_app_state()
 
   shiny::testServer(mod_export_server, args = list(app_state = app_state), {
-    session$flushReact()
+    # suppressWarnings(): BFHcharts emitterer FONT_FALLBACK-warning når CI-runner
+    # mangler de proprietære BFH-fonte (#650). .resolve_font_family cacher per
+    # process, så første cache-miss i test-suiten lander her under
+    # session$flushReact() → export_plot reactive → BFHcharts. Warning ville
+    # bryde R-CMD-check gate (error-on=warning) på PR→master. Upstream BFHcharts
+    # bør konvertere warning() → message() (tracked separat).
+    suppressWarnings(session$flushReact())
 
     # Initial: data + y_column sat → plot_available-logik skal give TRUE.
     expect_true(
@@ -196,7 +202,7 @@ test_that("mod_export_server plot_available reflects app_state (§2.3.2)", {
 
     # Ryd y_column → plot_available-logik skal give FALSE
     app_state$columns$mappings$y_column <- NULL
-    session$flushReact()
+    suppressWarnings(session$flushReact())
     expect_false(
       shiny::isolate(
         !is.null(app_state$data$current_data) &&


### PR DESCRIPTION
## Summary

- `test-mod_export.R:186` triggede `[FONT_FALLBACK] Font 'sans' ikke registreret på systemet` warning under R-CMD-check gate (PR→master, `error-on=warning`) → blokerede PR #722 promote develop→master.
- Wrappet `session$flushReact()` i `suppressWarnings()` på de to call-sites i test-blokken hvor warning lander. Matcher etableret pattern fra #650 (`test-context-aware-plots.R`, `test-spc-plot-generation-comprehensive.R`).

## Root cause

`BFHcharts::.resolve_font_family` cacher resolved fonts per process via `.font_cache`. CI-runner mangler de proprietære BFH-fonte → første cache-miss for `(dev_type, family)` fyrer `warning()`. testthat kører i fælles R-process; warning landede i denne test-blok grundet aktuel test-orden + state (`active_tab="eksporter"` + data + y_column → `export_plot` reactive fyrer → BFHcharts render).

Cache betyder kun ét hit per process → narrow wrap er sufficient.

## Test plan

- [x] `testthat::test_file('tests/testthat/test-mod_export.R')` lokalt — 31 tests pass (lokalt har BFH-fonte; verificerer kun at suppressWarnings ej bryder logik)
- [x] Pre-push gate (lintr + manifest-validation + regression tests) bestået
- [ ] CI R-CMD-check gate på denne PR — develop-branch trigger har **ingen** gate-job (gate kun PR→master), så denne PR validerer kun smoke + lint + testthat
- [ ] **Verifikation:** Når merged til develop + PR #722 rebases/regen, skal `gate (tests + warnings)` på #722 nu være SUCCESS

## Follow-up

Upstream BFHcharts bør konvertere `warning()` → `message()` for FONT_FALLBACK (tracked separat). Indtil da fortsætter dette suppress-pattern.