### PR TITLE
fix(report-bug): escape non-ASCII chars i string-literals

### DIFF
--- a/R/config_support.R
+++ b/R/config_support.R
@@ -12,7 +12,7 @@
 
 #' Support-email til bug-rapporter
 #'
-#' Modtager-adresse for bug-rapporter sendt via "Rapportér fejl"-siden.
+#' Modtager-adresse for bug-rapporter sendt via "Rapport\u00e9r fejl"-siden.
 #' Ændring kræver kun opdatering af denne konstant.
 #'
 #' @keywords internal
@@ -42,10 +42,10 @@ SUPPORT_EMAIL_BODY <- paste(
   "Hvad havde du forventet?",
   "[Beskriv hvad du regnede med ville ske]",
   "",
-  "Vedhæft gerne:",
-  "* evt. downloadet kopi af data og indstillinger (gemt til .xlsx fra Analysér-trin eller Eksportér-trin)",
-  "* evt. graf (eksporteret fra Eksportér-fanen)",
-  "* evt. skærmbillede",
+  "Vedh\u00e6ft gerne:",
+  "* evt. downloadet kopi af data og indstillinger (gemt til .xlsx fra Analys\u00e9r-trin eller Eksport\u00e9r-trin)",
+  "* evt. graf (eksporteret fra Eksport\u00e9r-fanen)",
+  "* evt. sk\u00e6rmbillede",
   "",
   "Andre kommentarer:",
   "[Valgfrit]",

--- a/R/mod_report_bug_ui.R
+++ b/R/mod_report_bug_ui.R
@@ -20,35 +20,35 @@ mod_report_bug_ui <- function(id) {
     class = "container-fluid",
     style = "max-width: 900px; margin: 0 auto; padding: 30px 20px;",
     help_back_link(ns),
-    shiny::tags$h1("Rapportér fejl"),
+    shiny::tags$h1("Rapport\u00e9r fejl"),
     shiny::tags$p(
       class = "lead",
       "Oplever du, at noget i biSPCharts ikke virker som forventet? ",
-      "Så hjælper du os meget ved at sende en kort beskrivelse. ",
-      "Du behøver ikke at være teknisk - bare fortæl, hvad du oplevede."
+      "S\u00e5 hj\u00e6lper du os meget ved at sende en kort beskrivelse. ",
+      "Du beh\u00f8ver ikke at v\u00e6re teknisk - bare fort\u00e6l, hvad du oplevede."
     ),
 
     # Section 1: Before you send
     shiny::tags$section(
       shiny::tags$h2("Inden du sender"),
       shiny::tags$p(
-        "Det hjælper os hurtigt at forstå og rette fejlen, hvis du kan vedhæfte:"
+        "Det hj\u00e6lper os hurtigt at forst\u00e5 og rette fejlen, hvis du kan vedh\u00e6fte:"
       ),
       shiny::tags$ul(
         shiny::tags$li(
           shiny::tags$strong("din datafil"),
           " - gem den via ",
-          shiny::tags$em("Eksportér"),
-          "-fanen som Excel og vedhæft .xlsx-filen"
+          shiny::tags$em("Eksport\u00e9r"),
+          "-fanen som Excel og vedh\u00e6ft .xlsx-filen"
         ),
         shiny::tags$li(
           shiny::tags$strong("grafen"),
-          ", du så, da fejlen opstod - gem den også via ",
-          shiny::tags$em("Eksportér"),
+          ", du s\u00e5, da fejlen opstod - gem den ogs\u00e5 via ",
+          shiny::tags$em("Eksport\u00e9r"),
           "-fanen"
         ),
         shiny::tags$li(
-          shiny::tags$strong("et skærmbillede"),
+          shiny::tags$strong("et sk\u00e6rmbillede"),
           " af det, du oplevede, hvis det er relevant ",
           "(Windows: Win+Shift+S, Mac: Cmd+Shift+4)"
         )
@@ -56,8 +56,8 @@ mod_report_bug_ui <- function(id) {
       shiny::div(
         class = "alert alert-info",
         shiny::tags$strong("Hvorfor? "),
-        "Med dit datasæt og grafen kan vi gen-afspille situationen og ",
-        "sikre, at fejlen er rettet, når vi melder tilbage."
+        "Med dit datas\u00e6t og grafen kan vi gen-afspille situationen og ",
+        "sikre, at fejlen er rettet, n\u00e5r vi melder tilbage."
       ),
       shiny::tags$hr()
     ),
@@ -66,18 +66,18 @@ mod_report_bug_ui <- function(id) {
     shiny::tags$section(
       shiny::tags$h2("Hvad er nyttigt at beskrive?"),
       shiny::tags$p(
-        "Skabelonen i mailen guider dig - men kort fortalt hjælper det os, ",
-        "hvis du fortæller:"
+        "Skabelonen i mailen guider dig - men kort fortalt hj\u00e6lper det os, ",
+        "hvis du fort\u00e6ller:"
       ),
       shiny::tags$ul(
         shiny::tags$li("Hvad skete der?"),
         shiny::tags$li("Hvad lavede du, da det skete?"),
         shiny::tags$li("Hvad havde du forventet?"),
-        shiny::tags$li("Skete det én gang, eller hver gang du prøver?")
+        shiny::tags$li("Skete det \u00e9n gang, eller hver gang du pr\u00f8ver?")
       ),
       shiny::tags$p(
         class = "text-muted",
-        "Du behøver ikke at udfylde alt - skriv bare det, du kan huske."
+        "Du beh\u00f8ver ikke at udfylde alt - skriv bare det, du kan huske."
       ),
       shiny::tags$hr()
     ),
@@ -86,9 +86,9 @@ mod_report_bug_ui <- function(id) {
     shiny::tags$section(
       shiny::tags$h2("Send rapporten"),
       shiny::tags$p(
-        "Når du klikker på knappen herunder, åbnes din mail-klient med ",
-        "en færdig skabelon til inspiration. Skriv eller udfyld det du kan, vedhæft gerne din datafil, ",
-        "samt evt. din graf og et skærmbillede, og tryk send."
+        "N\u00e5r du klikker p\u00e5 knappen herunder, \u00e5bnes din mail-klient med ",
+        "en f\u00e6rdig skabelon til inspiration. Skriv eller udfyld det du kan, vedh\u00e6ft gerne din datafil, ",
+        "samt evt. din graf og et sk\u00e6rmbillede, og tryk send."
       ),
       shiny::div(
         class = "text-center my-4",
@@ -97,19 +97,19 @@ mod_report_bug_ui <- function(id) {
           class = "btn btn-primary btn-lg",
           style = "color: #ffffff;",
           shiny::icon("envelope"),
-          " Åbn mail"
+          " \u00c5bn mail"
         )
       ),
       shiny::div(
         class = "alert alert-light border",
         shiny::tags$strong("Virker knappen ikke? "),
-        "Så kan du i stedet sende en mail direkte til ",
+        "S\u00e5 kan du i stedet sende en mail direkte til ",
         shiny::tags$a(
           href = paste0("mailto:", SUPPORT_EMAIL),
           SUPPORT_EMAIL
         ),
-        " - skriv kort, hvad du oplevede, og vedhæft gerne ",
-        "datasæt, graf og skærmbillede."
+        " - skriv kort, hvad du oplevede, og vedh\u00e6ft gerne ",
+        "datas\u00e6t, graf og sk\u00e6rmbillede."
       )
     )
   )


### PR DESCRIPTION
## Summary

- R CMD check WARNING (`error_on = warning`) blokerede gate-job i PR #748 (`Promote develop to master`) fordi UI-strings i `R/config_support.R` og `R/mod_report_bug_ui.R` indeholdt direkte æøå/é.
- Eksisterende pattern i pakken er `\uXXXX`-escapes i kode-strings (jf. `R/app_ui.R` title-felter).
- Roxygen-kommentarer beholder æøå (R CMD check ignorerer kommentarer ifølge CRAN-policy).

## Test plan

- [x] `Rscript -e 'tools::showNonASCIIfile("R/mod_report_bug_ui.R")'` → 0 hits
- [x] `tools::showNonASCIIfile("R/config_support.R")` → kun roxygen-comments (OK)
- [x] `parse()` på begge filer → OK
- [x] `testthat::test_file("tests/testthat/test-mod_report_bug.R")` → 24 PASS, 0 FAIL
- [x] Funktionel decode: `SUPPORT_EMAIL_BODY` indeholder "Vedhæft gerne:" som forventet
- [ ] CI `gate (tests + warnings)` grøn