### PR TITLE
fix(logger): eliminer partial-match-bug paa bfh_params$n

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,15 @@
 
 ## Bug fixes
 
+* Eliminer root-cause for cycle 11 COLLAPSE_ERROR i
+  `call_bfh_chart()`-logging: brug `bfh_params_clean[["n"]]` i stedet
+  for `$n`. R's `$`-operator udfører partial-matching og returnerede
+  `notes`-vektoren (length=nrow) når `n` ikke findes som key, hvilket
+  brød `class(data[[n_col_name]])`-lookup i log_debug-build. `[[`-form
+  er strict og returnerer NULL ved manglende key. Følger op på
+  defensiv `.safe_col_class()`-fix; eliminerer `<INVALID_COL_NAME:
+  length=N>`-støj i debug-output ved chart-typer der har notes-kolonne
+  men ingen denominator.
 * Defensiv kolonne-klasse-lookup i `call_bfh_chart()`-logging
   forhindrer at log_debug-build kaster når `bfh_params$n` (eller
   x/y) er malformed opstrøms (fx en row-vektor i stedet for et

--- a/R/fct_spc_bfh_invocation.R
+++ b/R/fct_spc_bfh_invocation.R
@@ -101,9 +101,18 @@ call_bfh_chart <- function(bfh_params) {
     )
   }
   if (!is.null(bfh_params_clean$data)) {
+    # NB: Brug [["n"]] ej $n. R's $-operator udfoerer partial-matching:
+    # bfh_params_clean$n matcher "notes" hvis "n" ikke findes, hvilket
+    # returnerer notes-vektoren (length nrow) som n_col_name og trigger
+    # COLLAPSE_ERROR i log_debug-build via tibble [[-validator.
+    # [["n"]] er strict og returnerer NULL ved manglende key.
     x_col_name <- as.character(bfh_params_clean$x)
     y_col_name <- as.character(bfh_params_clean$y)
-    n_col_name <- if (!is.null(bfh_params_clean$n)) as.character(bfh_params_clean$n) else NULL
+    n_col_name <- if (!is.null(bfh_params_clean[["n"]])) {
+      as.character(bfh_params_clean[["n"]])
+    } else {
+      NULL
+    }
 
     log_debug(
       paste(

--- a/tests/testthat/test-fct_spc_bfh_invocation.R
+++ b/tests/testthat/test-fct_spc_bfh_invocation.R
@@ -105,6 +105,52 @@ test_that(".safe_col_class haandterer ugyldige col-references uden crash", {
   expect_match(.safe_col_class(df, "missing"), "<MISSING_COL: missing>")
 })
 
+test_that("call_bfh_chart logging ej partial-matcher notes til n via $-operator", {
+  skip_if_not_installed("BFHcharts")
+  require_internal("call_bfh_chart", mode = "function")
+
+  # Root-cause for cycle 11 COLLAPSE_ERROR: bfh_params indeholder "notes" men
+  # IKKE "n". R's $-operator partial-matcher "n" -> "notes" og returnerer
+  # notes-vektoren (length nrow), hvilket trigger log_debug-fejl. Fix bruger
+  # [["n"]] som er strict (NULL ved manglende key).
+  notes_only_params <- c(
+    minimal_bfh_params(),
+    list(notes = c("", "", "Kompleks patient", "Ny teknik"))
+  )
+
+  # Capture log-messages via mocked log_debug
+  captured_msgs <- character(0)
+  local_mocked_bindings(
+    log_debug = function(..., .context = NULL) {
+      msg <- paste(..., collapse = " ")
+      captured_msgs <<- c(captured_msgs, msg)
+      invisible(NULL)
+    }
+  )
+
+  with_mocked_bindings(
+    bfh_qic = function(...) {
+      structure(list(qic_data = data.frame(x = 1), plot = NULL),
+        class = "bfh_qic_result"
+      )
+    },
+    is_bfh_qic_result = function(x) inherits(x, "bfh_qic_result"),
+    .package = "BFHcharts",
+    code = {
+      result <- call_bfh_chart(notes_only_params)
+    }
+  )
+
+  expect_s3_class(result, "bfh_qic_result")
+  # Verificer at "BFHcharts data types"-log IKKE rapporterer n via partial-match.
+  # Pre-fix: log indeholdt "n(,,Kompleks...)=<INVALID_COL_NAME: length=4>".
+  # Post-fix: log ender efter y-class uden n-segment.
+  data_types_msg <- captured_msgs[grepl("BFHcharts data types", captured_msgs)]
+  expect_length(data_types_msg, 1)
+  expect_false(grepl("INVALID_COL_NAME", data_types_msg))
+  expect_false(grepl("Kompleks patient", data_types_msg))
+})
+
 test_that("call_bfh_chart logging survives malformed n parameter (root-cause exposed)", {
   skip_if_not_installed("BFHcharts")
   require_internal("call_bfh_chart", mode = "function")


### PR DESCRIPTION
## Summary

Skift `bfh_params_clean$n` → `bfh_params_clean[["n"]]` i `R/fct_spc_bfh_invocation.R:103-114`. Eliminerer root-cause for cycle 11 COLLAPSE_ERROR, ikke kun symptom.

## Root cause

R's `$`-operator udfører partial-matching på liste-keys. `bfh_params_clean` indeholder `"notes"` men IKKE `"n"`. `$n` matcher derfor til `"notes"` som eneste prefix-match og returnerer notes-vektoren (length=nrow). Det brød `class(data[[n_col_name]])`-lookup i `log_debug`-build via tibble's strict `[[`-validator → fanget af `.safe_collapse()` → rapporteret som `<COLLAPSE_ERROR: ...>`.

**Bevis fra repro (`devtools::load_all()` + `map_to_bfh_params(notes_column="Kommentar")`):**

\`\`\`
=== Keys ===
[1] "data" "x" "y" "chart_type" ".column_mapping" ".original_names" "notes"

=== params\$n: ===      ← SAMME som params\$notes
 [1] "" "" "" "" "" "Påske" ...
class: character  length: 24
\`\`\`

`[["n"]]` er strict — returnerer NULL ved manglende key, ingen partial-match.

## Forhold til #765

#765 leverede defensiv `.safe_col_class()`-helper der **maskerer** symptomet (returnerer `<INVALID_COL_NAME: length=N>` i stedet for at crashe). Det er stadig korrekt defense-in-depth. Denne PR fjerner **selve den underliggende bug** så debug-output viser ren `BFHcharts data types: x( Dato )= Date , y( ... )= numeric` uden støj-segmenter.

## Test plan

- [x] Eksisterende tests pass (12/12 i `test-fct_spc_bfh_invocation.R`)
- [x] Ny test verificerer at log-msg IKKE inkluderer n-segment når kun notes findes (via `local_mocked_bindings(log_debug=...)`-capture)
- [x] Lokal repro post-fix: log viser `BFHcharts data types: x( Dato )= Date , y( Operationstid_min )= numeric` uden trailing n-segment
- [x] Pre-push fast-mode grøn
- [ ] Manuel runtime-verifikation efter merge: i-chart + notes_column → ingen `<INVALID_COL_NAME>` i debug-log

## Affected files

- `R/fct_spc_bfh_invocation.R` (+7 / -2)
- `tests/testthat/test-fct_spc_bfh_invocation.R` (+45)
- `NEWS.md` (+11)