### PR TITLE
chore(ci): opret develop -> master promote-PR som draft

### DIFF
--- a/.github/workflows/open-master-pr.yaml
+++ b/.github/workflows/open-master-pr.yaml
@@ -152,5 +152,6 @@ jobs:
             --repo "$REPO" \
             --base master \
             --head develop \
+            --draft \
             --title "Promote develop to master" \
             --body "$body"


### PR DESCRIPTION
## Summary

Tilføj `--draft`-flag til `gh pr create`-kald i `.github/workflows/open-master-pr.yaml`. Matcher projektets PR-konvention om at alle PRs oprettes som drafts indtil bruger markerer ready for review.

## Test plan

- [ ] Verificer at næste auto-genererede "Promote develop to master" PR åbnes som draft
- [ ] Bruger kan markere ready manuelt efter review