### PR TITLE
fix(export-pdf): bevar operator-direction paa metadata$target

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,22 @@
 
 ## Bug fixes
 
+* PDF-analysetekst respekterer nu retning på operator-targets (fx
+  `<=1%`, `>=90%`) og arrow-only targets (`<`, `>`). Tidligere shadowede
+  `build_export_analysis_metadata()` BFHcharts' `config$target_text` ved
+  at sende numerisk `target_value` som `metadata$target`. BFHcharts'
+  `.resolve_analysis_target()` foretrækker metadata-feltet, så
+  operator-information forsvandt og analysen faldt til værdi-neutral
+  "ligger tæt på udviklingsmålet" — selvom CL lå på forkert side, eller
+  selvom brugeren slet ikke havde angivet en målværdi (arrow-only).
+  Fix: send `target_text`-strengen (når til stede) som `metadata$target`
+  så BFHcharts kan udlede direction og vælge `near_target.detailed`
+  ("ligger lige over/under udviklingsmålet") eller `stable_no_target`
+  ("Overvej, om et udviklingsmål kan fastsættes…") afhængigt af om
+  brugeren har givet en målværdi. Samtidig strammes
+  `compute_at_target()`-tolerancen fra `max(target*0.05, 0.01)` til ren
+  `target*0.05` (relativ 5%); det absolutte floor på 0.01 betød at
+  proportion-targets klassificerede 100%-relativ afvigelse som "tæt nok".
 * Cache-key for SPC-beregning resolver nu reactive `chart_title` til
   string FØR hashing. Tidligere passerede analysis-tab en
   `shiny::reactive`-function-objekt der hashede som reference uafhængigt

--- a/R/utils_export_analysis_metadata.R
+++ b/R/utils_export_analysis_metadata.R
@@ -60,7 +60,11 @@ compute_at_target <- function(centerline, target_value, target_text = NULL) {
   }
 
   target_label <- trimws(target_text %||% "")
-  tolerance <- max(abs(target_value) * 0.05, 0.01)
+  # Relativ tolerance uden absolut floor. Floor pa 0.01 var meningslost for
+  # proportion-targets (target=0.01 gav tolerance=0.01 = 100% af target), saa
+  # enhver centerlinje inden for +/-100% blev klassificeret som at_target.
+  # Fix: ren 5%-relativ tolerance + lille epsilon-floor mod target=0-edge.
+  tolerance <- max(abs(target_value) * 0.05, 1e-9)
   close_enough <- abs(centerline - target_value) <= tolerance
 
   if (grepl("^\\s*(>|>=|\u2265|\u2191)", target_label)) {
@@ -155,9 +159,23 @@ build_export_analysis_metadata <- function(bfh_qic_result,
     !is.null(centerline_raw) &&
     !is.na(centerline_raw)
 
+  # Foretraek operator-string (fx "<=1%") fremfor numerisk vaerdi som
+  # metadata$target. BFHcharts' .resolve_analysis_target() bruger
+  # metadata$target FOER config$target_text, saa hvis vi sender numerisk
+  # taber vi operator-information og resolve_target() returnerer
+  # direction = NULL. Det fanger BFHcharts ikke som near_target-scenarie
+  # paa "forkert side af target inden for proces-stoej" og falder tilbage
+  # til vaerdi-neutral at_target-tekst ("ligger taet paa udviklingsmaalet")
+  # i stedet for "ligger lige over/under udviklingsmaalet".
+  metadata_target <- if (nzchar(normalized_target_text)) {
+    normalized_target_text
+  } else {
+    normalized_target_value
+  }
+
   list(
     data_definition = data_definition %||% "",
-    target = normalized_target_value,
+    target = metadata_target,
     target_display = format_analysis_context_value(normalized_target_value, y_axis_unit),
     chart_title = chart_title %||% "",
     department = normalized_department,

--- a/tests/testthat/test-utils-export-analysis-metadata.R
+++ b/tests/testthat/test-utils-export-analysis-metadata.R
@@ -36,7 +36,9 @@ test_that("build_export_analysis_metadata enriches context with BFHddl-like fiel
   )
 
   expect_equal(metadata$data_definition, "Ventetid til operation")
-  expect_equal(metadata$target, 10)
+  # Foretraek operator-string fremfor numerisk vaerdi som metadata$target
+  # saa BFHcharts kan parse direction (#TBD).
+  expect_equal(metadata$target, "< 10")
   expect_equal(metadata$chart_title, "Ventetid 2026")
   expect_equal(metadata$department, "Ortopædkirurgi")
   expect_equal(metadata$centerline, "12,4")
@@ -302,4 +304,80 @@ test_that("build_export_analysis_metadata defaulter baseline_analysis + signal_e
 
   expect_equal(metadata$baseline_analysis, "")
   expect_equal(metadata$signal_examples, "")
+})
+
+# ============================================================================
+# Regression: target-direction-shadowed-in-analysis-metadata (#TBD)
+#
+# Bug: numerisk metadata$target shadowede config$target_text i BFHcharts'
+# .resolve_analysis_target(). resolve_target(0.01) returnerede
+# direction = NULL og analysen faldt til vaerdi-neutral at_target-tekst
+# ("ligger taet paa udviklingsmaalet") selvom brugeren havde skrevet "<=1%"
+# og centerlinjen var paa forkert side af maalet.
+#
+# Fix: send target_text-strengen (operator + value) som metadata$target
+# saa BFHcharts kan parse retning og vaelge near_target-tekst korrekt.
+# ============================================================================
+
+test_that("build_export_analysis_metadata sender target_text som metadata$target (#TBD)", {
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 0.019, y_axis_unit = "percent"),
+    target_value = 0.01,
+    target_text = "<=1%"
+  )
+  expect_identical(metadata$target, "<=1%",
+    info = "metadata$target skal bevare operator-streng saa BFHcharts kan udlede direction"
+  )
+})
+
+test_that("build_export_analysis_metadata fallbacker til numerisk target naar target_text mangler (#TBD)", {
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 50, y_axis_unit = "count"),
+    target_value = 42,
+    target_text = NULL
+  )
+  expect_identical(metadata$target, 42)
+})
+
+test_that("compute_at_target afviser CL paa forkert side af target uden for relativ tolerance (#TBD)", {
+  # Bug-scenarie: target <=1% (0.01) og CL 1.9% (0.019).
+  # Tidligere: tolerance = max(0.0005, 0.01) = 0.01 (= 100% af target) ->
+  # close_enough = TRUE -> at_target = TRUE selvom 0.019 > 0.01.
+  # Fix: tolerance = 0.0005 (5% af target), |0.019-0.01| = 0.009 > 0.0005
+  # -> close_enough = FALSE -> lower-branch: 0.019 <= 0.01 = FALSE.
+  result <- compute_at_target(
+    centerline = 0.019,
+    target_value = 0.01,
+    target_text = "<=1%"
+  )
+  expect_false(result,
+    info = "CL=1.9% er ikke 'taet nok' paa target=1% (90% relativ afvigelse)"
+  )
+})
+
+test_that("compute_at_target accepterer CL inden for 5% relativ tolerance (#TBD)", {
+  # target=0.01, CL=0.0103 -> delta=0.0003 < tolerance=0.0005 -> close_enough=TRUE
+  result <- compute_at_target(
+    centerline = 0.0103,
+    target_value = 0.01,
+    target_text = "<=1%"
+  )
+  expect_true(result)
+})
+
+test_that("build_export_analysis_metadata sender operator-streng for arrow-only target (#TBD)", {
+  # SPC-47 scenarie: bruger satte kun "<" i target-feltet (retning uden vaerdi).
+  # biSPCharts UI saetter target_value = 0 (dummy) + target_text = "<".
+  # Tidligere blev metadata$target = 0 (numerisk) -> BFHcharts laeste
+  # target_value=0 og rapporterede "ligger taet paa udviklingsmaalet (0%)".
+  # Fix: metadata$target = "<" (string) -> BFHcharts' resolve_target()
+  # parser arrow -> value=NA -> has_target=FALSE -> stable_no_target-armen.
+  metadata <- build_export_analysis_metadata(
+    bfh_qic_result = make_bfh_result_with_anhoej(centerline = 0.019, y_axis_unit = "percent"),
+    target_value = 0,
+    target_text = "<"
+  )
+  expect_identical(metadata$target, "<",
+    info = "Arrow-only target skal videregives som streng saa BFHcharts kan udlede direction-uden-vaerdi"
+  )
 })


