### PR TITLE
fix(export): unify nav-guard download med Eksporter-trin Excel-output

### DIFF
--- a/R/utils_server_navigation_guard.R
+++ b/R/utils_server_navigation_guard.R
@@ -217,7 +217,7 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
         session$sendCustomMessage(
           "download_blob",
           list(
-            filename = generate_spc_filename(app_state),
+            filename = spc_save_filename(app_state, input),
             data_b64 = base64enc::base64encode(blob),
             mime_type = paste0(
               "application/vnd.openxmlformats-officedocument.",
@@ -281,46 +281,8 @@ handle_nav_guard_confirm <- function(app_state, emit, session, input) {
   )
 }
 
-#' Build in-memory Excel-blob fra current app_state
-#'
-#' Genbruger eksisterende build_spc_excel() (3-ark: Data + Indstillinger +
-#' SPC-analyse) som returnerer en tempfil-sti. L\u00e6ser bytes tilbage via
-#' readBin og rydder op via on.exit.
-#'
-#' current_data bruges som original_data fordi det er det eneste tilg\u00e6ngelige
-#' datas\u00e6t i nav-guard-flowet (ingen separat original ved dette tidspunkt).
-#'
-#' @param app_state Hierarchical reactiveValues
-#' @param input Shiny input (kr\u00e6ves af collect_metadata)
-#' @return Raw bytes \u2014 XLSX file content
-#' @keywords internal
-#' @noRd
-build_spc_excel_blob <- function(app_state, input) {
-  data <- shiny::isolate(app_state$data$current_data)
-  metadata <- collect_metadata(input, app_state)
-
-  temp_path <- build_spc_excel(
-    data = data,
-    metadata = metadata,
-    qic_data = NULL,
-    original_data = data,
-    analysis_options = list()
-  )
-  on.exit(unlink(temp_path), add = TRUE)
-
-  readBin(temp_path, what = "raw", n = file.info(temp_path)$size)
-}
-
-#' Generer brugervenligt filnavn til nav-guard download
-#'
-#' Format: "spc-data_YYYY-MM-DD_HHMMSS.xlsx"
-#'
-#' @param app_state Hierarchical reactiveValues (reserveret til fremtidig
-#'   brug af file_info.name)
-#' @return Character \u2014 filnavn
-#' @keywords internal
-#' @noRd
-generate_spc_filename <- function(app_state) {
-  ts <- format(Sys.time(), "%Y-%m-%d_%H%M%S")
-  paste0("spc-data_", ts, ".xlsx")
-}
+# Excel-blob + filnavn-helpers er flyttet til utils_server_spc_save.R
+# saa nav-guard-download deler implementation med
+# "Download kopi af data og indstillinger"-knappen paa Eksport\u00e9r-trinnet.
+# Begge call-sites genererer nu identisk 3-ark Excel (Data +
+# Indstillinger + SPC-analyse) + samme titel-baserede filnavn.

--- a/R/utils_server_spc_save.R
+++ b/R/utils_server_spc_save.R
@@ -1,0 +1,147 @@
+# utils_server_spc_save.R
+#
+# Faelles helpers for download af biSPCharts Excel-fil med data,
+# indstillinger + SPC-analyse-ark. Genbruges af:
+#   - Eksportér-trinnet ("Download kopi af data og indstillinger"-knap),
+#     se utils_server_wizard_gates.R
+#   - Navigation-guard-modal ("Nulstil"-flow med download-opt-in),
+#     se utils_server_navigation_guard.R
+#
+# Begge call-sites skal levere identisk Excel-output: 3-ark (Data +
+# Indstillinger + SPC-analyse) + samme filnavn-skema. Tidligere havde
+# nav-guard et reduceret 2-ark-output + timestamp-filnavn, hvilket
+# overraskede brugere.
+
+#' Generer titel-baseret filnavn til biSPCharts Excel-download
+#'
+#' Bruger metadata$indicator_title som basis (saniteret + trunkeret til
+#' 50 tegn). Falder tilbage til "data_biSPCharts.xlsx" hvis titel ej er
+#' angivet eller saniteres til tom streng.
+#'
+#' @param app_state Hierarchical reactiveValues
+#' @param input Shiny input (list eller reactivevalues, kraeves af
+#'   collect_metadata)
+#' @return Character — filnavn (.xlsx-suffix)
+#' @keywords internal
+#' @noRd
+spc_save_filename <- function(app_state, input) {
+  md <- collect_metadata(input, app_state)
+  title <- md$indicator_title
+  if (is.null(title) || !nzchar(trimws(title))) {
+    return("data_biSPCharts.xlsx")
+  }
+  safe_title <- sanitize_filename(trimws(title))
+  if (nchar(safe_title) == 0) {
+    return("data_biSPCharts.xlsx")
+  }
+  safe_title <- stringr::str_trunc(safe_title, 50, ellipsis = "")
+  paste0(safe_title, "_biSPCharts.xlsx")
+}
+
+#' Byg fuld biSPCharts Excel-fil fra current app_state
+#'
+#' Producerer 3-ark Excel (Data + Indstillinger + SPC-analyse) via
+#' build_spc_excel(). SPC-analyse-arket bygges hvis build_export_plot()
+#' kan generere qic_data; ellers logges advarsel og arket droppes
+#' gracefully (build_spc_excel haandterer qic_data = NULL).
+#'
+#' analysis_options inkluderer pkg-versions, computed_at-tidsstempel og
+#' freeze_position udledt af data + metadata$frys_column.
+#'
+#' @param app_state Hierarchical reactiveValues
+#' @param input Shiny input (list eller reactivevalues)
+#' @param file Optional path. Hvis non-NULL, kopieres genereret xlsx
+#'   til denne sti (passende til downloadHandler's content-callback).
+#'   Hvis NULL, returneres temp-path direkte (caller skal selv haandtere
+#'   oprydning, fx via on.exit/unlink).
+#' @return Character — sti til xlsx-fil. Hvis file blev sat, returneres
+#'   file-argumentet; ellers returneres en temp-path.
+#' @keywords internal
+#' @noRd
+build_spc_excel_full <- function(app_state, input, file = NULL) {
+  shiny::isolate({
+    data <- app_state$data$current_data
+    metadata <- collect_metadata(input, app_state)
+
+    # Hent qic_data fra senest beregnede SPC-resultat via samme pipeline
+    # som UI-grafen. Fejler hvis kolonner ikke er mappet endnu (typisk
+    # nav-guard-flowet hvor brugeren forlader trin 2 uden plot) — i det
+    # tilfaelde droppes SPC-analyse-arket gracefully.
+    qic_data <- NULL
+    spc_for_export <- tryCatch(
+      build_export_plot(
+        app_state = app_state,
+        title_input = metadata$indicator_title %||% "",
+        dept_input = metadata$export_department %||% "",
+        plot_context = "export_pdf"
+      ),
+      error = function(e) {
+        log_warn(
+          .context = "EXCEL_EXPORT",
+          message = paste(
+            "build_export_plot fejlede ved Excel-download;",
+            "SPC-analyse-ark springes over:", conditionMessage(e)
+          )
+        )
+        NULL
+      }
+    )
+    has_qic <- !is.null(spc_for_export) && is.list(spc_for_export) &&
+      !is.null(spc_for_export$qic_data)
+    if (has_qic) {
+      qic_data <- spc_for_export$qic_data
+    }
+
+    freeze_position <- tryCatch(
+      extract_freeze_position(data, metadata$frys_column),
+      error = function(e) NULL # nolint: swallowed_error_linter
+    )
+
+    analysis_options <- list(
+      pkg_versions = list(
+        biSPCharts = tryCatch(
+          as.character(utils::packageVersion("biSPCharts")),
+          error = function(e) ""
+        ),
+        BFHcharts = tryCatch(
+          as.character(utils::packageVersion("BFHcharts")),
+          error = function(e) ""
+        )
+      ),
+      computed_at = Sys.time(),
+      freeze_position = freeze_position
+    )
+
+    temp_path <- build_spc_excel(
+      data = data,
+      metadata = metadata,
+      qic_data = qic_data,
+      original_data = data,
+      analysis_options = analysis_options
+    )
+
+    if (is.null(file)) {
+      return(temp_path)
+    }
+
+    file.copy(temp_path, file, overwrite = TRUE)
+    unlink(temp_path)
+    file
+  })
+}
+
+#' Byg in-memory Excel-blob (raw bytes) til nav-guard-download
+#'
+#' Wrapper omkring build_spc_excel_full() som returnerer raw bytes,
+#' egnet til base64-encoding + sendCustomMessage("download_blob").
+#'
+#' @param app_state Hierarchical reactiveValues
+#' @param input Shiny input
+#' @return Raw bytes — XLSX file content
+#' @keywords internal
+#' @noRd
+build_spc_excel_blob <- function(app_state, input) {
+  temp_path <- build_spc_excel_full(app_state, input, file = NULL)
+  on.exit(unlink(temp_path), add = TRUE)
+  readBin(temp_path, what = "raw", n = file.info(temp_path)$size)
+}

--- a/R/utils_server_wizard_gates.R
+++ b/R/utils_server_wizard_gates.R
@@ -145,92 +145,19 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
     }
   })
 
