### PR TITLE
fix(scaling): respekter eksplicit percent user_unit ved run-chart-target

### DIFF
--- a/R/utils_y_axis_scaling.R
+++ b/R/utils_y_axis_scaling.R
@@ -426,6 +426,23 @@ normalize_axis_value <- function(x, user_unit = NULL, col_unit = NULL,
     return(NULL)
   }
 
+  # Override chart-type default når brugeren eksplicit angiver proportion-familien.
+  # Forhindrer at chart_type="run" (default "absolute") pass-through "1%" som 1
+  # i stedet for 0.01 når y_axis_unit=percent er valgt i UI. Phase 2 design:
+  # uden eksplicit user_unit forbliver run/c/u "absolute" pass-through.
+  proportion_family <- c("percent", "permille", "proportion")
+  has_proportion_user_unit <- !is.null(user_unit) && user_unit %in% proportion_family
+  if (internal_unit == "absolute" && has_proportion_user_unit) {
+    log_debug(
+      paste(
+        "Override internal_unit absolute -> proportion (user_unit:", user_unit,
+        ", symbol:", parsed$symbol, ", chart_type:", chart_type, ")"
+      ),
+      .context = "Y_AXIS_SCALING"
+    )
+    internal_unit <- "proportion"
+  }
+
   # Layer 2: Resolve target unit (with symbol awareness to prevent conflicts)
   target_unit <- resolve_y_unit_smart(user_unit, col_unit, y_sample, parsed)
 

--- a/tests/testthat/test-y-axis-scaling-overhaul.R
+++ b/tests/testthat/test-y-axis-scaling-overhaul.R
@@ -301,6 +301,51 @@ test_that("Priority system works as designed", {
   expect_equal(result_heuristic, 80) # Data suggests percent: 80% → 80 percent
 })
 
+# REGRESSION: chart_type=run må ikke pass-through percent-symbol som absolute -----
+# Bug-rapport 2026-05-16: target ">=1%" på p-chart → 0.01, men ved skift til
+# run-chart blev target opfattet som 1 (100%) i stedet for 0.01.
+# Årsag: determine_internal_unit_by_chart_type("run") returnerer "absolute",
+# hvilket lod to_internal_scale pass-through "1" uden percent→proportion-scaling.
+
+test_that("run-chart respekterer eksplicit percent-symbol i target (regression)", {
+  # User_unit="percent" + symbol "%" må aldrig pass-through som absolute
+  expect_equal(
+    normalize_axis_value("1%", user_unit = "percent", chart_type = "run"),
+    0.01
+  )
+  expect_equal(
+    normalize_axis_value("80%", user_unit = "percent", chart_type = "run"),
+    0.8
+  )
+
+  # Permille pendant
+  expect_equal(
+    normalize_axis_value("10‰", user_unit = "percent", chart_type = "run"),
+    0.01
+  )
+
+  # p-chart skal være uændret (kontrol)
+  expect_equal(
+    normalize_axis_value("1%", user_unit = "percent", chart_type = "p"),
+    0.01
+  )
+
+  # Run + count må ikke ændres af fix (input uden symbol, count-unit)
+  expect_equal(
+    normalize_axis_value("5", user_unit = "count", chart_type = "run"),
+    5
+  )
+})
+
+test_that("run-chart uden user_unit forbliver absolute pass-through (Phase 2)", {
+  # Phase 2 design-kontrakt: uden eksplicit user_unit forbliver run/c/u
+  # "absolute" pass-through. Override sker kun ved user_unit i proportion-familie.
+  expect_equal(
+    normalize_axis_value("80%", chart_type = "run"),
+    80
+  )
+})
+
 # =============================================================================
 # SEKTION 2: Y-AXIS MAPPING (fra test-y-axis-mapping.R)
 # Tests for chart_type_to_ui_type() og decide_default_y_axis_ui_type()


### PR DESCRIPTION
## Summary

- Bug: target ">=1%" satt på p-chart blev opfattet som 1 (100%) i stedet for 0.01 ved skift til run-chart
- Root cause: `determine_internal_unit_by_chart_type("run")` returnerer `"absolute"` → `to_internal_scale` pass-through "1%" som 1
- Fix: override `internal_unit` "absolute"→"proportion" i `normalize_axis_value()` når `user_unit` eksplicit er i proportion-familie (percent/permille/proportion). Phase 2-invariant bevares (uden `user_unit` forbliver run/c/u/i/mr/g/up som absolute pass-through)

## Test plan

- [x] `test-y-axis-scaling-overhaul.R` — 167 pass, 1 skip
- [x] `test-100x-mismatch-prevention.R` — 50 pass (Phase 2-invarianter intakte)
- [x] `test-centerline-handling.R` — 8 pass
- [x] `test-fct_spc_prepare.R` — 22 pass
- [x] Bug-repro: `normalize_axis_value("1%", user_unit="percent", chart_type="run")` → 0.01 ✓
- [ ] **End-to-end smoke**: indlæs SPC-data, p-chart med target ">=1%", skift til run-chart, verificer target-linje ved 1% (ikke 100%)

## Bug-evidens (fra log)

```
[10:31:58] Target parameter included: target_value = 0.01   ← p-chart, target=">=1%"
[10:32:06] Target parameter included: target_value = 1      ← run-chart, samme UI-target ✗
```

Efter fix forbliver `target_value = 0.01` ved chart-type-skift.

## Filer ændret

- `R/utils_y_axis_scaling.R` — override-blok efter Layer 1
- `tests/testthat/test-y-axis-scaling-overhaul.R` — 2 nye test_that-blokke (regression + Phase 2-invariant)