### PR TITLE
fix(export-ai): skjul hele AI-suggestion-blok naar feature disabled

### DIFF
--- a/R/mod_export_ai.R
+++ b/R/mod_export_ai.R
@@ -42,10 +42,11 @@ register_ai_button_state <- function(session, input, output, app_state) {
     # button hidden. Forhindrer fragile reliance paa CSS-display:none alene.
     ai_enabled <- isTRUE(get_ai_config()$enabled)
     if (!ai_enabled) {
-      shinyjs::hide("ai_generate_suggestion")
+      # Skjul BAADE knap OG helper-tekst som samlet blok naar feature disabled.
+      shinyjs::hide("ai_suggestion_block")
       log_debug(
         .context = "EXPORT_MODULE",
-        message = "AI button hidden: ai.enabled=false in golem-config"
+        message = "AI suggestion block hidden: ai.enabled=false in golem-config"
       )
       return(invisible(NULL))
     }
@@ -63,8 +64,9 @@ register_ai_button_state <- function(session, input, output, app_state) {
     # Button enabled only when all prerequisites met
     can_use_ai <- has_spc_data && api_ready
 
-    # Show + toggle button state
-    shinyjs::show("ai_generate_suggestion")
+    # Show entire block (knap + helper-tekst) naar feature enabled.
+    # toggleState styrer kun knap-state baseret paa data/api-prerequisites.
+    shinyjs::show("ai_suggestion_block")
     shinyjs::toggleState("ai_generate_suggestion", can_use_ai)
 
     # Update tooltip based on state

--- a/R/mod_export_ui.R
+++ b/R/mod_export_ui.R
@@ -227,12 +227,13 @@ mod_export_ui <- function(id) {
                 " Auto-genereret analyse \u2014 rediger for at tilpasse"
               ),
             ),
-            # AI Suggestion Button.
+            # AI Suggestion Block (button + helper text).
             # Cycle G H_NEW (2026-05-09): Synlighed styres af golem-config
             # ai.enabled-flag via register_ai_button_state() (mod_export_ai.R).
-            # Production har enabled=false -> shinyjs::hide() ved boot.
-            # Erstatter tidligere fragile CSS display:none-hide.
+            # Production har enabled=false -> shinyjs::hide(ai_suggestion_block)
+            # ved boot, saa BAADE knap OG helper-tekst skjules samlet.
             shiny::div(
+              id = ns("ai_suggestion_block"),
               shiny::actionButton(
                 ns("ai_generate_suggestion"),
                 label = "Gener\u00e9r forslag med AI",


### PR DESCRIPTION
## Summary

- Tidligere skjulte `register_ai_button_state()` kun selve **knappen** (`ai_generate_suggestion`) ved `ai.enabled=false`. Helper-teksten ("AI kan hjælpe med at formulere ...") forblev synlig og afslørede funktionens eksistens.
- Funktionen er disabled i production-profilen (`inst/golem-config.yml`), så brugere skal ikke kunne se at den findes lige pt.

## Fix

- `R/mod_export_ui.R`: outer div får `id = ns("ai_suggestion_block")` så hele blokken (knap + loading-output + helper-tekst) kan adresseres samlet.
- `R/mod_export_ai.R`: observeren `hide`/`show`'er nu `ai_suggestion_block` i stedet for kun `ai_generate_suggestion`. `toggleState` bevares på knappen for at styre enabled/disabled-state når feature er aktiv.

## Test plan

- [x] `devtools::load_all()` → OK
- [x] `testthat::test_file("tests/testthat/test-mod_export.R")` → 83 PASS, 0 FAIL, 3 SKIP (shinytest2-visual)
- [ ] CI grøn
- [ ] Manuel verifikation i production-profil: hverken knap eller helper-tekst synlig på Eksport-fanen