### PR TITLE
fix(sample-data): ret U-kort label til 'pr. indlaeggelse'

### DIFF
--- a/R/config_sample_data.R
+++ b/R/config_sample_data.R
@@ -60,8 +60,8 @@ SAMPLE_DATASETS <- list(
   # ),
   list(
     id = "u",
-    label = "U-kort \u2014 Medicineringsfejl pr. 1000",
-    description = "Rate af medicineringsfejl per 1000 indl\u00e6ggelser",
+    label = "U-kort \u2014 Medicineringsfejl pr. indl\u00e6ggelse",
+    description = "Rate af medicineringsfejl per indl\u00e6ggelse",
     file = "sample_u.csv",
     chart_type = "u"
   ),


### PR DESCRIPTION
## Summary

Codex peer-review 2026-05-16 sen sen fandt diskrepans mellem U-kort sample-data-label og faktisk pipeline-adfaerd.

**Problem:** \`SAMPLE_DATASETS["u"]\` label sagde "pr. 1000" men appen normaliserer IKKE til pr. 1000. Pipeline kalder BFHcharts med \`y_axis_unit="rate"\` (ej rate_1000). Faktisk vist: 8 medicineringsfejl / 310 indlaeggelser = 0.0258 (per 1 indlaeggelse). Lovet: 25.8 per 1000.

Faktor 1000 diskrepans → misvisende for kliniske brugere.

**Fix:** Ret label + description til "pr. indlaeggelse" — matcher faktisk skalering.

Andre sample-datasaet (p, run, c, i) verificeret konsistente jf. Codex.

## Test plan

- [x] grep verificeret: ingen andre forekomster af gammel label
- [x] Y_AXIS_UI_TYPES_DA eksponerer ej rate_1000 i UI (verificeret config_spc_config.R:113-120) → ingen anden fix kraevet
- [ ] Manuel: load U-sample, verificer plot-titel + y-axis-label viser "Medicineringsfejl pr. indlaeggelse"