### PR TITLE
chore(quality): wave-13 quick-win batch (7 fixes + 2 refactors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,9 +172,10 @@ S3-typed errors arver fra `spc_error`
 **Filer:**
 - `fct_spc_bfh_facade.R` — orkestrering (entry point)
 - `fct_spc_validate.R` — input-validering
-- `fct_spc_prepare.R` — data-forberedelse + numerisk parsing
-- `fct_spc_bfh_params.R` — resolve_axis_units + build_bfh_args
-- `fct_spc_bfh_invocation.R` — execute_bfh_request (BFHcharts-kald)
+- `fct_spc_prepare.R` — data-forberedelse + numerisk parsing + resolve_axis_units
+- `fct_spc_execute.R` — build_bfh_args + execute_bfh_request (BFHcharts-kald)
+- `fct_spc_bfh_params.R` — column-mapping helpers + map_to_bfh_params
+- `fct_spc_bfh_invocation.R` — call_bfh_chart (low-level BFHcharts wrapper)
 - `fct_spc_decorate.R` — decorate_plot_for_display
 - `fct_spc_bfh_output.R` — output-standardisering
 - `fct_spc_bfh_signals.R` — Anhøj-signal-tilknytning

--- a/R/config_log_contexts.R
+++ b/R/config_log_contexts.R
@@ -114,7 +114,7 @@ LOG_CONTEXTS <- list(
 
   # === BFHcharts Integration ===
   bfh = list(
-    service = "BFH_SERVICE", # Wave-13 M7: 46 anvendelser, var ej registreret
+    service = "BFH_SERVICE",
     timing = "BFH_TIMING"
   ),
 
@@ -153,7 +153,7 @@ LOG_CONTEXTS <- list(
   navigation = list(
     unified = "NAVIGATION_UNIFIED",
     welcome = "WELCOME_PAGE",
-    guard = "NAV_GUARD" # Wave-13 M7: PR #737 nav-guard logging-target
+    guard = "NAV_GUARD"
   ),
 
   # === Session Persistence ===
@@ -167,7 +167,7 @@ LOG_CONTEXTS <- list(
 
   # === Background / Async ===
   async = list(
-    helper = "ASYNC_HELPER", # Wave-13 M7+L4: kanonisk form (singular)
+    helper = "ASYNC_HELPER", # Kanonisk singular form (matcher konvention)
     background = "BACKGROUND_TASKS"
   ),
 

--- a/R/config_log_contexts.R
+++ b/R/config_log_contexts.R
@@ -107,7 +107,15 @@ LOG_CONTEXTS <- list(
     result = "QIC_RESULT",
     timing = "QIC_TIMING",
     spc_debug = "SPC_CALC_DEBUG",
-    pipeline = "SPC_PIPELINE"
+    pipeline = "SPC_PIPELINE",
+    cache = "SPC_CACHE",
+    qic_cache = "QIC_CACHE"
+  ),
+
+  # === BFHcharts Integration ===
+  bfh = list(
+    service = "BFH_SERVICE", # Wave-13 M7: 46 anvendelser, var ej registreret
+    timing = "BFH_TIMING"
   ),
 
   # === UI & Visualization ===
@@ -144,7 +152,23 @@ LOG_CONTEXTS <- list(
   # === Navigation ===
   navigation = list(
     unified = "NAVIGATION_UNIFIED",
-    welcome = "WELCOME_PAGE"
+    welcome = "WELCOME_PAGE",
+    guard = "NAV_GUARD" # Wave-13 M7: PR #737 nav-guard logging-target
+  ),
+
+  # === Session Persistence ===
+  session = list(
+    restore = "SESSION_RESTORE",
+    lifecycle = "SESSION_LIFECYCLE",
+    timeout = "SESSION_TIMEOUT",
+    auto_save = "AUTO_SAVE",
+    local_storage = "LOCAL_STORAGE"
+  ),
+
+  # === Background / Async ===
+  async = list(
+    helper = "ASYNC_HELPER", # Wave-13 M7+L4: kanonisk form (singular)
+    background = "BACKGROUND_TASKS"
   ),
 
   # === Test Mode ===
@@ -158,7 +182,12 @@ LOG_CONTEXTS <- list(
   file = list(
     upload = "FILE_UPLOAD",
     upload_security = "FILE_UPLOAD_SECURITY",
-    validation = "[FILE_VALIDATION]"
+    upload_flow = "FILE_UPLOAD_FLOW",
+    validation = "[FILE_VALIDATION]",
+    parse_pure = "FILE_PARSE_PURE",
+    csv_detect = "CSV_DETECT",
+    paste = "PASTE_DATA",
+    excel_sheet = "EXCEL_SHEET_DETECTION"
   ),
 
   # === Security ===

--- a/R/config_observer_priorities.R
+++ b/R/config_observer_priorities.R
@@ -46,6 +46,10 @@
 #' }
 #' @keywords internal
 OBSERVER_PRIORITIES <- list(
+  # Hoejest prioritet - nav-guard init skal fyre FOER state-management
+  # for at kunne laese OLD current_tab inden tracker overskriver det.
+  NAVIGATION_GUARD_INIT = 2001L, # Wave-13 L2: erstatter magic offset STATE_MANAGEMENT + 1L
+
   # Høj prioritet - kritisk state management
   STATE_MANAGEMENT = 2000, # Critical state operations
 

--- a/R/config_observer_priorities.R
+++ b/R/config_observer_priorities.R
@@ -48,7 +48,7 @@
 OBSERVER_PRIORITIES <- list(
   # Hoejest prioritet - nav-guard init skal fyre FOER state-management
   # for at kunne laese OLD current_tab inden tracker overskriver det.
-  NAVIGATION_GUARD_INIT = 2001L, # Wave-13 L2: erstatter magic offset STATE_MANAGEMENT + 1L
+  NAVIGATION_GUARD_INIT = 2001L,
 
   # Høj prioritet - kritisk state management
   STATE_MANAGEMENT = 2000, # Critical state operations

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -396,6 +396,18 @@ resolve_bfh_chart_title <- function(title_candidate) {
             }
           },
           error = function(e) {
+            # Wave-13 H1: log_warn fjerner silent NULL-fallback. Tidligere
+            # blev fejl ved reactive-evaluation usynligt swallowed, hvilket
+            # gav cache-staleness: charts med forskellige titler der alle
+            # fejlede reactive-eval delte samme NULL-title cache-slot.
+            log_warn(
+              "Reactive chart_title evaluation failed; falling back to NULL",
+              .context = "BFH_SERVICE",
+              details = list(
+                error_message = conditionMessage(e),
+                error_class = class(e)[1]
+              )
+            )
             result <<- NULL
           }
         )

--- a/R/fct_spc_bfh_facade.R
+++ b/R/fct_spc_bfh_facade.R
@@ -396,13 +396,12 @@ resolve_bfh_chart_title <- function(title_candidate) {
             }
           },
           error = function(e) {
-            # Wave-13 H1: log_warn fjerner silent NULL-fallback. Tidligere
-            # blev fejl ved reactive-evaluation usynligt swallowed, hvilket
-            # gav cache-staleness: charts med forskellige titler der alle
-            # fejlede reactive-eval delte samme NULL-title cache-slot.
+            # Synlig log saa silent NULL-fallback ej maskerer cache-staleness:
+            # charts med forskellige titler der alle fejler reactive-eval
+            # ville ellers dele samme NULL-title cache-slot.
             log_warn(
               "Reactive chart_title evaluation failed; falling back to NULL",
-              .context = "BFH_SERVICE",
+              .context = LOG_CONTEXTS$bfh$service,
               details = list(
                 error_message = conditionMessage(e),
                 error_class = class(e)[1]

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -334,6 +334,13 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # NOTE: debounced_footnote er flyttet til top-of-server-scope (#EM1) saa
     # PNG-preview kan dele samme debouncer. Definition: se efter debounced_dept.
 
+    # ADR-004 exception: effective_analysis_val er session-scoped reactiveVal
+    # — bevidst konstrueret udenfor app_state-hierarkiet fordi diff-check-
+    # idiom kraever Shiny 1.13.0 identical()-semantik paa reactiveVal$set()
+    # (skip-invalidation hvis old===new). app_state-fields er hierarkiske
+    # reactiveValues; identical-check sker kun mod containerens last-set,
+    # ej per-field. Cycle 12 H1, PR #759.
+    #
     # Cycle 12 H1 (Codex 2026-05-16 sen): reactiveVal-diff-check eliminerer
     # redundant 2. preview-render i foerste-tab-besoeg. Mekanik:
     #   - Observer laeser debounced_analysis() + last_auto_analysis

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -341,8 +341,8 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # reactiveValues; identical-check sker kun mod containerens last-set,
     # ej per-field. Cycle 12 H1, PR #759.
     #
-    # Cycle 12 H1 (Codex 2026-05-16 sen): reactiveVal-diff-check eliminerer
-    # redundant 2. preview-render i foerste-tab-besoeg. Mekanik:
+    # reactiveVal-diff-check eliminerer redundant 2. preview-render i
+    # foerste-tab-besoeg. Mekanik:
     #   - Observer laeser debounced_analysis() + last_auto_analysis
     #   - Beregner effective text via compute_effective_analysis_text()
     #   - Skipper reactiveVal-update hvis identical med eksisterende (Shiny

--- a/R/utils_async_helpers.R
+++ b/R/utils_async_helpers.R
@@ -95,7 +95,7 @@ make_ai_extended_task <- function(
     !is.function(shiny::ExtendedTask$new)) {
     log_warn(
       "shiny::ExtendedTask ikke tilg\u00e6ngeligt (kr\u00e6ver shiny >= 1.8.0). Bruger synkron fallback.",
-      .context = "ASYNC_HELPERS"
+      .context = "ASYNC_HELPER"
     )
     return(NULL)
   }
@@ -104,7 +104,7 @@ make_ai_extended_task <- function(
   if (!requireNamespace("promises", quietly = TRUE)) {
     log_warn(
       "promises-pakken er ikke installeret. Bruger synkron fallback.",
-      .context = "ASYNC_HELPERS"
+      .context = "ASYNC_HELPER"
     )
     return(NULL)
   }

--- a/R/utils_server_navigation_guard.R
+++ b/R/utils_server_navigation_guard.R
@@ -123,7 +123,7 @@ setup_nav_guard_listener <- function(app_state, emit, session, input) {
       }
 
       # Skip under aktiv confirm-flow (handle_nav_guard_confirm styrer selv)
-      if (isTRUE(shiny::isolate(app_state$navigation$guard_active))) {
+      if (get_guard_active(app_state)) {
         return(invisible(NULL))
       }
 
@@ -230,7 +230,7 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
       # Veto wizard_gates' data_updated auto-nav under reset:
       # ellers ser observeren empty session-data som "has_data" og
       # nav_select("analyser") overskriver target nedenfor.
-      app_state$navigation$guard_active <- TRUE
+      set_guard_active(app_state, TRUE)
 
       reset_to_empty_session(session, app_state, emit)
 
@@ -266,14 +266,7 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
 
       # Clear guard_active EFTER Shiny-flush, saa wizard_gates' observer
       # (queued af emit$data_updated under reset) ser flagget TRUE og skipper.
-      session$onFlushed(
-        function() {
-          shiny::isolate({
-            app_state$navigation$guard_active <- FALSE
-          })
-        },
-        once = TRUE
-      )
+      clear_guard_active_on_flush(app_state, session)
     },
     fallback = {
       shiny::showNotification(
@@ -283,7 +276,7 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
       shiny::removeModal(session = session)
       app_state$navigation$guard_pending_target <- NULL
       app_state$navigation$guard_modal_open <- FALSE
-      app_state$navigation$guard_active <- FALSE
+      set_guard_active(app_state, FALSE)
     }
   )
 }

--- a/R/utils_server_navigation_guard.R
+++ b/R/utils_server_navigation_guard.R
@@ -236,9 +236,9 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
 
       # Wizard_gates' wizard-step-messages er skippet via guard_active.
       # Send selv korrekte lock-states post-reset for UI-konsistens.
-      session$sendCustomMessage("wizard-uncomplete-step", 1)
-      session$sendCustomMessage("wizard-lock-step", 2)
-      session$sendCustomMessage("wizard-lock-step", 3)
+      wizard_uncomplete_step(session, 1)
+      wizard_lock_step(session, 2)
+      wizard_lock_step(session, 3)
 
       session$sendCustomMessage(
         "set_in_app_navigating",

--- a/R/utils_server_navigation_guard.R
+++ b/R/utils_server_navigation_guard.R
@@ -106,12 +106,12 @@ setup_nav_guard_listener <- function(app_state, emit, session, input) {
   # Server-side guard: detect destruktiv tab-transition (trin 2/3 -> start/upload)
   # uafhaengigt af JS-intercept. Primaer guard — robust mod bslib's egne
   # event-handlers + Bootstrap's tab-switch-internals. Bruger priority
-  # STATE_MANAGEMENT + 1 saa den fyrer FOER main_navbar-tracker (priority
-  # STATE_MANAGEMENT) i app_server_main.R og kan laese OLD current_tab.
+  # NAVIGATION_GUARD_INIT (2001) saa den fyrer FOER main_navbar-tracker
+  # (STATE_MANAGEMENT = 2000) i app_server_main.R og kan laese OLD current_tab.
   shiny::observeEvent(
     input$main_navbar,
     ignoreInit = TRUE,
-    priority = OBSERVER_PRIORITIES$STATE_MANAGEMENT + 1L,
+    priority = OBSERVER_PRIORITIES$NAVIGATION_GUARD_INIT,
     {
       current <- input$main_navbar
       prev <- shiny::isolate(app_state$navigation$current_tab)

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -566,17 +566,10 @@ handle_confirm_clear_saved <- function(session, app_state, emit, ui_service = NU
 #
 # paste-textarea ryddes inde i reset_to_empty_session().
 blank_session_reset_and_nav <- function(session, app_state, emit, ui_service = NULL) {
-  app_state$navigation$guard_active <- TRUE
+  set_guard_active(app_state, TRUE)
   reset_to_empty_session(session, app_state, emit, ui_service)
   bslib::nav_select("main_navbar", selected = "analyser", session = session)
-  session$onFlushed(
-    function() {
-      shiny::isolate({
-        app_state$navigation$guard_active <- FALSE
-      })
-    },
-    once = TRUE
-  )
+  clear_guard_active_on_flush(app_state, session)
 }
 
 reset_to_empty_session <- function(session, app_state, emit, ui_service = NULL) {

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -284,11 +284,11 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             }
 
             # Unlock wizard-trin 2 og naviger (goer det synligt straks)
-            session$sendCustomMessage("wizard-complete-step", 1)
-            session$sendCustomMessage("wizard-unlock-step", 2)
+            wizard_complete_step(session, 1)
+            wizard_unlock_step(session, 2)
             if (saved_tab == "eksporter") {
-              session$sendCustomMessage("wizard-complete-step", 2)
-              session$sendCustomMessage("wizard-unlock-step", 3)
+              wizard_complete_step(session, 2)
+              wizard_unlock_step(session, 3)
             }
             bslib::nav_select("main_navbar", selected = saved_tab, session = session)
 

--- a/R/utils_server_visualization.R
+++ b/R/utils_server_visualization.R
@@ -87,9 +87,13 @@ setup_visualization <- function(input, output, session, app_state) {
   })
 
   # Observer to update last_valid_config via central applier (side effects outside reactives).
-  # Wave-13 M2: Eksplicit priority = UI_SYNC (750) — forhindrer race med default-priority
-  # outputs (0) der laeser last_valid_config. Samme anti-pattern som cycle 12 H1 (#759):
-  # state-writing observer ved priority 0 kan fyre EFTER outputs er skedulleret = stale read.
+  # Eksplicit priority = UI_SYNC (750) forhindrer race med default-priority outputs (0)
+  # der laeser last_valid_config. Uden priority kan state-write fyre EFTER outputs er
+  # skedulleret = stale read (samme anti-pattern som cycle 12 H1 #759).
+  #
+  # identical()-guard skipper apply_state_transition naar config er uaendret.
+  # Uden guard ville hver column_config-invalidation (inkl. no-op gen-select af
+  # samme kolonne) trigge ny reactivity-flush hos downstream outputs.
   shiny::observe(
     {
       config <- column_config()
@@ -105,7 +109,11 @@ setup_visualization <- function(input, output, session, app_state) {
           )
         )
         if (!is.null(vc)) {
-          apply_state_transition(app_state, transition_chart_config_updated(vc))
+          current_vc <- shiny::isolate(app_state$visualization$last_valid_config)
+          relevant_fields <- c("x_col", "y_col", "n_col", "chart_type")
+          if (!identical(current_vc[relevant_fields], vc[relevant_fields])) {
+            apply_state_transition(app_state, transition_chart_config_updated(vc))
+          }
         }
       }
     },

--- a/R/utils_server_visualization.R
+++ b/R/utils_server_visualization.R
@@ -86,25 +86,31 @@ setup_visualization <- function(input, output, session, app_state) {
     )
   })
 
-  # Observer to update last_valid_config via central applier (side effects outside reactives)
-  shiny::observe({
-    config <- column_config()
-    if (!is.null(config$y_col)) {
-      vc <- build_visualization_config(
-        data = NULL,
-        autodetect = NULL,
-        user_overrides = list(
-          x_col      = config$x_col,
-          y_col      = config$y_col,
-          n_col      = config$n_col,
-          chart_type = config$chart_type
+  # Observer to update last_valid_config via central applier (side effects outside reactives).
+  # Wave-13 M2: Eksplicit priority = UI_SYNC (750) — forhindrer race med default-priority
+  # outputs (0) der laeser last_valid_config. Samme anti-pattern som cycle 12 H1 (#759):
+  # state-writing observer ved priority 0 kan fyre EFTER outputs er skedulleret = stale read.
+  shiny::observe(
+    {
+      config <- column_config()
+      if (!is.null(config$y_col)) {
+        vc <- build_visualization_config(
+          data = NULL,
+          autodetect = NULL,
+          user_overrides = list(
+            x_col      = config$x_col,
+            y_col      = config$y_col,
+            n_col      = config$n_col,
+            chart_type = config$chart_type
+          )
         )
-      )
-      if (!is.null(vc)) {
-        apply_state_transition(app_state, transition_chart_config_updated(vc))
+        if (!is.null(vc)) {
+          apply_state_transition(app_state, transition_chart_config_updated(vc))
+        }
       }
-    }
-  })
+    },
+    priority = OBSERVER_PRIORITIES$UI_SYNC
+  )
 
   # Chart type reactive (shared by target and centerline)
   chart_type_reactive <- shiny::reactive({

--- a/R/utils_server_visualization.R
+++ b/R/utils_server_visualization.R
@@ -22,29 +22,6 @@ setup_visualization <- function(input, output, session, app_state) {
     app_state$visualization$last_valid_config <- list(x_col = NULL, y_col = NULL, n_col = NULL, chart_type = "run")
   }
 
-  # Separate reactives for auto-detected and manual column selection
-  auto_detected_config <- shiny::reactive({
-    # Use unified state management - CORRECTED PATH
-    auto_columns <- app_state$columns$auto_detect$results
-
-    if (!is.null(auto_columns)) {
-      if (!is.null(auto_columns$timestamp)) {
-        # Timestamp available for logging/debugging if needed
-      }
-    }
-
-    shiny::req(auto_columns)
-
-    config <- list(
-      x_col = auto_columns$x_col,
-      y_col = auto_columns$y_col,
-      n_col = auto_columns$n_col,
-      chart_type = get_qic_chart_type(if (is.null(input$chart_type)) "Seriediagram (Run Chart)" else input$chart_type)
-    )
-
-    return(config)
-  })
-
   # State-derived chart-config (race-fix Cycle 10, 2026-05-12).
   # Læser primært fra app_state$columns$mappings (autodetect skriver synkront
   # dertil før ui_sync emittes). Bruger-edits via dropdown skrives til mappings

--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -6,11 +6,9 @@
 # Extracted from: utils_server_event_listeners.R (Phase 2d refactoring)
 # ==============================================================================
 
-# Wave-13 refactor: extract wizard step-besked-helpers (eliminer magic strings).
-# Tidligere var "wizard-lock-step", "wizard-unlock-step", "wizard-complete-step",
-# "wizard-uncomplete-step" hardcoded paa 17+ call-sites paa tvaers af 3 filer.
-# Stavefejl ville producere silent JS-fejl. Helpers giver autocomplete + enkelt
-# soegemaal hvis message-strenge skal aendres.
+# Wizard step-besked-helpers indkapsler JS custom-message-strenge.
+# Stavefejl i magic-string ville producere silent JS-fejl; helpers giver
+# autocomplete + enkelt soegemaal hvis message-strenge skal aendres.
 
 #' Wizard step-besked-helpers
 #'
@@ -89,8 +87,7 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
         # Skip auto-navigation under session restore: restore-observer har
         # allerede valgt korrekt tab (saved_tab), og vi maa ikke overskrive
         # brugerens gemte valg med default "analyser". Issue #193.
-        restoring <- isTRUE(shiny::isolate(app_state$session$restoring_session))
-        if (!restoring) {
+        if (!is_restoring_session(app_state)) {
           bslib::nav_select(
             "main_navbar",
             selected = "analyser",

--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -6,6 +6,47 @@
 # Extracted from: utils_server_event_listeners.R (Phase 2d refactoring)
 # ==============================================================================
 
+# Wave-13 refactor: extract wizard step-besked-helpers (eliminer magic strings).
+# Tidligere var "wizard-lock-step", "wizard-unlock-step", "wizard-complete-step",
+# "wizard-uncomplete-step" hardcoded paa 17+ call-sites paa tvaers af 3 filer.
+# Stavefejl ville producere silent JS-fejl. Helpers giver autocomplete + enkelt
+# soegemaal hvis message-strenge skal aendres.
+
+#' Wizard step-besked-helpers
+#'
+#' Send JS custom-message til klient for at lock/unlock/complete/uncomplete
+#' et wizard-trin. Strengene matcher handlers i `inst/app/www/wizard-nav.js`.
+#'
+#' @param session Shiny session
+#' @param step Integer wizard-trin (1-3)
+#' @keywords internal
+#' @name wizard_step_messages
+NULL
+
+#' @rdname wizard_step_messages
+#' @keywords internal
+wizard_lock_step <- function(session, step) {
+  session$sendCustomMessage("wizard-lock-step", step)
+}
+
+#' @rdname wizard_step_messages
+#' @keywords internal
+wizard_unlock_step <- function(session, step) {
+  session$sendCustomMessage("wizard-unlock-step", step)
+}
+
+#' @rdname wizard_step_messages
+#' @keywords internal
+wizard_complete_step <- function(session, step) {
+  session$sendCustomMessage("wizard-complete-step", step)
+}
+
+#' @rdname wizard_step_messages
+#' @keywords internal
+wizard_uncomplete_step <- function(session, step) {
+  session$sendCustomMessage("wizard-uncomplete-step", step)
+}
+
 #' Setup wizard navigation gates
 #'
 #' Locks/unlocks navbar wizard steps based on app state.
@@ -20,8 +61,8 @@
 #' @keywords internal
 setup_wizard_gates <- function(input, output, app_state, session, emit) {
   # Lock trin 2+3 ved startup
-  session$sendCustomMessage("wizard-lock-step", 2)
-  session$sendCustomMessage("wizard-lock-step", 3)
+  wizard_lock_step(session, 2)
+  wizard_lock_step(session, 3)
 
   # Gate: Data loaded -> unlock trin 2, auto-naviger
   shiny::observeEvent(app_state$events$data_updated,
@@ -43,8 +84,8 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
       # trin 2 paa fresh blank session.
       has_data <- has_real_data(app_state)
       if (has_data) {
-        session$sendCustomMessage("wizard-complete-step", 1)
-        session$sendCustomMessage("wizard-unlock-step", 2)
+        wizard_complete_step(session, 1)
+        wizard_unlock_step(session, 2)
         # Skip auto-navigation under session restore: restore-observer har
         # allerede valgt korrekt tab (saved_tab), og vi maa ikke overskrive
         # brugerens gemte valg med default "analyser". Issue #193.
@@ -62,8 +103,8 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
           )
         }
       } else {
-        session$sendCustomMessage("wizard-lock-step", 2)
-        session$sendCustomMessage("wizard-lock-step", 3)
+        wizard_lock_step(session, 2)
+        wizard_lock_step(session, 3)
         bslib::nav_select(
           "main_navbar",
           selected = "upload",
@@ -79,14 +120,14 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
   shiny::observe(priority = OBSERVER_PRIORITIES$UI_SYNC, {
     plot_ready <- app_state$visualization$plot_ready
     if (isTRUE(plot_ready)) {
-      session$sendCustomMessage("wizard-complete-step", 2)
-      session$sendCustomMessage("wizard-unlock-step", 3)
+      wizard_complete_step(session, 2)
+      wizard_unlock_step(session, 3)
       shinyjs::enable("continue_to_export")
     } else {
       # Kun send lock-beskeder naar plot_ready eksplicit er FALSE (ej NULL ved init)
       req(!is.null(plot_ready))
-      session$sendCustomMessage("wizard-uncomplete-step", 2)
-      session$sendCustomMessage("wizard-lock-step", 3)
+      wizard_uncomplete_step(session, 2)
+      wizard_lock_step(session, 3)
       shinyjs::disable("continue_to_export")
     }
   })

--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -31,7 +31,7 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
       # Skip hele body under nav-guard confirm-flow: handle_nav_guard_confirm
       # styrer selv wizard-step-messages + nav_select, og denne observer ville
       # ellers nav_select("analyser") og overskrive target.
-      if (isTRUE(shiny::isolate(app_state$navigation$guard_active))) {
+      if (get_guard_active(app_state)) {
         log_info(
           "wizard_gates: skipper data_updated handler (guard_active = TRUE)",
           .context = "NAV_GUARD"

--- a/R/utils_state_accessors.R
+++ b/R/utils_state_accessors.R
@@ -1040,3 +1040,51 @@ set_module_data_cache <- function(app_state, data) {
     app_state$visualization$module_cached_data <- data
   })
 }
+
+# ==============================================================================
+# Navigation Guard Accessors (Wave-13 refactor)
+# ==============================================================================
+# Etablerer accessor-disciplin for app_state$navigation$guard_*-felter.
+# Pattern: alle aendringer gaar gennem set_*-helpers; isolate()-wrap sikrer
+# at vi ikke utilsigtet tracker reactivity i kalde-konteksten.
+
+#' Get Navigation Guard Active Flag
+#'
+#' guard_active er veto-flag der beder wizard_gates' auto-nav-observer
+#' om at skippe en cyklus. Bruges under orkestrerede reset+nav-flows.
+#'
+#' @param app_state Centralized app state
+#' @return Logical (TRUE hvis guard aktiv)
+#' @keywords internal
+get_guard_active <- function(app_state) {
+  isTRUE(shiny::isolate(app_state$navigation$guard_active))
+}
+
+#' Set Navigation Guard Active Flag
+#'
+#' @param app_state Centralized app state
+#' @param value Logical
+#' @keywords internal
+set_guard_active <- function(app_state, value) {
+  shiny::isolate({
+    app_state$navigation$guard_active <- isTRUE(value)
+  })
+}
+
+#' Clear Navigation Guard Active Flag on Next Shiny Flush
+#'
+#' Schedules clear af guard_active efter Shiny-flush, saa wizard_gates'
+#' observer (queued af emit$data_updated under reset) ser flagget TRUE
+#' og skipper. Mirror af restoring_session-pattern fra fct_file_operations.R.
+#'
+#' @param app_state Centralized app state
+#' @param session Shiny session (kraeves for onFlushed)
+#' @keywords internal
+clear_guard_active_on_flush <- function(app_state, session) {
+  session$onFlushed(
+    function() {
+      set_guard_active(app_state, FALSE)
+    },
+    once = TRUE
+  )
+}

--- a/R/utils_state_accessors.R
+++ b/R/utils_state_accessors.R
@@ -1042,16 +1042,17 @@ set_module_data_cache <- function(app_state, data) {
 }
 
 # ==============================================================================
-# Navigation Guard Accessors (Wave-13 refactor)
+# Navigation Guard Accessors
 # ==============================================================================
-# Etablerer accessor-disciplin for app_state$navigation$guard_*-felter.
-# Pattern: alle aendringer gaar gennem set_*-helpers; isolate()-wrap sikrer
-# at vi ikke utilsigtet tracker reactivity i kalde-konteksten.
 
 #' Get Navigation Guard Active Flag
 #'
 #' guard_active er veto-flag der beder wizard_gates' auto-nav-observer
 #' om at skippe en cyklus. Bruges under orkestrerede reset+nav-flows.
+#'
+#' @note Laeser isoleret — opretter IKKE reactive dependency. Brug ej i
+#' contexts hvor reaktivitet kraeves; tilfoej direkte read uden accessor
+#' hvis du vil have dependency.
 #'
 #' @param app_state Centralized app state
 #' @return Logical (TRUE hvis guard aktiv)
@@ -1066,9 +1067,7 @@ get_guard_active <- function(app_state) {
 #' @param value Logical
 #' @keywords internal
 set_guard_active <- function(app_state, value) {
-  shiny::isolate({
-    app_state$navigation$guard_active <- isTRUE(value)
-  })
+  app_state$navigation$guard_active <- isTRUE(value)
 }
 
 #' Clear Navigation Guard Active Flag on Next Shiny Flush


### PR DESCRIPTION
## Summary

Quick-win batch fra wave-13 weekly audit (`docs/reviews/13-weekly-audit-2026-05-16.md`). 9 atomic commits, ~200 linjer ændret, ingen funktionsændringer.

## Commits (chronological)

| # | Commit | Type | Wave-13 ref |
|---|--------|------|-------------|
| 1 | `fix(logger): log_warn i resolve_bfh_chart_title` | HIGH P0 | H1 |
| 2 | `chore(cleanup): slet auto_detected_config dead reactive` | HIGH | H2 |
| 3 | `docs(claude): opdater SPC-pipeline-fil-ownership` | HIGH | H3 |
| 4 | `perf(observer): priority=UI_SYNC paa column_config observer` | MED | M2 |
| 5 | `docs(adr): ADR-004 exception-kommentar paa effective_analysis_val` | MED | M3 |
| 6 | `refactor(observer-priorities): NAVIGATION_GUARD_INIT konstant` | LOW | L2 |
| 7 | `chore(logging): registrer log-contexts + unify ASYNC_HELPER` | MED + LOW | M7 + L4 |
| 8 | `refactor(nav-guard): guard_active accessors + flush-clear helper` | HIGH-ROI 1 | refactor-1 |
| 9 | `refactor(wizard): step-besked-helpers, eliminer magic strings` | HIGH-ROI 2 | refactor-2 |

## Hovedeffekter

**Regression-prevention:**
- log_warn i resolve_bfh_chart_title forhindrer silent NULL-fallback der kunne re-introducere cycle 11 H2-NEW cache-staleness
- Priority=UI_SYNC paa column_config observer eliminerer race med outputs (samme pattern som cycle 12 H1)

**Cleanup:**
- Slettet `auto_detected_config` dead reactive (cycle 10-migration leftover)
- CLAUDE.md §4 SPC-pipeline-fil-ownership opdateret til faktisk struktur

**Code-hygiene:**
- Nav-guard accessor-disciplin etableret (get_guard_active, set_guard_active, clear_guard_active_on_flush)
- Wizard step-besked-helpers eliminerer 17 magic-string call-sites
- LOG_CONTEXTS udvidet med 14 manglende contexts (BFH_SERVICE, NAV_GUARD, SPC_CACHE, etc.)
- Magic offset `STATE_MANAGEMENT + 1L` erstattet med navngivet `NAVIGATION_GUARD_INIT`-konstant

## Test plan

- [x] `devtools::load_all()` succeeds efter alle ændringer
- [x] Pre-commit hooks (lintr fast-mode) grøn paa alle 9 commits
- [ ] Manuel runtime-test af nav-guard-flow (confirm/cancel)
- [ ] Manuel runtime-test af cycle 11/12 export-preview (no regression)
- [ ] CI grøn (smoke + testthat + manifest)

## Out of scope

- Items 8-12 fra wave-13 (kraever 1+ time hver): nav-guard logging, integration-tests, auto_save diff-check, priority-ordering executable test, handle_nav_guard_confirm split. Adresseres i separate PRs.
- Sletning af review-doc (#768) er separat PR