### PR TITLE
chore(dev): tilføj BFHchartsAssets til dev-helper i run_dev.R

### DIFF
--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -27,10 +27,12 @@
 # remove.packages("BFHcharts")
 # remove.packages("BFHtheme")
 # remove.packages("BFHllm")
+# remove.packages("BFHchartsAssets")
 # 
 # pak::pkg_install(c(
 #   "johanreventlow/BFHtheme",
 #   "johanreventlow/BFHcharts",
+#   "johanreventlow/BFHchartsAssets",
 #   "johanreventlow/BFHllm"))
 
 # ==============================================================================


### PR DESCRIPTION
## Summary

- Udvider auskommenteret `pak::pkg_install`-blok i `dev/run_dev.R` så lokal sibling-reinstall-helper også dækker `BFHchartsAssets`
- Ingen runtime-impact — kun comment-only addition i dev-helper

## Test plan

- [x] Pre-push hooks bestået (lint skipped — ingen R-filer staged ud over dev/-helper)
- [ ] Merge PR → develop
- [ ] Re-trigger `/publish-to-connect` fra develop