### PR TITLE
fix(logger): defensiv kolonne-klasse-lookup i call_bfh_chart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,18 @@
 
 ## Bug fixes
 
+* Defensiv kolonne-klasse-lookup i `call_bfh_chart()`-logging
+  forhindrer at log_debug-build kaster når `bfh_params$n` (eller
+  x/y) er malformed opstrøms (fx en row-vektor i stedet for et
+  length-1 symbol). Tidligere blev sådanne fejl fanget af
+  `.safe_collapse()` og rapporteret som
+  `<COLLAPSE_ERROR: Can't extract column with n_col_name. Subscript
+  n_col_name must be size 1, not 24.>` — hvilket maskerede den ægte
+  rendering-fejl bag en generisk wrap. Ny `.safe_col_class()`-helper
+  returnerer altid en streng (`<NULL>`, `<INVALID_COL_NAME: length=N>`,
+  `<MISSING_COL: ...>` eller `<CLASS_ERROR: ...>`), så root-cause
+  propagerer uden at brake logging-pipelinen. Observeret i cycle 11
+  post-merge session 2026-05-16.
 * PDF-analysetekst respekterer nu retning på operator-targets (fx
   `<=1%`, `>=90%`) og arrow-only targets (`<`, `>`). Tidligere shadowede
   `build_export_analysis_metadata()` BFHcharts' `config$target_text` ved

--- a/R/fct_spc_bfh_invocation.R
+++ b/R/fct_spc_bfh_invocation.R
@@ -6,6 +6,28 @@
 # - Error handling og graceful degradation
 # - Diagnostisk logging
 