-  # Gem til fil: download handler (delt logik mellem trin 2 og trin 3)
-  spc_save_filename <- function() {
-    md <- collect_metadata(input, app_state)
-    title <- md$indicator_title
-    if (is.null(title) || !nzchar(trimws(title))) {
-      return("data_biSPCharts.xlsx")
-    }
-    safe_title <- sanitize_filename(trimws(title))
-    if (nchar(safe_title) == 0) {
-      return("data_biSPCharts.xlsx")
-    }
-    safe_title <- stringr::str_trunc(safe_title, 50, ellipsis = "")
-    paste0(safe_title, "_biSPCharts.xlsx")
+  # Gem til fil: download handler (delt logik mellem trin 2 og trin 3).
+  # Helper-funktioner findes i utils_server_spc_save.R og deles med
+  # navigation-guard-modal saa begge call-sites producerer identisk
+  # 3-ark Excel-fil plus samme titel-baserede filnavn.
+  spc_save_filename_handler <- function() {
+    spc_save_filename(app_state, input)
   }
 
-  spc_save_content <- function(file) {
+  spc_save_content_handler <- function(file) {
     safe_operation(
       "Gem til fil",
       code = {
-        data <- shiny::isolate(app_state$data$current_data)
-        metadata <- collect_metadata(input, app_state)
-
-        # Hent qic_data fra senest beregnede SPC-resultat. build_export_plot()
-        # genererer plot + qic_data via samme pipeline som UI-grafen.
-        # Hvis kaldet fejler eller returnerer NULL, springes SPC-analyse-arket
-        # over (build_spc_excel() haandterer NULL graciously).
-        qic_data <- NULL
-
-        # Cycle C H1 (Codex 2026-05-10): ekstraher freeze_position fra data
-        # + metadata$frys_column saa SPC-analyse-arket Sektion A 'Frozen til
-        # raekke' populeres per spec. extract_freeze_position returnerer NULL
-        # hvis ingen frys_column eller ingen markeringer findes — gracefully
-        # haandteret af build_spc_analysis_sheet.
-        # NB: phase_names er IKKE sat (Codex anbefaling): qic_data$part er
-        # auto-genereret integer-IDs, ej user-labels. Implementer kun naar
-        # eksplicit label-source-kontrakt eksisterer.
-        freeze_position <- tryCatch(
-          extract_freeze_position(data, metadata$frys_column),
-          error = function(e) NULL # nolint: swallowed_error_linter
-        )
-
-        analysis_options <- list(
-          pkg_versions = list(
-            biSPCharts = tryCatch(as.character(utils::packageVersion("biSPCharts")),
-              error = function(e) ""
-            ),
-            BFHcharts = tryCatch(as.character(utils::packageVersion("BFHcharts")),
-              error = function(e) ""
-            )
-          ),
-          computed_at = Sys.time(),
-          freeze_position = freeze_position
-        )
-        spc_for_export <- tryCatch(
-          build_export_plot(
-            app_state = app_state,
-            title_input = metadata$indicator_title %||% "",
-            dept_input = metadata$export_department %||% "",
-            plot_context = "export_pdf"
-          ),
-          error = function(e) {
-            log_warn(
-              .context = "EXCEL_EXPORT",
-              message = paste(
-                "build_export_plot fejlede ved Excel-download;",
-                "SPC-analyse-ark springes over:", conditionMessage(e)
-              )
-            )
-            NULL
-          }
-        )
-        has_qic <- !is.null(spc_for_export) && is.list(spc_for_export) &&
-          !is.null(spc_for_export$qic_data)
-        if (has_qic) {
-          qic_data <- spc_for_export$qic_data
-        }
-
-        temp_path <- build_spc_excel(
-          data = data,
-          metadata = metadata,
-          qic_data = qic_data,
-          original_data = data,
-          analysis_options = analysis_options
-        )
-        on.exit(unlink(temp_path), add = TRUE)
-        file.copy(temp_path, file)
+        build_spc_excel_full(app_state, input, file = file)
       },
       error_type = "processing",
       session = session,
@@ -239,12 +166,12 @@ setup_wizard_gates <- function(input, output, app_state, session, emit) {
   }
 
   output$download_spc_file <- shiny::downloadHandler(
-    filename = spc_save_filename,
-    content = spc_save_content
+    filename = spc_save_filename_handler,
+    content = spc_save_content_handler
   )
   output$download_spc_file_step3 <- shiny::downloadHandler(
-    filename = spc_save_filename,
-    content = spc_save_content
+    filename = spc_save_filename_handler,
+    content = spc_save_content_handler
   )
 
   # Tilbage-knap: Trin 2 -> Trin 1 (via navigation guard)

--- a/tests/testthat/test-navigation-guard.R
+++ b/tests/testthat/test-navigation-guard.R
@@ -229,11 +229,58 @@ test_that("build_spc_excel_blob returns raw bytes with XLSX magic header", {
   expect_equal(as.integer(blob[1:4]), c(0x50, 0x4B, 0x03, 0x04))
 })
 
-test_that("generate_spc_filename returns .xlsx filename with date", {
+test_that("spc_save_filename uses indicator_title when available", {
   app_state <- create_app_state()
-  name <- generate_spc_filename(app_state)
+  input_stub <- list(indicator_title = "Min Indikator")
+  name <- spc_save_filename(app_state, input_stub)
   expect_match(name, "\\.xlsx$")
-  expect_match(name, "\\d{4}-\\d{2}-\\d{2}")
+  expect_match(name, "_biSPCharts\\.xlsx$")
+  expect_match(name, "Min")
+})
+
+test_that("spc_save_filename falls back to data_biSPCharts.xlsx without title", {
+  app_state <- create_app_state()
+  input_stub <- list()
+  name <- spc_save_filename(app_state, input_stub)
+  expect_equal(name, "data_biSPCharts.xlsx")
+})
+
+test_that("nav-guard blob og wizard-handler producerer identisk Excel-struktur", {
+  # Regression-test for fejlrapport 2026-05-17: nav-guard-download
+  # genererede 2-ark Excel mens "Download kopi af data og indstillinger"
+  # paa Eksportér-trinnet gav 3-ark. Begge call-sites skal nu kalde
+  # build_spc_excel_full og producere identisk output.
+  app_state <- create_app_state()
+  shiny::isolate({
+    app_state$data$current_data <- data.frame(
+      dato = as.Date("2026-01-01") + 0:9,
+      taeller = withr::with_seed(42, sample(10, 10))
+    )
+    app_state$columns$mappings$x_column <- "dato"
+    app_state$columns$mappings$y_column <- "taeller"
+  })
+
+  input_stub <- list(indicator_title = "Regressionstest")
+
+  # Path A: wizard-handler skriver til file (downloadHandler-callback)
+  file_a <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(file_a), add = TRUE)
+  build_spc_excel_full(app_state, input_stub, file = file_a)
+
+  # Path B: nav-guard blob → bytes → fil
+  blob <- build_spc_excel_blob(app_state, input_stub)
+  file_b <- tempfile(fileext = ".xlsx")
+  on.exit(unlink(file_b), add = TRUE)
+  writeBin(blob, file_b)
+
+  sheets_a <- openxlsx::getSheetNames(file_a)
+  sheets_b <- openxlsx::getSheetNames(file_b)
+
+  expect_equal(sheets_a, sheets_b)
+  # Begge call-sites skal generere mindst Data + Indstillinger; helper
+  # forsoeger SPC-analyse-ark via build_export_plot. Verifikation af
+  # arknavne sikrer at de to paths ej divergerer fremover.
+  expect_true(all(c("Data", "Indstillinger") %in% sheets_a))
 })
 
 test_that("nav_guard_confirm without download resets session and navigates", {

--- a/tests/testthat/test-spc-excel-freeze-position.R
+++ b/tests/testthat/test-spc-excel-freeze-position.R
@@ -2,24 +2,23 @@
 # Cycle C H1 (Codex 2026-05-10): regression-tests for freeze_position
 # extraction i SPC-analyse-arket.
 #
-# Pre-fix: spc_save_content() byggede analysis_options uden freeze_position.
+# Pre-fix: download-handlers byggede analysis_options uden freeze_position.
 # build_spc_analysis_sheet defaulter til NULL -> Sektion A 'Frozen til
 # raekke' altid tomt. Spec-divergens (openspec/specs/excel-spc-analysis-
 # sheet/spec.md:51 SHALL angive 'Frozen til raekke').
 #
-# Post-fix: spc_save_content kalder extract_freeze_position(data,
-# metadata\$frys_column) og passerer til analysis_options.
+# Post-fix: build_spc_excel_full() kalder extract_freeze_position(data,
+# metadata$frys_column) og passerer til analysis_options. Funktionen er
+# delt mellem wizard-eksport-knappen og navigation-guard-modal download.
 
-test_that("spc_save_content body kalder extract_freeze_position", {
+test_that("build_spc_excel_full body kalder extract_freeze_position", {
   # Body-introspection (R CMD check sikker) — verificer at fix-kald
-  # eksisterer i save-content-kroppen. spc_save_content er defineret som
-  # nested function inde i setup_wizard_gates, saa vi tjekker via
-  # deparse paa parent-funktionen.
-  require_internal("setup_wizard_gates", mode = "function")
-  body_text <- paste(deparse(body(setup_wizard_gates)), collapse = "\n")
+  # eksisterer i den delte Excel-builder-funktion.
+  require_internal("build_spc_excel_full", mode = "function")
+  body_text <- paste(deparse(body(build_spc_excel_full)), collapse = "\n")
   expect_true(
     grepl("extract_freeze_position", body_text),
-    info = "setup_wizard_gates skal kalde extract_freeze_position i spc_save_content"
+    info = "build_spc_excel_full skal kalde extract_freeze_position"
   )
   expect_true(
     grepl("freeze_position\\s*=\\s*freeze_position", body_text),


### PR DESCRIPTION
## Summary
- Nav-guard "Nulstil"-modal download producerede 2-ark Excel + timestamp-filnavn; Eksporter-trinnets download gav 3-ark + titel-baseret filnavn. Brugere fik forskellige filer afhaengig af sti.
- Extraher delt helper \`build_spc_excel_full()\` + \`spc_save_filename()\` til ny \`R/utils_server_spc_save.R\`. Begge call-sites kalder nu samme helper → identisk output.
- SPC-analyse-arket bygges via \`build_export_plot()\`; droppes gracefully hvis kaldet fejler (nav-guard-flow kan ramme dette).

## Test plan
- [x] \`test-navigation-guard.R\` (60/60 pass) inkl. end-to-end regression-test der verificerer identiske arknavne mellem \`build_spc_excel_full\` og \`build_spc_excel_blob\`
- [x] \`test-spc-excel-freeze-position.R\` (7/7 pass) — introspection-target opdateret til ny helper
- [x] \`test-fct_spc_file_save_load.R\` (63/63) + \`test-spc_excel_round_trip.R\` (16/16)
- [x] \`test-mod_export.R\` (83/83 + 3 browser-only skip) + wizard-tests (49/49 + 12/12)
- [x] \`lintr::lint()\` clean paa nye/aendrede filer
- [ ] Manuel UI-verifikation: download samme fil fra (a) nav-guard-modal og (b) Eksporter-trin → bekraefte identisk Excel-struktur + filnavn