### PR DESCRIPTION
## Summary

- `build_export_analysis_metadata()` sendte numerisk `target_value` som `metadata$target`. BFHcharts' `.resolve_analysis_target()` foretrækker metadata-feltet over `config$target_text`, så operator-information (`<=1%`, `>=90%`, `<`, `>`) forsvandt og analyseteksten faldt til værdi-neutral "ligger tæt på udviklingsmålet (X%)" — selv når CL lå på forkert side eller brugeren slet ikke havde sat en målværdi.
- Fix: send `target_text`-strengen (når til stede) som `metadata$target` så BFHcharts kan udlede direction og vælge `near_target.detailed` ("ligger lige over/under udviklingsmålet") eller `stable_no_target.detailed` ("Overvej, om et udviklingsmål kan fastsættes…") afhængigt af om der er en målværdi.
- Ekstra: stram `compute_at_target()`-tolerance fra `max(target*0.05, 0.01)` til ren `target*0.05`. Det absolutte floor på 0.01 betød at proportion-targets klassificerede 100%-relativ afvigelse som "tæt nok" (target=0.01 + CL=0.019 → tolerance=0.01 → at_target=TRUE).

## Repro

**SPC-46** (`<=1%`, CL=1.9%):
- Før: "Det nuværende niveau på 2% ligger tæt på udviklingsmålet (1%). Fortsæt med praksis som hidtil…"
- Efter: "Det nuværende niveau på 1,9% ligger lige over udviklingsmålet (≤1%). Overvej, om forbedring er nødvendig…"

**SPC-47** (arrow-only `<`, CL=1.9%):
- Før: "Det nuværende niveau på 2% ligger tæt på udviklingsmålet (0%). Fortsæt med praksis som hidtil…"
- Efter: "[ingen target-tekst]. Overvej, om et udviklingsmål kan fastsættes…"

E2E-verificeret via `BFHcharts::bfh_generate_analysis()`-kald — begge scenarier producerer korrekt tekst nu.

## Test plan

- [x] 44/44 tests passerer i `test-utils-export-analysis-metadata.R`
- [x] 9/9 tests passerer i `test-export-footnote.R` (anden konsument af `build_export_analysis_metadata`)
- [x] E2E-verificeret med rigtigt `bfh_qic()`-kald + `BFHcharts::bfh_generate_analysis()` for begge SPC-46- og SPC-47-scenarier
- [x] Regression-tests dækker primary fix (operator-string + arrow-only) og extra fix (tolerance)
- [ ] Manuel verifikation via biSPCharts UI: indtast `<=1%` i target-felt, generér PDF, bekræft "lige over udviklingsmålet"-tekst
- [ ] Manuel verifikation via UI: indtast kun `<` i target-felt, generér PDF, bekræft "Overvej, om et udviklingsmål kan fastsættes"-tekst