### PR TITLE
fix(export-preview): eliminer dobbelt PDF preview-render (cycle 11 H1)

### DIFF
--- a/R/mod_export_analysis.R
+++ b/R/mod_export_analysis.R
@@ -100,9 +100,23 @@ register_analysis_autogen <- function(session, input, output, pdf_export_plot, a
       user_has_edited <- nzchar(trimws(current_text)) && current_text != prev_auto
 
       if (!user_has_edited) {
+        # Cycle 11 H1 (Codex 2026-05-16): Saet server-state FOERST. Dette
+        # eliminerer afhaengighed af klient-roundtrip for downstream-consumers
+        # (pdf_preview_image bruger effective_analysis_text() der laeser
+        # last_auto_analysis fra app_state — ej input$pdf_improvement).
         app_state$ui$last_auto_analysis <- auto_text
-        # Sæt suspend-flag FØR updateTextAreaInput så settings_save ikke
-        # gemmer den programmatiske input-ændring som en bruger-ændring.
+
+        # Cycle 11 H1: Skip updateTextAreaInput hvis feltets value allerede
+        # matcher auto_text (fx tab-revisit med uaendret data). Tidligere
+        # sendte vi altid besked til klient, hvilket forarsagede tom
+        # roundtrip + debounced_analysis-invalidering => unoedig preview-
+        # re-render.
+        if (identical(current_text, auto_text)) {
+          return()
+        }
+
+        # Saet suspend-flag FOER updateTextAreaInput saa settings_save ikke
+        # gemmer den programmatiske input-aendring som en bruger-aendring.
         # onFlushed(once=TRUE) rydder flaget efter Shiny har flushet
         # updateTextAreaInput-beskeden til klienten.
         set_autogen_active(app_state, TRUE)

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -362,7 +362,20 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       dept_input <- shiny::isolate(input$export_department)
       # Analyse, datadefinition og hospital er debounced reactives (1000ms)
       # saa preview opdateres naar brugeren stopper med at skrive
-      analysis_input <- debounced_analysis()
+      #
+      # Cycle 11 H1 (Codex 2026-05-16): Brug effective-analysis-pattern.
+      # Tidligere lyttede preview KUN paa input$pdf_improvement (debounced),
+      # hvilket forarsagede dobbelt-render ved tab-skift med ny data:
+      #   1) Preview render FOERST med tom analyse-tekst
+      #   2) Autogen-observer kalder updateTextAreaInput med auto-tekst
+      #   3) Klient-roundtrip + debounce 1500ms => preview re-render
+      # Fix: prefer app_state$ui$last_auto_analysis (server-state sat synkront
+      # af autogen-observer) over debounced_analysis. Brug input-vaerdien KUN
+      # hvis bruger har redigeret (input differerer fra auto-tekst).
+      analysis_input <- compute_effective_analysis_text(
+        user_text = debounced_analysis(),
+        auto_text = app_state$ui$last_auto_analysis %||% ""
+      )
       data_def_input <- debounced_data_def()
       hospital_input <- debounced_hospital()
       footnote_input <- trimws(debounced_footnote())

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -295,3 +295,37 @@ build_export_plot <- function(app_state, title_input, dept_input,
     error_type = "processing"
   )
 }
+
+#' Beregn effektiv analyse-tekst til PDF-preview
+#'
+#' Cycle 11 H1 (Codex peer-review 2026-05-16): Helper der vaelger mellem
+#' bruger-redigeret tekst og auto-genereret analyse-tekst. Tidligere lyttede
+#' pdf_preview_image-reactive direkte paa input$pdf_improvement (debounced),
+#' hvilket forarsagede dobbelt-render ved tab-skift med ny data:
+#' (1) Preview rendres FOERST med tom analyse-tekst.
+#' (2) Autogen-observer kalder updateTextAreaInput med auto-tekst.
+#' (3) Klient-roundtrip + debounce 1500ms udloeser preview-re-render.
+#'
+#' Helperen bruger app_state$ui$last_auto_analysis (server-state sat synkront
+#' af autogen-observer) som primaer kilde og falder kun tilbage til
+#' input-vaerdien hvis brugeren faktisk har redigeret feltet.
+#'
+#' @param user_text character. Bruger-input (typisk debounced_analysis()).
+#' @param auto_text character. Auto-genereret tekst fra
+#'   app_state$ui$last_auto_analysis.
+#'
+#' @return character. Effektiv analyse-tekst til preview-rendering.
+#'   Returnerer user_text kun hvis non-empty + differer fra auto_text;
+#'   ellers returnerer auto_text.
+#'
+#' @keywords internal
+compute_effective_analysis_text <- function(user_text, auto_text) {
+  user_text <- user_text %||% ""
+  auto_text <- auto_text %||% ""
+  if (nzchar(trimws(user_text)) &&
+    !identical(trimws(user_text), trimws(auto_text))) {
+    user_text
+  } else {
+    auto_text
+  }
+}

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -337,6 +337,14 @@ files:
   reviewed: yes
   reviewer: johanreventlow
   reviewed_date: '2026-04-17'
+- file: test-export-effective-analysis.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-16'
+  rationale: Regression-test for cycle 11 H1 compute_effective_analysis_text helper — tilfoejet manuelt.
 - file: test-export-footnote.R
   audit_category: green
   type: unit

--- a/tests/testthat/test-export-effective-analysis.R
+++ b/tests/testthat/test-export-effective-analysis.R
@@ -1,0 +1,81 @@
+# test-export-effective-analysis.R
+# Regression-tests for cycle 11 H1 (Codex peer-review 2026-05-16):
+# compute_effective_analysis_text() vaelger mellem bruger-redigeret tekst
+# og auto-genereret analyse-tekst. Eliminerer dobbelt preview-render-bug
+# hvor pdf_preview_image lyttede direkte paa debounced input.
+
+test_that("compute_effective_analysis_text returner auto_text naar user_text er tom", {
+  expect_identical(compute_effective_analysis_text("", "Auto-tekst"), "Auto-tekst")
+  expect_identical(compute_effective_analysis_text(NULL, "Auto-tekst"), "Auto-tekst")
+  expect_identical(compute_effective_analysis_text("   ", "Auto-tekst"), "Auto-tekst")
+})
+
+test_that("compute_effective_analysis_text returnerer auto_text naar user_text matcher", {
+  # Foreliggende-state: bruger har ikke redigeret (input matcher auto).
+  # Preview boer bruge auto-tekst (deterministisk fra server-state).
+  expect_identical(
+    compute_effective_analysis_text("Auto-tekst", "Auto-tekst"),
+    "Auto-tekst"
+  )
+  # Trim-tolerance: trailing whitespace fra klient-side regnes som no-edit.
+  expect_identical(
+    compute_effective_analysis_text("Auto-tekst   ", "Auto-tekst"),
+    "Auto-tekst"
+  )
+  expect_identical(
+    compute_effective_analysis_text("  Auto-tekst", "  Auto-tekst"),
+    "  Auto-tekst"
+  )
+})
+
+test_that("compute_effective_analysis_text returnerer user_text naar bruger har redigeret", {
+  # Bruger har redigeret pdf_improvement-feltet. Preview boer bruge bruger-tekst.
+  expect_identical(
+    compute_effective_analysis_text("Manuel rettelse", "Auto-tekst"),
+    "Manuel rettelse"
+  )
+})
+
+test_that("compute_effective_analysis_text handterer begge NULL/empty graceful", {
+  expect_identical(compute_effective_analysis_text(NULL, NULL), "")
+  expect_identical(compute_effective_analysis_text("", ""), "")
+  expect_identical(compute_effective_analysis_text(NULL, ""), "")
+  expect_identical(compute_effective_analysis_text("", NULL), "")
+})
+
+test_that("compute_effective_analysis_text dispatcher korrekt mellem user/auto efter tab-skift-flow", {
+  # Simulér tab-skift-flow:
+  # T0: tab-skift, auto-tekst endnu ej genereret
+  state_t0 <- list(user = "", auto = "")
+  expect_identical(
+    compute_effective_analysis_text(state_t0$user, state_t0$auto),
+    ""
+  )
+
+  # T1: autogen-observer satte last_auto_analysis. user-input endnu tom.
+  state_t1 <- list(user = "", auto = "Processen udviser ustabilitet...")
+  expect_identical(
+    compute_effective_analysis_text(state_t1$user, state_t1$auto),
+    "Processen udviser ustabilitet..."
+  )
+
+  # T2: klient-roundtrip lander input-update (samme som auto).
+  state_t2 <- list(
+    user = "Processen udviser ustabilitet...",
+    auto = "Processen udviser ustabilitet..."
+  )
+  expect_identical(
+    compute_effective_analysis_text(state_t2$user, state_t2$auto),
+    "Processen udviser ustabilitet..."
+  )
+
+  # T3: bruger redigerer manuelt.
+  state_t3 <- list(
+    user = "Min egen tolkning af mønstret",
+    auto = "Processen udviser ustabilitet..."
+  )
+  expect_identical(
+    compute_effective_analysis_text(state_t3$user, state_t3$auto),
+    "Min egen tolkning af mønstret"
+  )
+})


### PR DESCRIPTION
## Summary

- **Performance-fix:** PDF preview rendres 2x ved navigation til eksport-tab med ny data — ~3 sek wasted + synlig flicker.
- **Root cause:** \`pdf_preview_image\` lyttede paa \`input\$pdf_improvement\` (debounced). Foerste render skete FOER \`register_analysis_autogen()\` havde sendt auto-tekst via \`updateTextAreaInput\`. Klient-roundtrip + 1500ms debounce udloeste 2. render.
- **Fix (recalibreret per Codex peer-review):**
  - Skip \`updateTextAreaInput\` hvis \`current_text == auto_text\` (eliminerer tab-revisit-roundtrip)
  - Ny helper \`compute_effective_analysis_text(user_text, auto_text)\` — preview bruger \`app_state\$ui\$last_auto_analysis\` (server-state) som primaer kilde, falder kun tilbage til input hvis bruger har redigeret

## Context

Codex afviste oprindelig fix-recipe \`req(!is_autogen_active(app_state))\`:
\`is_autogen_active()\` bruger \`shiny::isolate()\`, saa flag-aendring invaliderer
IKKE reactive-dependents. Identisk auto-text ved tab-revisit ville have blokeret
preview permanent.

Refs: \`docs/reviews/11-export-preview-ineffektivitet.md\` H1

## Test plan

- [x] Regression-test: \`tests/testthat/test-export-effective-analysis.R\` (15 pass)
  - Tom user_text → auto_text
  - User-text matches auto → auto_text (no-edit case)
  - User-text differer → user_text (user-edit case)
  - Tab-skift-flow T0-T3
  - NULL/empty graceful handling
- [x] No-regression: \`test-mod_export.R\` (8 pass, 3 skip browser-only)
- [x] No-regression: \`test-utils-export-analysis-metadata.R\` (39 pass)
- [x] No-regression: \`test-utils_server_export.R\` (11 pass, 3 skip reactive-only)
- [ ] Manual verifikation: navigation til eksport-tab med ny data — preview rendres ÉN gang, ej 2x