### PR TITLE
Rewrite app help guides

### DIFF
--- a/R/mod_app_guide_ui.R
+++ b/R/mod_app_guide_ui.R
@@ -1,9 +1,9 @@
 # mod_app_guide_ui.R
-# App-vejledning: S\u00e5dan bruger du biSPCharts
+# App-vejledning: Saadan bruger du biSPCharts
 
 #' App Guide Module UI
 #'
-#' Detaljeret trin-for-trin vejledning i brug af biSPCharts-appen.
+#' Praktisk trin-for-trin vejledning i brug af biSPCharts-appen.
 #' Indholdet er statisk og kraever ingen server-logik.
 #'
 #' @param id Character. Namespace ID for modulet
@@ -11,6 +11,24 @@
 #' @keywords internal
 mod_app_guide_ui <- function(id) {
   ns <- shiny::NS(id)
+
+  screenshot_placeholder <- function(title, description, suggestion) {
+    shiny::div(
+      class = "alert alert-light border my-3",
+      style = paste(
+        "border-style: dashed !important;",
+        "background-color: #fafafa;",
+        "color: #555;"
+      ),
+      shiny::tags$strong(title),
+      shiny::tags$p(class = "mb-1 mt-2", description),
+      shiny::tags$small(
+        class = "text-muted",
+        shiny::tags$strong("Screenshot-forslag: "),
+        suggestion
+      )
+    )
+  }
 
   shiny::div(
     class = "container-fluid",
@@ -23,7 +41,11 @@ mod_app_guide_ui <- function(id) {
     shiny::tags$h1("S\u00e5dan bruger du appen"),
     shiny::tags$p(
       class = "lead",
-      "En trin-for-trin vejledning i at uploade data, analysere med SPC og eksportere resultater."
+      "biSPCharts hj\u00e6lper dig fra data til f\u00e6rdigt SPC-diagram i tre trin: upload, analyse og eksport."
+    ),
+    shiny::tags$p(
+      "Denne side handler om selve arbejdsgangen i appen. Hvis du vil forst\u00e5 ",
+      "SPC, variation, Anh\u00f8j-regler og kontrolgr\u00e6nser, s\u00e5 brug siden \u201eL\u00e6r om SPC\u201c."
     ),
 
     # Indholdsfortegnelse
@@ -34,452 +56,337 @@ mod_app_guide_ui <- function(id) {
         shiny::tags$h5("Indhold", class = "card-title"),
         shiny::tags$ol(
           style = "margin-bottom: 0;",
-          shiny::tags$li(shiny::tags$a(href = "#guide-overblik", "Overblik")),
-          shiny::tags$li(shiny::tags$a(href = "#guide-trin1", "Trin 1: Upload data")),
-          shiny::tags$li(shiny::tags$a(href = "#guide-trin2", "Trin 2: Analys\u00e9r")),
-          shiny::tags$li(shiny::tags$a(href = "#guide-trin3", "Trin 3: Eksport\u00e9r")),
-          shiny::tags$li(shiny::tags$a(href = "#guide-tips", "Tips og genveje"))
+          shiny::tags$li(shiny::tags$a(href = "#guide-upload", "1. Upload data")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-kolonner", "2. Tildel kolonner")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-diagram", "3. Just\u00e9r diagrammet")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-laes", "4. L\u00e6s diagrammet")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-rediger", "5. Redig\u00e9r data ved behov")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-eksport", "6. Eksport\u00e9r")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-gem", "7. Gem arbejdet")),
+          shiny::tags$li(shiny::tags$a(href = "#guide-screenshots", "Forslag til screenshots"))
         )
       )
     ),
 
