### PR TITLE
fix(ai): skjul AI-feature globalt + GOLEM_CONFIG_ACTIVE=production paa Connect Cloud

### DIFF
--- a/app.R
+++ b/app.R
@@ -7,6 +7,12 @@
 # uden installation. pkgload skal være i Imports (ikke Suggests) for at være
 # installeret på Connect. Se docs/adr/ADR-019-production-entrypoint-pkgload.md.
 
+# Aktiver production-profile FOER load_all saa get_golem_config() returnerer
+# production-overrides (ai.enabled=false, branding-gate, logging.level=ERROR).
+# Connect Cloud setter ej dette env var pr default — uden eksplicit setenv
+# falder profile tilbage til "default" og production-only settings haandhaeves ej.
+Sys.setenv(GOLEM_CONFIG_ACTIVE = "production")
+
 # Forhindre Shiny fra at auto-source R/ filer (pkgload haandterer dette)
 options(shiny.autoload.r = FALSE)
 

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -93,12 +93,17 @@ default:
     github_sync_enabled: false    # Opt-in: kræver eksplicit konfiguration
 
   # AI-powered improvement suggestions
+  # NB (2026-05-17): AI-feature GLOBALT disabled (default+dev+prod+test).
+  # AI-feature er bevidst hidden foreloebig — re-enable kraever:
+  #   1. Fix data_consent='explicit' i mod_export_ai.R + utils_async_helpers.R
+  #      (cycle G H0 + H3 - se docs/reviews/04-ai-rag.md)
+  #   2. Implementer shared preflight guard (PHI-check + truncate)
+  #   3. Skift enabled: true her + i development-profile
   # NB (Cycle A 2026-05-09): model-felt droppet — biSPCharts foelger BFHllm's
-  # default-model (Gemini 3.1 Flash-Lite). Hvis BFHllm bumper sin default,
-  # foelger biSPCharts automatisk med uden config-update. Override-mulighed
-  # bevares: tilfoej `model: "..."` for at pinne specifik model.
+  # default-model (Gemini 3.1 Flash-Lite). Override-mulighed bevares: tilfoej
+  # `model: "..."` for at pinne specifik model.
   ai:
-    enabled: true
+    enabled: false                  # GLOBAL kill-switch (fail-closed)
     provider: "gemini"
     timeout_seconds: 10
     max_response_chars: 350
@@ -109,9 +114,9 @@ default:
     rate_limit:
       max_requests_per_minute: 20
     rag:
-      enabled: true
-      n_results: 3              # Number of knowledge chunks to retrieve
-      method: "hybrid"          # Search method: "hybrid", "vector", "keyword"
+      enabled: false              # RAG uden AI er meningsloest
+      n_results: 3                # Number of knowledge chunks to retrieve
+      method: "hybrid"            # Search method: "hybrid", "vector", "keyword"
 
 
 # DEVELOPMENT CONFIGURATION ==================================================
@@ -197,13 +202,13 @@ development:
     github_sync_enabled: false    # Off — undgå utilsigtet upload under dev
 
   # AI configuration (development overrides)
+  # NB (2026-05-17): AI globalt disabled — dev override matcher default.
+  # Lokal AI-test kraever midlertidig flip til enabled=true (se default-blok-kommentar).
   ai:
-    enabled: true                   # Enable AI in development
+    enabled: false                  # Match default (global kill-switch)
     timeout_seconds: 15            # Longer timeout for debugging
     rag:
-      enabled: true                 # Enable RAG for development testing
-      n_results: 3                  # Standard retrieval count
-      method: "hybrid"              # Hybrid search (vector + keyword)
+      enabled: false                # Match default
 
 # PRODUCTION CONFIGURATION ===================================================
 # Optimized for security, stability and performance
@@ -282,18 +287,13 @@ production:
     shinylogs_enabled: false      # Opt-in: sæt til true i deployment-config
     github_sync_enabled: false    # Opt-in: kræver eksplicit konfiguration
 
-  # AI configuration (production settings)
-  # Cycle G H_NEW (2026-05-09): AI-feature er BEVIDST disabled i production
-  # foreloebig. For meget i begyndelsen at give brugere adgang. Re-enable
-  # kraever:
-  #   1. Fix data_consent='explicit' i mod_export_ai.R + utils_async_helpers.R
-  #      (cycle G H0 + H3 - se docs/reviews/04-ai-rag.md)
-  #   2. Implementer shared preflight guard (PHI-check + truncate)
-  #   3. Skift enabled: true her
+  # AI configuration (production)
+  # NB (2026-05-17): AI globalt disabled — production override matcher default.
+  # Re-enable-kriterier dokumenteret i default-blok-kommentar ovenfor.
   ai:
-    enabled: false                  # DISABLED: see Cycle G H_NEW comment above
+    enabled: false                  # Match default (eksplicit kill-switch)
     rag:
-      enabled: false                # DISABLED with AI (RAG kun nyttig naar AI aktiv)
+      enabled: false                # Match default
       n_results: 3                  # Balance between context and performance
       method: "hybrid"              # Optimal search accuracy
 

--- a/tests/testthat/test-ai-feature-flag-enforcement.R
+++ b/tests/testthat/test-ai-feature-flag-enforcement.R
@@ -73,6 +73,42 @@ test_that("production-config har ai.enabled=false (eksplicit kill-switch)", {
   )
 })
 
+# 2026-05-17: AI-feature skjules globalt (alle profiler). Connect Cloud setter
+# ej GOLEM_CONFIG_ACTIVE pr default; uden default-fail-closed vil app falde
+# tilbage til "default"-profil og vise AI-blok i deploy. Test verificerer at
+# default+development+testing matcher production (kill-switch).
+test_that("default-config har ai.enabled=false (fail-closed naar profil mangler)", {
+  config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
+  skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  expect_false(
+    isTRUE(yaml_content$default$ai$enabled),
+    info = paste(
+      "default-profile skal have ai.enabled=false saa Connect Cloud uden",
+      "eksplicit GOLEM_CONFIG_ACTIVE ej viser AI-blok."
+    )
+  )
+  expect_false(
+    isTRUE(yaml_content$default$ai$rag$enabled),
+    info = "default-profile RAG skal koble til ai (begge false naar AI disabled)"
+  )
+})
+
+test_that("development-config har ai.enabled=false (matcher global kill-switch)", {
+  config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
+  skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  expect_false(
+    isTRUE(yaml_content$development$ai$enabled),
+    info = paste(
+      "development-profile skal have ai.enabled=false. AI globalt disabled",
+      "2026-05-17 — re-enable kraever explicit flip + H0+H3-fix."
+    )
+  )
+})
+
 test_that("production-config har ai.rag.enabled=false (kobles til ai)", {
   config_path <- testthat::test_path("..", "..", "inst", "golem-config.yml")
   skip_if_not(file.exists(config_path), "golem-config.yml ikke fundet")


### PR DESCRIPTION
## Summary

- **Root cause:** Connect Cloud setter ej `GOLEM_CONFIG_ACTIVE` pr default + `app.R` satte den heller ej. `get_golem_config()` falder tilbage til `default`-profil hvor `ai.enabled=true` → AI-blok synlig i deploy trods bevidst kill-switch i `production`-profil.
- **Fix (defense-in-depth):** `app.R` sætter nu `GOLEM_CONFIG_ACTIVE=production` eksplicit + `inst/golem-config.yml` har `ai.enabled=false` globalt (fail-closed default).
- **Bonus:** Production-only overrides (branding hard-fail, security session_timeout=60, logging.level=ERROR) håndhæves nu faktisk på Connect Cloud.

## Changes

- `app.R`: `Sys.setenv(GOLEM_CONFIG_ACTIVE = "production")` før `pkgload::load_all`
- `inst/golem-config.yml`:
  - `default.ai.enabled: true → false`
  - `default.ai.rag.enabled: true → false`
  - `development.ai.enabled: true → false`
  - `development.ai.rag.enabled: true → false`
  - Production allerede `false` (uændret, kommentar opdateret)
- `tests/testthat/test-ai-feature-flag-enforcement.R`: udvid regression-coverage til `default` + `development`-profil

## Test plan

- [x] `test-ai-feature-flag-enforcement.R` (11 pass, +2 nye assertions)
- [x] `test-mod_export.R` (83 pass, 3 skip browser-context)
- [x] `test-bfhllm-config-injection.R` + `test-utils-bfhllm-integration.R` + `test-fct_ai_improvement_suggestions.R` (18 pass)
- [x] `test-yaml-config-adherence.R` + `test-config-boot-validation.R` + `test-branding-policy.R` (18 pass, 3 skip)
- [x] Pre-push gate (lintr + styler + manifest + regression) pass
- [ ] Manual: deploy til Connect Cloud + verificér AI-blok skjult på trin 3
- [ ] Manual: verificér boot-fail hvis BFHchartsAssets mangler (branding-gate aktiveres nu)

## Re-enable-procedure (fremtidig)

1. Fix `data_consent='explicit'` (cycle G H0 + H3, se `docs/reviews/04-ai-rag.md`)
2. Implementer shared preflight guard (PHI-check + truncate)
3. Flip `default.ai.enabled=true` + `development.ai.enabled=true` (production beholder eksplicit `false` indtil prod-rollout godkendt)