+# Defensiv kolonne-klasse-lookup for diagnostisk logging. Returnerer altid
+# en streng. Forhindrer at log_debug-build (paste()) propagerer fejl naar
+# col_name ej er en valid length-1 kolonne-reference — fx hvis bfh_params$n
+# er overskrevet med en row-vektor opstroems. Tidligere blev saadanne fejl
+# fanget af .safe_collapse og rapporteret som <COLLAPSE_ERROR: ...>, hvilket
+# maskerede ægte rendering-fejl bag generisk wrap.
+.safe_col_class <- function(data, col_name) {
+  if (is.null(col_name)) {
+    return("<NULL>")
+  }
+  if (length(col_name) != 1L) {
+    return(sprintf("<INVALID_COL_NAME: length=%d>", length(col_name)))
+  }
+  if (!col_name %in% names(data)) {
+    return(sprintf("<MISSING_COL: %s>", col_name))
+  }
+  tryCatch(
+    class(data[[col_name]])[1],
+    error = function(e) paste0("<CLASS_ERROR: ", conditionMessage(e), ">")
+  )
+}
+
 call_bfh_chart <- function(bfh_params) {
   # H5 (#451): Pre-condition validation kaster typed spc_render_error
   # direkte. Tidligere brugte safe_operation + base stop() — fejlene
@@ -86,9 +108,16 @@ call_bfh_chart <- function(bfh_params) {
     log_debug(
       paste(
         "BFHcharts data types:",
-        "x(", x_col_name, ")=", class(bfh_params_clean$data[[x_col_name]])[1],
-        ", y(", y_col_name, ")=", class(bfh_params_clean$data[[y_col_name]])[1],
-        if (!is.null(n_col_name)) paste0(", n(", n_col_name, ")=", class(bfh_params_clean$data[[n_col_name]])[1]) else ""
+        "x(", x_col_name, ")=", .safe_col_class(bfh_params_clean$data, x_col_name),
+        ", y(", y_col_name, ")=", .safe_col_class(bfh_params_clean$data, y_col_name),
+        if (!is.null(n_col_name)) {
+          paste0(
+            ", n(", paste(n_col_name, collapse = ","), ")=",
+            .safe_col_class(bfh_params_clean$data, n_col_name)
+          )
+        } else {
+          ""
+        }
       ),
       .context = "BFH_SERVICE"
     )

--- a/tests/testthat/test-fct_spc_bfh_invocation.R
+++ b/tests/testthat/test-fct_spc_bfh_invocation.R
@@ -92,3 +92,46 @@ test_that("call_bfh_chart wraps non-spc BFHcharts errors as typed render errors"
   expect_equal(err$details$original_class, "simpleError")
   expect_equal(err$details$chart_type, "run")
 })
+
+test_that(".safe_col_class haandterer ugyldige col-references uden crash", {
+  require_internal(".safe_col_class", mode = "function")
+  df <- data.frame(a = 1:3, b = letters[1:3])
+
+  expect_equal(.safe_col_class(df, "a"), "integer")
+  expect_equal(.safe_col_class(df, "b"), class(df$b)[1])
+  expect_equal(.safe_col_class(df, NULL), "<NULL>")
+  expect_match(.safe_col_class(df, c("a", "b")), "<INVALID_COL_NAME: length=2>")
+  expect_match(.safe_col_class(df, rep("a", 24)), "<INVALID_COL_NAME: length=24>")
+  expect_match(.safe_col_class(df, "missing"), "<MISSING_COL: missing>")
+})
+
+test_that("call_bfh_chart logging survives malformed n parameter (root-cause exposed)", {
+  skip_if_not_installed("BFHcharts")
+  require_internal("call_bfh_chart", mode = "function")
+
+  # Simulerer opstroems bug: bfh_params$n er en row-vektor (length > 1)
+  # i stedet for et single-symbol. Tidligere kastede log_debug-build en
+  # tibble subscript-fejl der blev fanget af .safe_collapse og rapporteret
+  # som <COLLAPSE_ERROR: ...> — maskerede ægte rendering-fejl.
+  malformed_params <- c(
+    minimal_bfh_params(),
+    list(n = as.character(1:24))
+  )
+
+  with_mocked_bindings(
+    bfh_qic = function(...) {
+      structure(list(qic_data = data.frame(x = 1), plot = NULL),
+        class = "bfh_qic_result"
+      )
+    },
+    is_bfh_qic_result = function(x) inherits(x, "bfh_qic_result"),
+    .package = "BFHcharts",
+    code = {
+      # Forventning: ingen crash, logging fanger length-24 og rapporterer
+      # <INVALID_COL_NAME: length=24> uden at brake call_bfh_chart-flow.
+      result <- call_bfh_chart(malformed_params)
+    }
+  )
+
+  expect_s3_class(result, "bfh_qic_result")
+})


### PR DESCRIPTION
## Summary

- Ny `.safe_col_class()`-helper i `R/fct_spc_bfh_invocation.R` returnerer altid en streng (4 edge cases: NULL, length>1, missing-col, generel class()-fejl)
- Refaktor af `log_debug`-build i `call_bfh_chart()` til at bruge helperen — forhindrer at logging-pipelinen kaster ved malformed `bfh_params$n`
- Eksponerer root-cause i stedet for at maskere bag `<COLLAPSE_ERROR: ...>`-wrap

## Kontekst

Fejl observeret i cycle 11 post-merge session 2026-05-16 (`docs/reviews/11-export-preview-ineffektivitet.md:423`):

```
<COLLAPSE_ERROR: Can't extract column with `n_col_name`.
Subscript `n_col_name` must be size 1, not 24.>
```

Fejlen fyrede ved hvert `bfh_qic`-kald uden `n_var` på i-chart. Root-cause ej reproducerbar i HEAD med standard scenarier (4 repro-attempts), så fix targets **logger-defekten** der maskerede den ægte fejl. Hvis bug fortsætter i runtime, vil næste session vise root-cause via det normale `tryCatch`-flow på BFHcharts-kaldet (`spc_render_error` med original besked).

## Test plan

- [x] 11/11 testthat-tests i `test-fct_spc_bfh_invocation.R` passerer (incl. 2 nye)
- [x] `test-spc-bfh-service.R` ingen regression (alle pass, 2 forventede skips)
- [x] `lintr::lint("R/fct_spc_bfh_invocation.R")` — No lints found
- [x] Pre-push hook (fast-mode) grøn
- [ ] Manuel runtime-verifikation: trigger i-chart-flow i app, bekræft at `<COLLAPSE_ERROR>` ej vises i session-log
- [ ] Hvis underliggende root-cause stadig manifesterer: følg op med separat issue mod BFHcharts med ny stack trace

## Affected files

- `R/fct_spc_bfh_invocation.R` (+30 / -3)
- `tests/testthat/test-fct_spc_bfh_invocation.R` (+42)
- `NEWS.md` (+12)