### PR TITLE
fix(ci): install remotes pkg in auto-regen-manifest workflow

### DIFF
--- a/.github/workflows/auto-regen-manifest.yaml
+++ b/.github/workflows/auto-regen-manifest.yaml
@@ -114,7 +114,7 @@ jobs:
         if: steps.check.outputs.deps_changed == 'true'
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rsconnect, any::pkgload, any::renv
+          extra-packages: any::rsconnect, any::pkgload, any::renv, any::remotes
           needs: check
 
       # Explicit install fra DESCRIPTION Remotes med korrekte @tag-refs.


### PR DESCRIPTION
## Summary
- `auto-regen-manifest.yaml` fejlede på develop efter merge af #732
- Workflow kalder `remotes::install_github` men `extra-packages`-listen mangler `any::remotes`
- Runtime: `there is no package called 'remotes'`

## Failure run
https://github.com/johanreventlow/biSPCharts/actions/runs/25735319547

## Fix
Tilføj `any::remotes` til `setup-r-dependencies@v2` extra-packages.

## Sammenhæng med #732
PR #732 bumpede BFHcharts 0.17.1 → 0.17.2 i DESCRIPTION Imports (via `publish_prepare.R install`-step for at fixe manifest-validation). Workflow `auto-regen-manifest.yaml` lytter på DESCRIPTION-ændringer og blev triggered første gang efter merge. Pre-eksisterende config-bug i workflow afsløret nu.

## Test plan
- [ ] CI: workflow fyrer ved næste DESCRIPTION-ændring og lykkes