### PR TITLE
docs(claude): document PR-target-develop rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@
 2. Push til remote uden anmodning
 3. Tilføj Claude attribution footers (`🤖 Generated with [Claude Code]` /
    `Co-Authored-By: Claude <noreply@anthropic.com>`)
+4. Target PRs mod master/main — alle `fix/feat/test/chore`-PRs SKAL
+   target `develop` (master modtager kun `develop→master` release-PRs)
 
 ---
 


### PR DESCRIPTION
## Summary

Tilføjer pkt 4 til OBLIGATORISKE REGLER i project CLAUDE.md: alle `fix/feat/test/chore`-PRs SKAL target `develop` (master modtager kun `develop→master` release-PRs).

Encoded fra memory `feedback_pr_target_develop` til at sikre fremtidige agent-sessioner ej target master direkte.

Universelle regler (hook-bypass, issue-resolution-workflow, CI-diagnose) tilføjes separat i `claude-config` global rules.

## Test plan

- [x] biSPCharts-specifik regel (sibling-pakker uden develop-branch upåvirket)
- [x] Ingen kodeændringer — kun dokumentation