### PR TITLE
fix(ci): erstat non-ASCII i string-literals med unicode escapes

### DIFF
--- a/R/utils_analytics_consent.R
+++ b/R/utils_analytics_consent.R
@@ -39,7 +39,7 @@ should_track_analytics <- function(consent = NULL) {
 #' @export
 require_consent_or_show_modal <- function(input, session, then_do) {
   if (!is.function(then_do)) {
-    stop("require_consent_or_show_modal: 'then_do' skal være en function")
+    stop("require_consent_or_show_modal: 'then_do' skal v\u00e6re en function")
   }
   consent <- tryCatch(
     shiny::isolate(input$analytics_consent),
@@ -173,7 +173,7 @@ setup_analytics_consent <- function(input, session, hashed_token, log_directory 
             session$onSessionEnded(function() {
               if (isTRUE(session$userData$analytics_revoked)) {
                 log_info(
-                  "Analytics-aggregering sprunget over — samtykke tilbagetrukket i sessionen",
+                  "Analytics-aggregering sprunget over \u2014 samtykke tilbagetrukket i sessionen",
                   .context = LOG_CONTEXTS$analytics$pins
                 )
                 return()
@@ -255,9 +255,9 @@ setup_analytics_consent <- function(input, session, hashed_token, log_directory 
         session$sendCustomMessage("spc_stop_analytics", list())
         log_info(
           paste0(
-            "Analytics tracking stoppet efter samtykke-tilbagetrækning. ",
+            "Analytics tracking stoppet efter samtykke-tilbagetr\u00e6kning. ",
             "Klient-side metrics stoppet straks. ",
-            "Server-side shinylogs-session kan ikke stoppes midt i session — ",
+            "Server-side shinylogs-session kan ikke stoppes midt i session \u2014 ",
             "log-aggregering sprunget over ved session-afslutning."
           ),
           .context = LOG_CONTEXTS$analytics$consent


### PR DESCRIPTION
## Problem

PR #722 (develop→master) fejler i `gate (tests + warnings)` pga. R CMD check WARNING:

```
* checking code files for non-ASCII characters ... WARNING
  R/utils_analytics_consent.R
```

Gate kører med `error-on: "warning"`, saa WARNING = failure.

## Root cause

`utils_analytics_consent.R` (tilfojet i #723) har danish special chars + em-dash i **string literals** (stop(), log_info(), paste0()). Med `Encoding: UTF-8` i DESCRIPTION er non-ASCII OK i kommentarer, men **ikke** i selve koden.

## Fix

4 linjer: `æ` (ae), `—` (em-dash) escapes i string literals.
Kommentarer bevaares urort (tilladt iflg. R CMD check docs).

## Paavirkede linjer

- L42: `stop("... skal være en function")`
- L176: `"... sprunget over — samtykke ..."`
- L258: `"... samtykke-tilbagetrækning ..."`
- L260: `"... midt i session — ..."`

## Test plan

- [x] Pre-push tests bestaaet
- [ ] Gate (tests + warnings) paa PR #722 skal bestaa efter merge til develop