-    # Sektion 1: Overblik
+    # Sektion 1: Upload data
     shiny::tags$section(
-      id = "guide-overblik",
-      shiny::tags$h2("Overblik"),
+      id = "guide-upload",
+      shiny::tags$h2("1. Upload data"),
       shiny::tags$p(
-        "Appen er bygget op om tre trin:"
+        "Start med at v\u00e6lge, hvordan du vil indl\u00e6se data:"
       ),
-      shiny::div(
-        class = "row mb-3",
-        shiny::tags$div(
-          class = "col-md-4",
-          shiny::tags$div(
-            class = "card h-100 text-center",
-            shiny::tags$div(
-              class = "card-body",
-              shiny::tags$h1(class = "display-4", "\u2460"),
-              shiny::tags$h5("Upload", class = "card-title"),
-              shiny::tags$p(
-                class = "card-text",
-                "Inds\u00e6t eller importer dine data. Appen registrerer automatisk kolonner."
-              )
-            )
-          )
+      shiny::tags$dl(
+        class = "row",
+        shiny::tags$dt(class = "col-sm-4", "Kopi\u00e9r & Inds\u00e6t data"),
+        shiny::tags$dd(
+          class = "col-sm-8",
+          "Brug denne, hvis dine data ligger i Excel. Mark\u00e9r tabellen inkl. ",
+          "kolonneoverskrifter, kopi\u00e9r den, inds\u00e6t den i feltet og klik ",
+          shiny::tags$strong("Forts\u00e6t.")
         ),
-        shiny::tags$div(
-          class = "col-md-4",
-          shiny::tags$div(
-            class = "card h-100 text-center",
-            shiny::tags$div(
-              class = "card-body",
-              shiny::tags$h1(class = "display-4", "\u2461"),
-              shiny::tags$h5("Analys\u00e9r", class = "card-title"),
-              shiny::tags$p(
-                class = "card-text",
-                "Map kolonner, v\u00e6lg charttype og tilpas indstillinger. Diagrammet opdateres i realtid."
-              )
-            )
-          )
+        shiny::tags$dt(class = "col-sm-4", "Indl\u00e6s XLS/CSV"),
+        shiny::tags$dd(
+          class = "col-sm-8",
+          "Brug denne, hvis du har en Excel- eller CSV-fil. Du kan ogs\u00e5 ",
+          "indl\u00e6se en tidligere gemt biSPCharts-fil."
         ),
-        shiny::tags$div(
-          class = "col-md-4",
-          shiny::tags$div(
-            class = "card h-100 text-center",
-            shiny::tags$div(
-              class = "card-body",
-              shiny::tags$h1(class = "display-4", "\u2462"),
-              shiny::tags$h5("Eksport\u00e9r", class = "card-title"),
-              shiny::tags$p(
-                class = "card-text",
-                "Download som PDF-rapport eller PNG-billede med titel, datadefinition og analyse."
-              )
-            )
-          )
-        )
-      ),
-      shiny::tags$hr()
-    ),
-
-    # Sektion 2: Trin 1 – Upload data
-    shiny::tags$section(
-      id = "guide-trin1",
-      shiny::tags$h2("Trin 1: Upload data"),
-      shiny::tags$p(
-        "Du kan indl\u00e6se data p\u00e5 fire m\u00e5der:"
-      ),
-
-      # Fire inputmetoder
-      shiny::tags$h4("Inputmetoder"),
-      shiny::tags$table(
-        class = "table table-striped mb-4",
-        shiny::tags$thead(
-          shiny::tags$tr(
-            shiny::tags$th("Metode"),
-            shiny::tags$th("Hvorn\u00e5r"),
-            shiny::tags$th("S\u00e5dan g\u00f8r du")
-          )
+        shiny::tags$dt(class = "col-sm-4", "Pr\u00f8v med eksempeldata"),
+        shiny::tags$dd(
+          class = "col-sm-8",
+          "Brug eksempeldata, hvis du vil l\u00e6re appen at kende eller teste ",
+          "forskellige diagramtyper."
         ),
-        shiny::tags$tbody(
-          shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("Kopi\u00e9r/inds\u00e6t")),
-            shiny::tags$td("Hurtig test, data fra Excel"),
-            shiny::tags$td(
-              "Marker celler i Excel, kopi\u00e9r (Ctrl+C), klik i tekstfeltet og inds\u00e6t (Ctrl+V)"
-            )
-          ),
-          shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("XLS/CSV-fil")),
-            shiny::tags$td("St\u00f8rre dataset, gentagen brug"),
-            shiny::tags$td(
-              "Klik \u201eUpload fil\u201c og v\u00e6lg en .xlsx, .xls eller .csv-fil fra din computer"
-            )
-          ),
-          shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("Eksempeldata")),
-            shiny::tags$td("L\u00e6re appen at kende"),
-            shiny::tags$td(
-              "Klik \u201eIndl\u00e6s eksempeldata\u201c for at se appen med rigtige SPC-data"
-            )
-          ),
-          shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("Tom session")),
-            shiny::tags$td("Starte forfra"),
-            shiny::tags$td(
-              "Klik \u201eNulstil\u201c for at rydde alle data og begynde p\u00e5 ny"
-            )
-          )
-        )
-      ),
-
-      # Dataformat
-      shiny::tags$h4("Dataformat"),
-      shiny::tags$p(
-        "Dine data skal v\u00e6re i ", shiny::tags$strong("tabelformat"),
-        " med \u00e9n r\u00e6kke per observation:"
-      ),
-      shiny::tags$ul(
-        shiny::tags$li(
-          shiny::tags$strong("F\u00f8rste r\u00e6kke:"),
-          " Kolonnenavne (overskrifter)"
-        ),
-        shiny::tags$li(
-          shiny::tags$strong("X-akse kolonne:"),
-          " Dato eller sekventielt tal (fx m\u00e5ned, uge, l\u00f8benummer)"
-        ),
-        shiny::tags$li(
-          shiny::tags$strong("Y-akse kolonne:"),
-          " Din indikator (talv\u00e6rdi per r\u00e6kke)"
-        ),
-        shiny::tags$li(
-          shiny::tags$strong("N\u00e6vner (valgfrit):"),
-          " Kun n\u00f8dvendig ved P- og U-kort (n\u00e6ller/begivenhedsrum)"
+        shiny::tags$dt(class = "col-sm-4", "Blank session"),
+        shiny::tags$dd(
+          class = "col-sm-8",
+          "Brug denne, hvis du vil starte helt forfra."
         )
       ),
       shiny::div(
         class = "alert alert-info",
-        shiny::tags$strong("Tip: "),
-        "Datoer kan v\u00e6re i de fleste formater \u2014 appen parser automatisk ISO-datoer (2024-01), ",
-        "danske m\u00e5nedsnavne (jan 2024) og Excel-datoer."
+        shiny::tags$strong("Dataformat: "),
+        "Dine data skal v\u00e6re en almindelig tabel med \u00e9n r\u00e6kke per ",
+        "observation. Du skal som minimum have en kolonne til tid/kategori ",
+        "og en kolonne med den v\u00e6rdi, du vil f\u00f8lge."
+      ),
+      screenshot_placeholder(
+        "Illustration kommer: Upload-trinnet",
+        "Her kan et screenshot vise de fire uploadvalg og paste-feltet.",
+        paste(
+          "Vis hele upload-siden med knapperne Kopi\u00e9r & Inds\u00e6t data,",
+          "Indl\u00e6s XLS/CSV, Pr\u00f8v med eksempeldata og Blank session."
+        )
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 3: Trin 2 – Analysér
+    # Sektion 2: Tildel kolonner
     shiny::tags$section(
-      id = "guide-trin2",
-      shiny::tags$h2("Trin 2: Analys\u00e9r"),
+      id = "guide-kolonner",
+      shiny::tags$h2("2. Tildel kolonner"),
       shiny::tags$p(
-        "N\u00e5r data er indl\u00e6st, viser appen automatisk et seriediagram. ",
-        "Du kan nu justere kolonnemap, charttype og indstillinger."
-      ),
-
-      # Kolonnemap
-      shiny::tags$h4("Kolonnemapping"),
-      shiny::tags$p(
-        "Under ", shiny::tags$strong("Kolonnemap"),
-        " fort\u00e6ller du appen, hvilke kolonner der indeholder hvad:"
+        "N\u00e5r data er indl\u00e6st, viser appen tabellen og et forel\u00f8bigt ",
+        "diagram. Klik ",
+        shiny::tags$strong("Tildel kolonner"),
+        " og kontroll\u00e9r, at appen har forst\u00e5et data korrekt."
       ),
       shiny::tags$table(
         class = "table table-striped mb-4",
         shiny::tags$thead(
           shiny::tags$tr(
             shiny::tags$th("Felt"),
-            shiny::tags$th("Hvad det er"),
-            shiny::tags$th("N\u00f8dvendigt?")
+            shiny::tags$th("Betydning")
           )
         ),
         shiny::tags$tbody(
           shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("X-akse")),
-            shiny::tags$td("Tidsakse eller sekvensnummer"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-danger", "P\u00e5kr\u00e6vet")
-            )
+            shiny::tags$td(shiny::tags$strong("Tid/kategori (X-akse)")),
+            shiny::tags$td("Dato, m\u00e5ned, uge eller observationsnummer.")
           ),
           shiny::tags$tr(
-            shiny::tags$td(shiny::tags$strong("Y-akse")),
-            shiny::tags$td("Din m\u00e5lte indikator"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-danger", "P\u00e5kr\u00e6vet")
-            )
+            shiny::tags$td(shiny::tags$strong("T\u00e6ller (Y-akse)")),
+            shiny::tags$td("Den v\u00e6rdi du vil f\u00f8lge over tid.")
           ),
           shiny::tags$tr(
             shiny::tags$td(shiny::tags$strong("N\u00e6vner")),
-            shiny::tags$td("Begivenhedsrum (f.eks. antal patienter)"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-warning text-dark", "Kun P/U-kort")
-            )
+            shiny::tags$td("Bruges ved andele og rater, fx patienter, forl\u00f8b eller sengedage.")
           ),
           shiny::tags$tr(
             shiny::tags$td(shiny::tags$strong("Skift")),
-            shiny::tags$td("Kolonne med 1 ved kendte process\u00e6ndringer"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-secondary", "Valgfrit")
-            )
+            shiny::tags$td("Markerer kendte proces\u00e6ndringer eller nye faser.")
           ),
           shiny::tags$tr(
             shiny::tags$td(shiny::tags$strong("Frys")),
-            shiny::tags$td("Kolonne der markerer, hvorn\u00e5r baseline fryses"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-secondary", "Valgfrit")
-            )
+            shiny::tags$td("Markerer hvor kontrolgr\u00e6nser skal l\u00e5ses ud fra en baseline-periode.")
           ),
           shiny::tags$tr(
             shiny::tags$td(shiny::tags$strong("Kommentar")),
-            shiny::tags$td("Kolonne med noter der vises som annotationer p\u00e5 diagrammet"),
-            shiny::tags$td(
-              shiny::tags$span(class = "badge bg-secondary", "Valgfrit")
-            )
+            shiny::tags$td("Noter der kan vises p\u00e5 diagrammet.")
           )
         )
       ),
-
-      # Charttyper
-      shiny::tags$h4("Charttyper"),
-      shiny::tags$table(
-        class = "table table-striped mb-4",
-        shiny::tags$thead(
-          shiny::tags$tr(
-            shiny::tags$th("Charttype"),
-            shiny::tags$th("Bruges til"),
-            shiny::tags$th("Kr\u00e6ver n\u00e6vner?")
-          )
-        ),
-        shiny::tags$tbody(
-          shiny::tags$tr(
-            shiny::tags$td("Seriediagram (Run)"),
-            shiny::tags$td("Alle m\u00e5l \u2014 det simpleste udgangspunkt"),
-            shiny::tags$td("Nej")
-          ),
-          shiny::tags$tr(
-            shiny::tags$td("I-kort"),
-            shiny::tags$td("Individuelle m\u00e5linger med kontrolgr\u00e6nser"),
-            shiny::tags$td("Nej")
-          ),
-          shiny::tags$tr(
-            shiny::tags$td("P-kort"),
-            shiny::tags$td("Andele og procenter"),
-            shiny::tags$td("Ja")
-          ),
-          shiny::tags$tr(
-            shiny::tags$td("C-kort"),
-            shiny::tags$td("T\u00e6llinger (antal h\u00e6ndelser)"),
-            shiny::tags$td("Nej")
-          ),
-          shiny::tags$tr(
-            shiny::tags$td("U-kort"),
-            shiny::tags$td("Rater (h\u00e6ndelser per enhed)"),
-            shiny::tags$td("Ja")
-          )
-        )
+      shiny::div(
+        class = "alert alert-warning",
+        shiny::tags$strong("Vigtigt: "),
+        "Kontroll\u00e9r altid kolonnemappingen. Hvis X-akse, t\u00e6ller eller ",
+        "n\u00e6vner er forkert valgt, bliver diagrammet ogs\u00e5 forkert."
       ),
-
-      # Indstillinger
-      shiny::tags$h4("Indstillinger"),
-      shiny::tags$dl(
-        class = "row",
-        shiny::tags$dt(class = "col-sm-3", "Y-akse enhed"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Tekst der vises p\u00e5 Y-aksen og i PDF-rapporten (f.eks. \u201edage\u201c, \u201epct.\u201c, \u201eantal\u201c)"
+      screenshot_placeholder(
+        "Illustration kommer: Tildel kolonner",
+        paste(
+          "Her kan et screenshot vise dialogen hvor kolonner tildeles til X-akse,",
+          "t\u00e6ller, n\u00e6vner, skift, frys og kommentar."
         ),
-        shiny::tags$dt(class = "col-sm-3", "Udviklingsm\u00e5l"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "V\u00e6lges som en vandret stiplet linje p\u00e5 diagrammet. Angiv et tal svarende til m\u00e5l-v\u00e6rdien p\u00e5 Y-aksen."
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Baseline"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Angiv f\u00f8rste og sidste observation der bruges til beregning af centrallinje og kontrolgr\u00e6nser. ",
-          "Som standard bruges alle data."
-        )
-      ),
-
-      # Value boxes
-      shiny::tags$h4("Afl\u00e6s value boxes"),
-      shiny::tags$p(
-        "Under diagrammet vises fire value boxes med Anh\u00f8j-information:"
-      ),
-      shiny::tags$dl(
-        class = "row",
-        shiny::tags$dt(class = "col-sm-3", "Observationer"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Antal datapunkter der indg\u00e5r i analysen (ekskl. manglende v\u00e6rdier)"
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Seriel\u00e6ngde"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "L\u00e6ngden af den l\u00e6ngste serie konsekutive punkter p\u00e5 samme side af medianen. ",
-          "Orange/r\u00f8d farve indikerer signal."
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Krydsninger"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Antal gange dataserien krydser medianen. For f\u00e5 krydsninger indikerer clustering. ",
-          "Orange/r\u00f8d farve indikerer signal."
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Signal"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "\u201eJa\u201c hvis Anh\u00f8j-reglerne detekterer ikke-tilf\u00e6ldig variation. ",
-          "\u201eNej\u201c hvis processen ser stabil ud."
+        paste(
+          "Vis kolonnemapping-dialogen med et realistisk datas\u00e6t,",
+          "gerne hvor auto-detekteringen allerede har foresl\u00e5et felter."
         )
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 4: Trin 3 – Eksportér
+    # Sektion 3: Juster diagrammet
     shiny::tags$section(
-      id = "guide-trin3",
-      shiny::tags$h2("Trin 3: Eksport\u00e9r"),
+      id = "guide-diagram",
+      shiny::tags$h2("3. Just\u00e9r diagrammet"),
       shiny::tags$p(
-        "P\u00e5 eksportsiden kan du udfylde metadata og downloade dit diagram."
+        "Under ",
+        shiny::tags$strong("Indstillinger"),
+        " v\u00e6lger du diagramtype og visning. Start med ",
+        shiny::tags$strong("Seriediagram (Run),"),
+        " hvis du er i tvivl. Det er ofte det bedste f\u00f8rste overblik."
       ),
-
-      # PDF vs PNG
-      shiny::tags$h4("PDF vs. PNG"),
-      shiny::tags$div(
-        class = "row mb-3",
-        shiny::tags$div(
-          class = "col-md-6",
-          shiny::tags$div(
-            class = "card h-100",
-            shiny::tags$div(
-              class = "card-body",
-              shiny::tags$h5("PDF-rapport", class = "card-title"),
-              shiny::tags$p(
-                class = "card-text",
-                "Inkluderer titel, datadefinition, analysetekst og diagrammet. ",
-                "Egner sig til rapportering og arkivering."
-              )
-            )
-          )
-        ),
-        shiny::tags$div(
-          class = "col-md-6",
-          shiny::tags$div(
-            class = "card h-100",
-            shiny::tags$div(
-              class = "card-body",
-              shiny::tags$h5("PNG-billede", class = "card-title"),
-              shiny::tags$p(
-                class = "card-text",
-                "Kun selve diagrammet som billede. ",
-                "Egner sig til inds\u00e6ttelse i pr\u00e6sentationer, Word-dokumenter og e-mails."
-              )
-            )
-          )
-        )
+      shiny::tags$p(
+        "Brug \u201eL\u00e6r om SPC\u201c, hvis du er usikker p\u00e5 forskellen mellem I-, P-, U- og C-kort."
       ),
-
-      # Metadatafelter
-      shiny::tags$h4("Metadatafelter"),
       shiny::tags$dl(
         class = "row",
-        shiny::tags$dt(class = "col-sm-3", "Titel"),
+        shiny::tags$dt(class = "col-sm-4", "Y-akse enhed"),
         shiny::tags$dd(
-          class = "col-sm-9",
-          "Diagrammets overskrift \u2014 vises \u00f8verst i b\u00e5de PDF og PNG"
+          class = "col-sm-8",
+          "V\u00e6lg hvordan v\u00e6rdierne skal vises, fx tal, procent, rate eller tid."
         ),
-        shiny::tags$dt(class = "col-sm-3", "Hospital"),
+        shiny::tags$dt(class = "col-sm-4", "Udviklingsm\u00e5l"),
         shiny::tags$dd(
-          class = "col-sm-9",
-          "Udfyldes automatisk med hospitalets navn. Kan \u00e6ndres."
+          class = "col-sm-8",
+          "En m\u00e5llinje i diagrammet, fx ",
+          shiny::tags$code(">=90%"),
+          ", ",
+          shiny::tags$code("<25"),
+          " eller ",
+          shiny::tags$code("0,8"),
+          ". M\u00e5let hj\u00e6lper l\u00e6seren, men \u00e6ndrer ikke SPC-beregningerne."
         ),
-        shiny::tags$dt(class = "col-sm-3", "Afdeling"),
+        shiny::tags$dt(class = "col-sm-4", "Evt. baseline"),
         shiny::tags$dd(
-          class = "col-sm-9",
-          "Angiv dit afsnit eller afdeling."
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Datadefinition"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Beskrivelse af hvad der m\u00e5les og hvordan: hvem taller, hvad er inkluderet, ",
-          "hvilken periode og eventuelle undtagelser"
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Analyse"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Fritekstfelt til din fortolkning af diagrammet. Appen genererer automatisk et udkast ",
-          "baseret p\u00e5 signalstatus og charttype."
+          class = "col-sm-8",
+          "En fast midterlinje, hvis du vil sammenligne mod en kendt v\u00e6rdi. ",
+          "Hvis du vil l\u00e5se kontrolgr\u00e6nser ud fra en baseline-periode i data, ",
+          "skal du bruge ",
+          shiny::tags$strong("Frys-kolonnen.")
         )
       ),
+      shiny::div(
+        class = "alert alert-light border",
+        shiny::tags$strong("Midterlinje / Nuv. niveau: "),
+        "Grafens midterlinje kaldes ",
+        shiny::tags$strong("\u201eNuv. niveau\u201c."),
+        " Den viser det niveau, processen aktuelt ligger omkring. ",
+        "I seriediagrammer er midterlinjen typisk medianen. I kontroldiagrammer ",
+        "er den typisk et gennemsnit eller en beregnet middelv\u00e6rdi. ",
+        "Midterlinjen er ikke det samme som udviklingsm\u00e5let: M\u00e5let viser, ",
+        "hvor I gerne vil hen; midterlinjen viser, hvor processen ser ud til at v\u00e6re nu."
+      ),
+      screenshot_placeholder(
+        "Illustration kommer: Analyse-trinnet",
+        "Her kan et screenshot vise datatabel, SPC-preview, indstillingspanel og signalbokse samlet.",
+        paste(
+          "Vis analyse-siden efter data er indl\u00e6st, med Tildel kolonner-knappen,",
+          "diagramtype, Y-akse enhed, udviklingsm\u00e5l og baseline synlige."
+        )
+      ),
+      shiny::tags$hr()
+    ),
 
-      # AI-feature
-      shiny::tags$h4("AI-forbedringsforslag"),
+    # Sektion 4: Laes diagrammet
+    shiny::tags$section(
+      id = "guide-laes",
+      shiny::tags$h2("4. L\u00e6s diagrammet"),
       shiny::tags$p(
-        "Klik p\u00e5 ", shiny::tags$strong("\u201eF\u00e5 AI-forslag\u201c"),
-        " for at f\u00e5 et SPC-relevant forbedringsforslag baseret p\u00e5 dit diagram. ",
-        "Forslaget tager h\u00f8jde for charttype, signalstatus, datadefinition og udviklingsm\u00e5l."
+        "Diagrammet opdateres automatisk, n\u00e5r du \u00e6ndrer data eller ",
+        "indstillinger."
+      ),
+      shiny::tags$p(
+        "Under diagrammet vises n\u00f8gletal for signaler i data, fx seriel\u00e6ngde, ",
+        "antal kryds og punkter uden for kontrolgr\u00e6nser. Farverne hj\u00e6lper dig ",
+        "med at se, om appen har fundet tegn p\u00e5 ",
+        "s\u00e6rlig variation."
       ),
       shiny::div(
         class = "alert alert-info",
-        shiny::tags$strong("Bem\u00e6rk: "),
-        "AI-forslaget er vejledende. Genneml\u00e6s og tilpas altid teksten, ",
-        "s\u00e5 den afspejler din lokale kontekst og viden om processen."
+        shiny::tags$strong("Husk: "),
+        "Et signal er ikke en forklaring i sig selv. Det er et tegn p\u00e5, ",
+        "at processen b\u00f8r vurderes fagligt."
+      ),
+      screenshot_placeholder(
+        "Illustration kommer: Signalbokse",
+        "Her kan et screenshot zoome ind p\u00e5 boksene under diagrammet.",
+        paste(
+          "Vis de tre bokse Seriel\u00e6ngde, Antal kryds og Uden for kontrolgr\u00e6nser,",
+          "gerne i en situation hvor mindst \u00e9n boks markerer signal."
+        )
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 5: Tips og genveje
+    # Sektion 5: Rediger data
     shiny::tags$section(
-      id = "guide-tips",
-      shiny::tags$h2("Tips og genveje"),
+      id = "guide-rediger",
+      shiny::tags$h2("5. Redig\u00e9r data ved behov"),
+      shiny::tags$p(
+        "Du kan rette data direkte i tabellen uden at uploade filen igen."
+      ),
+      shiny::tags$ul(
+        shiny::tags$li("Tilf\u00f8j r\u00e6kker"),
+        shiny::tags$li("Tilf\u00f8j kolonner"),
+        shiny::tags$li("Omd\u00f8b kolonner"),
+        shiny::tags$li("Ret kolonnemapping")
+      ),
+      shiny::tags$p(
+        "N\u00e5r data \u00e6ndres, opdateres diagrammet automatisk."
+      ),
+      screenshot_placeholder(
+        "Illustration kommer: Tabeleditoren",
+        "Her kan et screenshot vise knapperne over datatabellen og en celle der redigeres.",
+        "Vis Omd\u00f8b, Kolonne og R\u00e6kke-knapperne samt en markeret celle i tabellen."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Sektion 6: Eksporter
+    shiny::tags$section(
+      id = "guide-eksport",
+      shiny::tags$h2("6. Eksport\u00e9r"),
+      shiny::tags$p(
+        "Klik ",
+        shiny::tags$strong("Forts\u00e6t"),
+        " for at g\u00e5 til eksport."
+      ),
       shiny::tags$dl(
         class = "row",
-        shiny::tags$dt(class = "col-sm-4", "Gem en kopi"),
+        shiny::tags$dt(class = "col-sm-3", "PDF"),
         shiny::tags$dd(
-          class = "col-sm-8",
-          "Appen gemmer automatisk din session i browseren. N\u00e6ste gang du \u00e5bner appen, ",
-          "tilbyder den at gendanne dine data og indstillinger."
+          class = "col-sm-9",
+          "Brug PDF til rapportering, kvalitetsm\u00f8der, arkivering og deling ",
+          "som f\u00e6rdig rapport."
         ),
-        shiny::tags$dt(class = "col-sm-4", "Rediger data"),
+        shiny::tags$dt(class = "col-sm-3", "PNG"),
         shiny::tags$dd(
-          class = "col-sm-8",
-          "Klik p\u00e5 tabellen under diagrammet for at \u00e6ndre enkeltv\u00e6rdier direkte ",
-          "uden at uploade filen igen."
-        ),
-        shiny::tags$dt(class = "col-sm-4", "Tilf\u00f8j kolonner"),
-        shiny::tags$dd(
-          class = "col-sm-8",
-          "Brug tabeleditoren til at tilf\u00f8je en ny kolonne (f.eks. Skift eller Kommentar), ",
-          "hvis din kildefil ikke indeholder den."
-        ),
-        shiny::tags$dt(class = "col-sm-4", "Omd\u00f8b kolonner"),
-        shiny::tags$dd(
-          class = "col-sm-8",
-          "Klik p\u00e5 et kolonnenavn i tabeleditoren for at omd\u00f8be det. ",
-          "Kolonnemap opdateres automatisk."
-        ),
-        shiny::tags$dt(class = "col-sm-4", "Eksempeldata"),
-        shiny::tags$dd(
-          class = "col-sm-8",
-          "Brug \u201eIndl\u00e6s eksempeldata\u201c til at udforske alle charttyper og indstillinger ",
-          "inden du bruger dine egne data."
+          class = "col-sm-9",
+          "Brug PNG n\u00e5r du kun skal bruge diagrammet i en pr\u00e6sentation, ",
+          "mail eller et dokument."
         )
+      ),
+      shiny::tags$p("Udfyld is\u00e6r:"),
+      shiny::tags$ul(
+        shiny::tags$li(shiny::tags$strong("Indikatortitel: "), "en kort titel eller konklusion."),
+        shiny::tags$li(shiny::tags$strong("Afdeling eller afsnit: "), "hvor data h\u00f8rer til."),
+        shiny::tags$li(
+          shiny::tags$strong("Datadefinition: "),
+          "hvad m\u00e5les, hvem indg\u00e5r, hvilken periode d\u00e6kker data, og hvad er eventuelt udeladt?"
+        ),
+        shiny::tags$li(
+          shiny::tags$strong("Analyse af processen: "),
+          "din faglige fortolkning af diagrammet."
+        ),
+        shiny::tags$li(shiny::tags$strong("Datakilde/fodnote: "), "hvor data kommer fra.")
+      ),
+      shiny::tags$p(
+        "Klik ",
+        shiny::tags$strong("Eksport\u00e9r"),
+        " for at downloade filen."
+      ),
+      screenshot_placeholder(
+        "Illustration kommer: Eksport-trinnet",
+        "Her kan et screenshot vise formatvalg, metadatafelter og preview.",
+        paste(
+          "Vis eksport-siden med PDF valgt, udfyldt indikatortitel,",
+          "datadefinition, analysefelt og preview til h\u00f8jre."
+        )
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Sektion 7: Gem arbejdet
+    shiny::tags$section(
+      id = "guide-gem",
+      shiny::tags$h2("7. Gem arbejdet"),
+      shiny::tags$p(
+        "Appen gemmer automatisk din session i browseren, s\u00e5 du kan ",
+        "forts\u00e6tte senere fra samme computer."
+      ),
+      shiny::tags$p(
+        "Hvis arbejdet skal deles, dokumenteres eller bruges p\u00e5 en anden ",
+        "computer, b\u00f8r du ogs\u00e5 downloade en kopi af data og indstillinger."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Sektion 8: Screenshot backlog
+    shiny::tags$section(
+      id = "guide-screenshots",
+      shiny::tags$h2("Forslag til screenshots"),
+      shiny::tags$p(
+        "N\u00e5r de rigtige screenshots er klar, kan pladsholderne ovenfor ",
+        "erstattes med billeder i samme stil som p\u00e5 siden \u201eL\u00e6r om SPC\u201c."
+      ),
+      shiny::tags$ul(
+        shiny::tags$li("Upload-siden med de fire startvalg og paste-feltet."),
+        shiny::tags$li("Kolonnemapping-dialogen med realistiske kolonnevalg."),
+        shiny::tags$li("Analyse-siden med datatabel, diagram, indstillinger og signalbokse."),
+        shiny::tags$li("Et n\u00e6rbillede af signalboksene, gerne med et aktivt signal."),
+        shiny::tags$li("Tabeleditoren med Omd\u00f8b, Kolonne og R\u00e6kke synlige."),
+        shiny::tags$li("Eksport-siden med PDF-preview og udfyldte metadatafelter.")
       )
     )
   )

--- a/R/mod_help_ui.R
+++ b/R/mod_help_ui.R
@@ -1,10 +1,10 @@
 # mod_help_ui.R
-# Hjælpeside: SPC-teori og app-vejledning
+# Hjaelpeside: Laer om SPC
 
 #' Help Module UI
 #'
-#' Hjælpeside med SPC-grundbegreber og app-vejledning.
-#' Indholdet er statisk og kræver ingen server-logik.
+#' Introduktion til SPC-begreber og praktisk brug i biSPCharts.
+#' Indholdet er statisk og kraever ingen server-logik.
 #'
 #' @param id Character. Namespace ID for modulet
 #' @return Shiny UI element
@@ -12,14 +12,39 @@
 mod_help_ui <- function(id) {
   ns <- shiny::NS(id)
 
+  help_image <- function(src, alt, caption) {
+    shiny::tags$div(
+      class = "text-center my-3",
+      shiny::tags$img(
+        src = src,
+        alt = alt,
+        class = "img-fluid rounded shadow-sm",
+        style = "max-width: 700px;"
+      ),
+      shiny::tags$p(class = "text-muted small mt-1", caption)
+    )
+  }
+
   shiny::div(
     class = "container-fluid",
     style = "max-width: 900px; margin: 0 auto; padding: 30px 20px;",
 
     # Tilbagelink til forrige side
     help_back_link(ns),
+    shiny::tags$h1("L\u00e6r om SPC"),
+    shiny::tags$p(
+      class = "lead",
+      "SPC hj\u00e6lper dig med at se, om en proces bare varierer naturligt, ",
+      "eller om der er tegn p\u00e5 en reel \u00e6ndring."
+    ),
+    shiny::tags$p(
+      "Denne side forklarer de vigtigste begreber, du m\u00f8der i biSPCharts: ",
+      "variation, seriediagrammer, Anh\u00f8j-regler, kontrolgr\u00e6nser og valg af charttype. ",
+      "Hvis du leder efter den konkrete klik-for-klik arbejdsgang, ",
+      "s\u00e5 brug siden \u201eS\u00e5dan bruger du appen\u201c."
+    ),
 
-    # Ankerlinks (indholdsfortegnelse)
+    # Ankerlinks
     shiny::div(
       class = "card mb-4",
       shiny::div(
@@ -28,55 +53,84 @@ mod_help_ui <- function(id) {
         shiny::tags$ol(
           style = "margin-bottom: 0;",
           shiny::tags$li(shiny::tags$a(href = "#spc-hvad", "Hvad er SPC?")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-data", "SPC starter med data over tid")),
           shiny::tags$li(shiny::tags$a(href = "#spc-variation", "To typer variation")),
           shiny::tags$li(shiny::tags$a(href = "#spc-laes", "S\u00e5dan l\u00e6ser du et seriediagram")),
           shiny::tags$li(shiny::tags$a(href = "#spc-anhoej", "Anh\u00f8j-reglerne")),
-          shiny::tags$li(shiny::tags$a(href = "#spc-kontrol", "Kontroldiagrammer")),
-          shiny::tags$li(shiny::tags$a(href = "#spc-raad", "Gode r\u00e5d")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-kontrol", "Kontroldiagrammer og kontrolgr\u00e6nser")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-chartvalg", "Hvilken charttype skal jeg v\u00e6lge?")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-appvalg", "M\u00e5l, baseline, skift og frys")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-fortolkning", "Fra signal til handling")),
+          shiny::tags$li(shiny::tags$a(href = "#spc-raad", "Typiske faldgruber")),
           shiny::tags$li(shiny::tags$a(href = "#spc-litteratur", "Videre l\u00e6sning"))
         )
       )
     ),
 
-    # Sektion 1: Hvad er SPC?
+    # Section 1: What is SPC?
     shiny::tags$section(
       id = "spc-hvad",
       shiny::tags$h2("Hvad er SPC?"),
       shiny::tags$p(
-        "SPC (Statistical Process Control) er en metode til at forst\u00e5 ",
-        shiny::tags$strong("variation"), " i processer over tid. ",
-        "Metoden blev udviklet af Walter Shewhart i 1920'erne og er i dag ",
-        "central i klinisk kvalitetsarbejde verden over."
+        "SPC st\u00e5r for ",
+        shiny::tags$em("Statistical Process Control."),
+        " Det er en metode til at forst\u00e5 variation i processer over tid."
       ),
       shiny::tags$p(
-        "Kernebudskabet i SPC er enkelt: ",
-        shiny::tags$em("Al data varierer. Sp\u00f8rgsm\u00e5let er om variationen er tilf\u00e6ldig eller meningsfuld."),
-        " Et seriediagram g\u00f8r det muligt at skelne mellem de to."
+        "I klinisk kvalitetsarbejde er pointen enkel: Data varierer altid. ",
+        "SPC hj\u00e6lper dig med at skelne mellem almindelige udsving og signaler, ",
+        "der kan betyde, at processen faktisk har \u00e6ndret sig."
       ),
-      shiny::tags$div(
-        class = "text-center my-3",
-        shiny::tags$img(
-          src = "www/help/01-run-chart-stabil.png",
-          alt = "Seriediagram der viser en stabil proces",
-          class = "img-fluid rounded shadow-sm",
-          style = "max-width: 700px;"
-        ),
-        shiny::tags$p(
-          class = "text-muted small mt-1",
-          "Et seriediagram med en stabil proces. Punkterne varierer tilf\u00e6ldigt omkring medianen."
-        )
+      shiny::div(
+        class = "alert alert-info",
+        shiny::tags$strong("Kort sagt: "),
+        "SPC svarer ikke bare p\u00e5 om et tal er h\u00f8jt eller lavt. ",
+        "SPC hj\u00e6lper dig med at vurdere, om udviklingen over tid ser stabil, ",
+        "forbedret eller ustabil ud."
+      ),
+      help_image(
+        "www/help/01-run-chart-stabil.png",
+        "Seriediagram der viser en stabil proces",
+        "En stabil proces: Punkterne varierer omkring midterlinjen uden tydeligt signal."
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 2: To typer variation
+    # Section 2: Data over time
+    shiny::tags$section(
+      id = "spc-data",
+      shiny::tags$h2("SPC starter med data over tid"),
+      shiny::tags$p(
+        "SPC virker bedst, n\u00e5r du f\u00f8lger den samme indikator p\u00e5 samme m\u00e5de over tid. ",
+        "R\u00e6kkef\u00f8lgen er afg\u00f8rende. Et gennemsnit eller en f\u00f8r/efter-sammenligning ",
+        "kan skjule, om processen var stabil, gradvist forbedret eller pr\u00e6get af enkelte udsving."
+      ),
+      shiny::tags$h4("Gode data til SPC har typisk"),
+      shiny::tags$ul(
+        shiny::tags$li("en tydelig tids- eller r\u00e6kkef\u00f8lgekolonne, fx m\u00e5ned, uge eller dato"),
+        shiny::tags$li("en ensartet definition af hvad der t\u00e6lles eller m\u00e5les"),
+        shiny::tags$li("nok datapunkter til at vurdere m\u00f8nstre over tid"),
+        shiny::tags$li("en relevant n\u00e6vner, hvis du arbejder med andele eller rater"),
+        shiny::tags$li("noter om kendte proces\u00e6ndringer, ferieperioder, databrud eller kampagner")
+      ),
+      shiny::div(
+        class = "alert alert-warning",
+        shiny::tags$strong("Pas p\u00e5 databrud: "),
+        "Hvis definitionen, datakilden eller opg\u00f8relsesmetoden \u00e6ndrer sig, ",
+        "kan diagrammet vise et signal, der skyldes m\u00e5den data er opgjort p\u00e5 ",
+        "- ikke en reel proces\u00e6ndring."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Section 3: Variation
     shiny::tags$section(
       id = "spc-variation",
       shiny::tags$h2("To typer variation"),
       shiny::tags$p(
-        "Den vigtigste skelnen i SPC er mellem to typer variation:"
+        "Den vigtigste skelnen i SPC er mellem tilf\u00e6ldig variation og s\u00e6rlig variation."
       ),
-      shiny::tags$div(
+      shiny::div(
         class = "row mb-3",
         shiny::tags$div(
           class = "col-md-6",
@@ -87,10 +141,10 @@ mod_help_ui <- function(id) {
               shiny::tags$h5("Tilf\u00e6ldig variation", class = "card-title text-success"),
               shiny::tags$p(
                 class = "card-text",
-                "Ogs\u00e5 kaldet ", shiny::tags$em("common cause variation"), ". ",
-                "Naturlig st\u00f8j der er til stede i alle processer. ",
-                "Processen er forudsigelig inden for sine gr\u00e6nser. ",
-                "Kan kun reduceres ved at \u00e6ndre selve systemet."
+                "Ogs\u00e5 kaldet ",
+                shiny::tags$em("common cause variation"),
+                ". Det er den naturlige st\u00f8j, der findes i alle processer. ",
+                "Processen er forudsigelig inden for sit normale niveau."
               )
             )
           )
@@ -104,235 +158,304 @@ mod_help_ui <- function(id) {
               shiny::tags$h5("S\u00e6rlig variation", class = "card-title text-danger"),
               shiny::tags$p(
                 class = "card-text",
-                "Ogs\u00e5 kaldet ", shiny::tags$em("special cause variation"), ". ",
-                "Ikke-tilf\u00e6ldige signaler fra us\u00e6dvanlige h\u00e6ndelser. ",
-                "Processen er uforudsigelig. ",
-                "Kan unders\u00f8ges og handles direkte."
+                "Ogs\u00e5 kaldet ",
+                shiny::tags$em("special cause variation"),
+                ". Det er tegn p\u00e5, at noget us\u00e6dvanligt kan v\u00e6re sket. ",
+                "Processen b\u00f8r unders\u00f8ges, f\u00f8r man konkluderer."
               )
             )
           )
         )
       ),
-      shiny::tags$div(
+      shiny::div(
         class = "alert alert-warning",
-        shiny::tags$strong("Pas p\u00e5 tampering: "),
-        "At reagere p\u00e5 tilf\u00e6ldig variation som om den var meningsfuld ",
-        "g\u00f8r processen ", shiny::tags$em("v\u00e6rre"), ", ikke bedre. ",
-        "Det er som at dreje p\u00e5 termostaten hver gang temperaturen svinger lidt."
+        shiny::tags$strong("Undg\u00e5 tampering: "),
+        "Hvis du reagerer p\u00e5 tilf\u00e6ldige udsving, som om de var reelle \u00e6ndringer, ",
+        "kan du g\u00f8re processen mere ustabil. SPC hj\u00e6lper med at undg\u00e5 den fejl."
       ),
-      shiny::tags$div(
-        class = "text-center my-3",
-        shiny::tags$img(
-          src = "www/help/02-variation-sammenligning.png",
-          alt = "Sammenligning af stabil proces og proces med niveauskift",
-          class = "img-fluid rounded shadow-sm",
-          style = "max-width: 700px;"
-        ),
-        shiny::tags$p(
-          class = "text-muted small mt-1",
-          "Venstre: Stabil proces (kun tilf\u00e6ldig variation). H\u00f8jre: Proces med niveauskift (s\u00e6rlig variation detekteret)."
-        )
+      shiny::tags$p(
+        "En stabil proces er ikke n\u00f8dvendigvis en god proces. Den er bare forudsigelig. ",
+        "Hvis niveauet er utilfredsstillende, kr\u00e6ver forbedring typisk en \u00e6ndring af selve systemet."
+      ),
+      help_image(
+        "www/help/02-variation-sammenligning.png",
+        "Sammenligning af stabil proces og proces med niveauskift",
+        "Venstre: Stabil proces. H\u00f8jre: Proces med et tydeligt niveauskift."
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 3: Sådan læser du et seriediagram
+    # Section 4: Read run chart
     shiny::tags$section(
       id = "spc-laes",
       shiny::tags$h2("S\u00e5dan l\u00e6ser du et seriediagram"),
-      shiny::tags$p("Et seriediagram har tre centrale elementer:"),
+      shiny::tags$p(
+        "Et seriediagram er det bedste sted at starte. Det viser dine datapunkter i r\u00e6kkef\u00f8lge ",
+        "og l\u00e6gger en midterlinje ind, s\u00e5 du kan se m\u00f8nstre over tid."
+      ),
       shiny::tags$dl(
         class = "row",
-        shiny::tags$dt(class = "col-sm-3", "Centrallinje (median)"),
+        shiny::tags$dt(class = "col-sm-3", "Punkter"),
+        shiny::tags$dd(class = "col-sm-9", "Hver observation i dataserien."),
+        shiny::tags$dt(class = "col-sm-3", "Linje"),
+        shiny::tags$dd(class = "col-sm-9", "Forbinder punkterne, s\u00e5 udviklingen over tid bliver synlig."),
+        shiny::tags$dt(class = "col-sm-3", "Midterlinje"),
         shiny::tags$dd(
           class = "col-sm-9",
-          "Den vandrette linje i midten. Halvdelen af punkterne ligger over, halvdelen under."
+          "Viser processens nuv\u00e6rende niveau og kaldes derfor \u201eNuv. niveau\u201c p\u00e5 grafen. ",
+          "I seriediagrammer er midterlinjen typisk medianen. I kontroldiagrammer er den typisk ",
+          "et gennemsnit eller en beregnet middelv\u00e6rdi."
         ),
-        shiny::tags$dt(class = "col-sm-3", "Serie (run)"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "Konsekutive punkter p\u00e5 samme side af medianen. En us\u00e6dvanligt lang serie tyder p\u00e5 et skift i processen."
-        ),
-        shiny::tags$dt(class = "col-sm-3", "Krydsning"),
-        shiny::tags$dd(
-          class = "col-sm-9",
-          "N\u00e5r linjen krydser medianen. For f\u00e5 krydsninger tyder p\u00e5 clustering eller stratificering."
-        )
+        shiny::tags$dt(class = "col-sm-3", "Serie"),
+        shiny::tags$dd(class = "col-sm-9", "Flere punkter efter hinanden p\u00e5 samme side af midterlinjen."),
+        shiny::tags$dt(class = "col-sm-3", "Kryds"),
+        shiny::tags$dd(class = "col-sm-9", "N\u00e5r linjen krydser midterlinjen.")
       ),
-      shiny::tags$div(
-        class = "text-center my-3",
-        shiny::tags$img(
-          src = "www/help/03-diagram-annoteret.png",
-          alt = "Seriediagram med annotationer der viser centrallinje, serie og krydsning",
-          class = "img-fluid rounded shadow-sm",
-          style = "max-width: 700px;"
-        ),
-        shiny::tags$p(
-          class = "text-muted small mt-1",
-          "Et seriediagram med centrallinje (median), en markeret serie, og krydsningspunkter."
-        )
+      help_image(
+        "www/help/03-diagram-annoteret.png",
+        "Seriediagram med annotationer der viser midterlinje, serie og kryds",
+        "Et seriediagram med midterlinje, markeret serie og kryds."
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 4: Anhøj-reglerne
+    # Section 5: Anhoej
     shiny::tags$section(
       id = "spc-anhoej",
       shiny::tags$h2("Anh\u00f8j-reglerne"),
       shiny::tags$p(
-        "Anh\u00f8j-reglerne er to statistiske tests der detekterer ikke-tilf\u00e6ldig variation. ",
-        "De er udviklet af Jacob Anh\u00f8j og valideret i peer-reviewed forskning."
+        "Anh\u00f8j-reglerne er to statistiske tests, der bruges til at finde tegn p\u00e5 ",
+        "ikke-tilf\u00e6ldig variation i seriediagrammer."
       ),
-      shiny::tags$div(
+      shiny::div(
         class = "card mb-3",
-        shiny::tags$div(
+        shiny::div(
           class = "card-body",
           shiny::tags$h5("Regel 1: Seriel\u00e6ngde", class = "card-title"),
           shiny::tags$p(
             class = "card-text",
-            "Hvis den l\u00e6ngste serie (konsekutive punkter p\u00e5 samme side af medianen) ",
-            "overstiger en gr\u00e6nse baseret p\u00e5 antal datapunkter, er der tegn p\u00e5 et ",
-            shiny::tags$strong("niveauskift"), " i processen."
+            "Hvis den l\u00e6ngste serie af punkter p\u00e5 samme side af midterlinjen er l\u00e6ngere end forventet, ",
+            "er der tegn p\u00e5 et niveauskift i processen."
           )
         )
       ),
-      shiny::tags$div(
+      shiny::div(
         class = "card mb-3",
-        shiny::tags$div(
+        shiny::div(
           class = "card-body",
-          shiny::tags$h5("Regel 2: Antal krydsninger", class = "card-title"),
+          shiny::tags$h5("Regel 2: Antal kryds", class = "card-title"),
           shiny::tags$p(
             class = "card-text",
-            "Hvis der er f\u00e6rre krydsninger af medianen end forventet, er der tegn p\u00e5 ",
-            shiny::tags$strong("clustering eller stratificering"), " i data."
+            "Hvis linjen krydser midterlinjen f\u00e6rre gange end forventet, kan det tyde p\u00e5 clustering, ",
+            "stratificering eller en trend i data."
           )
         )
       ),
-      shiny::tags$p(
-        "Reglerne tilpasser sig automatisk til datas\u00e6ttets st\u00f8rrelse og kr\u00e6ver ",
-        "ingen antagelser om dataens fordeling \u2014 i mods\u00e6tning til traditionelle kontroldiagram-regler."
+      shiny::div(
+        class = "alert alert-info",
+        shiny::tags$strong("I biSPCharts: "),
+        "Signalboksene viser blandt andet seriel\u00e6ngde og antal kryds. ",
+        "Farvemarkering betyder, at appen har fundet et signal, som b\u00f8r vurderes fagligt."
       ),
-      shiny::tags$div(
-        class = "text-center my-3",
-        shiny::tags$img(
-          src = "www/help/04-anhoej-signal.png",
-          alt = "Diagram med Anh\u00f8j-signal detekteret og value boxes",
-          class = "img-fluid rounded shadow-sm",
-          style = "max-width: 700px;"
-        ),
-        shiny::tags$p(
-          class = "text-muted small mt-1",
-          "Et diagram med detekteret signal. V\u00e6rdiboksene i bunden viser seriel\u00e6ngde og krydsninger."
-        )
+      shiny::tags$p(
+        "Reglerne kr\u00e6ver ikke, at data er normalfordelte. De bliver dog mere meningsfulde, ",
+        "n\u00e5r der er nok datapunkter. Ved meget korte serier skal resultaterne tolkes forsigtigt."
+      ),
+      help_image(
+        "www/help/04-anhoej-signal.png",
+        "Diagram med Anh\u00f8j-signal detekteret og value boxes",
+        "Et diagram med signal. Boksene hj\u00e6lper med at vise, hvilken regel der er udslagsgivende."
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 5: Kontroldiagrammer
+    # Section 6: Control charts
     shiny::tags$section(
       id = "spc-kontrol",
-      shiny::tags$h2("Kontroldiagrammer"),
+      shiny::tags$h2("Kontroldiagrammer og kontrolgr\u00e6nser"),
       shiny::tags$p(
-        "Kontroldiagrammer tilf\u00f8jer ", shiny::tags$strong("kontrolgr\u00e6nser"),
-        " (3-sigma gr\u00e6nser) baseret p\u00e5 dataens naturlige variation. ",
-        "Punkter uden for kontrolgr\u00e6nserne er st\u00e6rke signaler om s\u00e6rlig variation."
+        "Kontroldiagrammer tilf\u00f8jer kontrolgr\u00e6nser omkring midterlinjen. ",
+        "Gr\u00e6nserne beregnes ud fra processens variation og viser, hvor langt man normalt kan forvente, ",
+        "at data varierer, hvis processen er stabil."
       ),
       shiny::tags$p(
-        shiny::tags$strong("Start altid med et seriediagram."),
-        " Brug kontroldiagram n\u00e5r du har brug for at opdage punkter der ligger ",
-        "ekstremt langt fra gennemsnittet."
+        "Punkter uden for kontrolgr\u00e6nserne er st\u00e6rke signaler om s\u00e6rlig variation. ",
+        "De skal ikke bare ignoreres som st\u00f8j, men de skal heller ikke tolkes uden lokal viden."
       ),
-      shiny::tags$h4("Charttyper i appen"),
+      shiny::div(
+        class = "alert alert-light border",
+        shiny::tags$strong("Kontrolgr\u00e6nser er ikke m\u00e5lgr\u00e6nser. "),
+        "Et udviklingsm\u00e5l viser, hvor I gerne vil hen. Kontrolgr\u00e6nser viser, ",
+        "hvad processen naturligt producerer lige nu."
+      ),
+      help_image(
+        "www/help/05-p-chart.png",
+        "P-kort med kontrolgr\u00e6nser",
+        "Et P-kort med kontrolgr\u00e6nser. Punkter uden for gr\u00e6nserne er markeret."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Section 7: Chart chooser
+    shiny::tags$section(
+      id = "spc-chartvalg",
+      shiny::tags$h2("Hvilken charttype skal jeg v\u00e6lge?"),
+      shiny::tags$p(
+        "Start med seriediagram, hvis du er i tvivl. V\u00e6lg derefter en kontrolcharttype, ",
+        "hvis du ved hvilken type data du arbejder med."
+      ),
       shiny::tags$table(
         class = "table table-striped",
         shiny::tags$thead(
           shiny::tags$tr(
             shiny::tags$th("Type"),
             shiny::tags$th("Bruges til"),
+            shiny::tags$th("N\u00e6vner?"),
             shiny::tags$th("Eksempel")
           )
         ),
         shiny::tags$tbody(
           shiny::tags$tr(
             shiny::tags$td("Seriediagram (Run)"),
-            shiny::tags$td("Simpleste type, bruger medianen"),
-            shiny::tags$td("Ethvert m\u00e5l over tid")
+            shiny::tags$td("F\u00f8rste overblik over udvikling over tid"),
+            shiny::tags$td("Valgfrit"),
+            shiny::tags$td("Ventetid eller andel per m\u00e5ned")
           ),
           shiny::tags$tr(
             shiny::tags$td("I-kort"),
-            shiny::tags$td("Individuelle m\u00e5linger"),
-            shiny::tags$td("Ventetid, temperatur")
+            shiny::tags$td("Individuelle m\u00e5linger med kontrolgr\u00e6nser"),
+            shiny::tags$td("Nej"),
+            shiny::tags$td("Liggetid, svartid, score")
           ),
           shiny::tags$tr(
             shiny::tags$td("P-kort"),
-            shiny::tags$td("Andele/procenter (kr\u00e6ver n\u00e6vner)"),
+            shiny::tags$td("Andele og procenter"),
+            shiny::tags$td("Ja"),
             shiny::tags$td("Andel patienter med komplikation")
           ),
           shiny::tags$tr(
-            shiny::tags$td("C-kort"),
-            shiny::tags$td("T\u00e6llinger"),
-            shiny::tags$td("Antal fald per m\u00e5ned")
+            shiny::tags$td("U-kort"),
+            shiny::tags$td("Rater, hvor observationsm\u00e6ngden varierer"),
+            shiny::tags$td("Ja"),
+            shiny::tags$td("Infektioner per 1.000 sengedage")
           ),
           shiny::tags$tr(
-            shiny::tags$td("U-kort"),
-            shiny::tags$td("Rater (kr\u00e6ver n\u00e6vner)"),
-            shiny::tags$td("Infektioner per 1000 plejedage")
+            shiny::tags$td("C-kort"),
+            shiny::tags$td("T\u00e6llinger, n\u00e5r observationsmuligheden er nogenlunde konstant"),
+            shiny::tags$td("Nej"),
+            shiny::tags$td("Antal fald per m\u00e5ned p\u00e5 samme enhed")
           )
         )
       ),
-      shiny::tags$div(
-        class = "text-center my-3",
-        shiny::tags$img(
-          src = "www/help/05-p-chart.png",
-          alt = "P-kort med kontrolgr\u00e6nser",
-          class = "img-fluid rounded shadow-sm",
-          style = "max-width: 700px;"
-        ),
-        shiny::tags$p(
-          class = "text-muted small mt-1",
-          "Et P-kort med kontrolgr\u00e6nser (de stiplede linjer). Punkter uden for gr\u00e6nserne er markeret."
-        )
+      shiny::div(
+        class = "alert alert-light border",
+        shiny::tags$strong("N\u00e6vner i seriediagram: "),
+        "Et seriediagram kan godt bruges med n\u00e6vner, fx hvis du vil vise en andel over tid. ",
+        "N\u00e6vneren er bare ikke p\u00e5kr\u00e6vet for at lave et seriediagram."
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 6: Gode råd
+    # Section 8: App choices
+    shiny::tags$section(
+      id = "spc-appvalg",
+      shiny::tags$h2("M\u00e5l, baseline, skift og frys"),
+      shiny::tags$p(
+        "Nogle af appens valg lyder ens, men de betyder forskellige ting."
+      ),
+      shiny::tags$dl(
+        class = "row",
+        shiny::tags$dt(class = "col-sm-3", "Udviklingsm\u00e5l"),
+        shiny::tags$dd(
+          class = "col-sm-9",
+          "En visuel m\u00e5llinje. Den viser ambitionen, men \u00e6ndrer ikke beregningerne."
+        ),
+        shiny::tags$dt(class = "col-sm-3", "Evt. baseline"),
+        shiny::tags$dd(
+          class = "col-sm-9",
+          "En fast midterlinje, hvis du vil sammenligne mod en kendt v\u00e6rdi."
+        ),
+        shiny::tags$dt(class = "col-sm-3", "Skift"),
+        shiny::tags$dd(
+          class = "col-sm-9",
+          "Markerer kendte proces\u00e6ndringer eller faser i diagrammet."
+        ),
+        shiny::tags$dt(class = "col-sm-3", "Frys"),
+        shiny::tags$dd(
+          class = "col-sm-9",
+          "L\u00e5ser kontrolgr\u00e6nser ud fra en baseline-periode, s\u00e5 senere data sammenlignes med det niveau."
+        )
+      ),
+      shiny::div(
+        class = "alert alert-info",
+        shiny::tags$strong("Praktisk tommelfingerregel: "),
+        "Brug udviklingsm\u00e5l til ambitionen, skift til kendte \u00e6ndringer i processen, ",
+        "og frys n\u00e5r I bevidst vil fastholde en baseline som sammenligningsgrundlag."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Section 9: Interpretation
+    shiny::tags$section(
+      id = "spc-fortolkning",
+      shiny::tags$h2("Fra signal til handling"),
+      shiny::tags$p(
+        "Et SPC-signal er starten p\u00e5 en faglig vurdering - ikke slutningen. ",
+        "Appen kan vise, at et m\u00f8nster er us\u00e6dvanligt, men den kan ikke alene forklare hvorfor."
+      ),
+      shiny::tags$h4("Gode sp\u00f8rgsm\u00e5l n\u00e5r der er signal"),
+      shiny::tags$ul(
+        shiny::tags$li("Skete der en kendt proces\u00e6ndring omkring tidspunktet?"),
+        shiny::tags$li("Er datadefinitionen eller datakilden \u00e6ndret?"),
+        shiny::tags$li("Er signalet klinisk meningsfuldt eller kun statistisk synligt?"),
+        shiny::tags$li("Er forbedringen stabil over tid, eller hviler den p\u00e5 f\u00e5 punkter?"),
+        shiny::tags$li("Hvad ved medarbejdere og ledere om perioden, som diagrammet ikke viser?")
+      ),
+      shiny::tags$p(
+        "N\u00e5r du eksporterer en rapport, b\u00f8r analysen derfor kombinere signalstatus, ",
+        "datadefinition og lokal viden om processen."
+      ),
+      shiny::tags$hr()
+    ),
+
+    # Section 10: Pitfalls
     shiny::tags$section(
       id = "spc-raad",
-      shiny::tags$h2("Gode r\u00e5d"),
+      shiny::tags$h2("Typiske faldgruber"),
       shiny::tags$ul(
         shiny::tags$li(
-          shiny::tags$strong("Start altid med et seriediagram"),
-          " \u2014 det er det simpleste og mest robuste"
+          shiny::tags$strong("For f\u00e5 datapunkter: "),
+          "Meget korte serier kan give usikre signalvurderinger. ",
+          "Brug derfor mindst 12 datapunkter i en serie - og helst 20 eller flere - ",
+          "f\u00f8r signalvurderingen till\u00e6gges stor v\u00e6gt."
         ),
         shiny::tags$li(
-          shiny::tags$strong("Brug mindst 12\u201315 datapunkter"),
-          " for at Anh\u00f8j-reglerne kan detektere signaler p\u00e5lideligt"
+          shiny::tags$strong("Forkert n\u00e6vner: "),
+          "P- og U-kort afh\u00e6nger af en meningsfuld n\u00e6vner."
         ),
         shiny::tags$li(
-          shiny::tags$strong("Marker skift kun ved kendte proces\u00e6ndringer"),
-          " \u2014 ikke ved tilf\u00e6ldig variation"
+          shiny::tags$strong("Data uden tidsorden: "),
+          "SPC handler om proces over tid. R\u00e6kkef\u00f8lgen m\u00e5 ikke v\u00e6re tilf\u00e6ldig."
         ),
         shiny::tags$li(
-          shiny::tags$strong("Lad data tale:"),
-          " undg\u00e5 at overfortolke enkelte punkter eller korte perioder"
+          shiny::tags$strong("For hurtige konklusioner: "),
+          "Et enkelt h\u00f8jt eller lavt punkt er ikke automatisk en forbedring eller forv\u00e6rring."
         ),
         shiny::tags$li(
-          shiny::tags$strong("Vis data som tidsserier,"),
-          " ikke som s\u00f8jlediagrammer eller tabeller \u2014 r\u00e6kkef\u00f8lgen er vigtig"
-        ),
-        shiny::tags$li(
-          shiny::tags$strong("En stabil proces er ikke n\u00f8dvendigvis en god proces"),
-          " \u2014 den er bare forudsigelig"
+          shiny::tags$strong("Skift markeret efter resultatet: "),
+          "Skift b\u00f8r afspejle kendte proces\u00e6ndringer, ikke bruges til at forklare et signal bagefter."
         )
       ),
       shiny::tags$hr()
     ),
 
-    # Sektion 8: Videre læsning
+    # Section 11: Further reading
     shiny::tags$section(
       id = "spc-litteratur",
       shiny::tags$h2("Videre l\u00e6sning"),
+      shiny::tags$p(
+        "Hvis du vil dykke dybere ned i SPC, er disse kilder gode at starte med:"
+      ),
       shiny::tags$ul(
         shiny::tags$li(
           "Anh\u00f8j J. ",
@@ -368,15 +491,6 @@ mod_help_ui <- function(id) {
           shiny::tags$a(
             href = "https://www.anhoej.net/jacob_fag_spc-manifest.html",
             "L\u00e6s manifestet", target = "_blank"
-          )
-        ),
-        shiny::tags$li(
-          "Anh\u00f8j J. ",
-          shiny::tags$em("Det begyndte med \u00f8l \u2014 en kort historie om forbedringsmodellen."),
-          " ",
-          shiny::tags$a(
-            href = "https://www.anhoej.net/jacob_fag_det_begyndte_med_oel.html",
-            "L\u00e6s artikel", target = "_blank"
           )
         )
       )


### PR DESCRIPTION
## What changed

Rewrites the two user-facing help pages:

- `Sådan bruger du appen` is now a practical workflow guide from upload through export, with placeholders and concrete suggestions for screenshots.
- `Lær om SPC` is now a broader introduction to SPC, including variation, run charts, Anhøj rules, control charts, chart type selection, and typical pitfalls.

The wording also aligns with the requested terminology:

- uses `midterlinje` and explains `Nuv. niveau`
- uses `varierer` instead of `svinger`
- uses `Kryds` instead of `Krydsning`
- clarifies that run charts can use a denominator, but do not require one
- adds the rule of thumb: at least 12 points, preferably 20 or more

## Why

The existing help text was more fragmented and less task-oriented. The new text should work better as both a practical UX guide and an introductory SPC guide for users starting with biSPCharts.

## Validation

- `parse('R/mod_help_ui.R'); parse('R/mod_app_guide_ui.R')`
- `tools::showNonASCIIfile('R/mod_help_ui.R'); tools::showNonASCIIfile('R/mod_app_guide_ui.R')`
- Render smoke test for both modules with `htmltools::renderTags()`
- `git diff --check`
- pre-commit checks: 0 lintr issues, styler unchanged
- pre-push fast gate passed