### PR TITLE
Fix/export tolerate null x mapping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,19 @@
 
 ## Bug fixes
 
+* PDF/PNG-eksport tolererer nu manglende x-kolonne-mapping paa samme
+  maade som analyse-pathen. Tidligere returnerede `build_export_plot()`
+  stille NULL hvis hverken `mappings$x_column` eller
+  `auto_detect$results$x_col` var sat — selv for datasaet hvor
+  analyse-fanen rendrede chart fint via fallback til syntetisk
+  `spc_row_index` (R/fct_spc_plot_generation.R:115-126). Resultatet for
+  brugeren: ingen preview blev vist, og download fejlede med "Ingen
+  plot tilgaengeligt til eksport". Triggeres typisk af indsat data med
+  tom kolonne-header (renamed til `...2`) eller ren tekst-x-kolonne der
+  ikke auto-detekteres. Fix: kun `y_col` er hard-requirement i
+  export-pathen; x_col=NULL propageres til `generateSPCPlot()` som har
+  egen fallback.
+
 * Eliminer root-cause for cycle 11 COLLAPSE_ERROR i
   `call_bfh_chart()`-logging: brug `bfh_params_clean[["n"]]` i stedet
   for `$n`. R's `$`-operator udfører partial-matching og returnerede

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -87,7 +87,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # Export plot reactive - regenerates plot with export-specific dimensions
     # Issue #61: Separate plot generation with context "export_preview" (800x450px)
     # Issue #62: Cache isolated from analysis context
-    # Issue #646: title/dept debounced paa input-niveau (1500ms) — png_width/
+    # Issue #646: title/dept debounced paa input-niveau (1500ms) -- png_width/
     # png_height passerer reactive uden delay for snappy spinner-respons.
     export_plot <- shiny::reactive({
       # TAB-GUARD (Issue #644): hejs guard fra renderPlot til selve reactive.
@@ -98,11 +98,16 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
 
       chart_type <- resolve_export_chart_type(app_state)
 
-      # Single req() call for all required dependencies
+      # Single req() call for all required dependencies.
+      # NB: x_column er IKKE i req() -- den maa vaere NULL (auto-detect kunne
+      # ikke gaette x, fx ved faa raekker eller tekst-x uden dato-format).
+      # build_export_plot tolererer NULL x og generateSPCPlot fallback'er til
+      # spc_row_index (samme som analyse-pathen). Tidligere blokerede req()
+      # paa NULL x_column og preview blev aldrig rendret -- selvom analyse-
+      # fanen viste fungerende chart. Se R/utils_export_helpers.R og NEWS.
       shiny::req(
         app_state,
         app_state$data$current_data,
-        app_state$columns$mappings$x_column,
         app_state$columns$mappings$y_column,
         chart_type,
         nzchar(trimws(chart_type))
@@ -153,10 +158,10 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       # TAB-GUARD (Issue #644): kun beregn pdf_export_plot paa eksporter-tab.
       shiny::req(app_state$session$active_tab == "eksporter")
 
+      # NB: x_column ej i req() -- se kommentar i export_plot reactive ovenfor.
       shiny::req(
         app_state,
         app_state$data$current_data,
-        app_state$columns$mappings$x_column,
         app_state$columns$mappings$y_column
       )
 
@@ -175,7 +180,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     output$export_preview <- shiny::renderPlot(
       {
         # Guard: kun render paa eksporter-tab. suspendWhenHidden=TRUE (linje 224)
-        # hjælper, men bs4Dash-navbar registrerer ej output som hidden i Shiny core.
+        # hjaelper, men bs4Dash-navbar registrerer ej output som hidden i Shiny core.
         # Eksplicit req() via app_state$session$active_tab sikrer korrekt gating
         # og skaber reaktiv dependency saa render genoptages naar brugeren navigerer
         # til eksporter-tab (Issue #407).
@@ -316,7 +321,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # PDF preview reactive - generates PNG preview of Typst PDF layout
     # Only active when format is "pdf"
     # Debounced metadata-inputs til PDF preview (undgaar re-render per tastetryk)
-    # Issue #646: hejs debounce 1000 → 1500ms for at absorbere flere keystrokes
+    # Issue #646: hejs debounce 1000 -> 1500ms for at absorbere flere keystrokes
     # i lange tekst-felter. Behold separate reactives for at undgaa unoedig
     # kobling i pdf-preview-cascade.
     debounced_analysis <- shiny::debounce(
@@ -335,7 +340,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     # PNG-preview kan dele samme debouncer. Definition: se efter debounced_dept.
 
     # ADR-004 exception: effective_analysis_val er session-scoped reactiveVal
-    # — bevidst konstrueret udenfor app_state-hierarkiet fordi diff-check-
+    # -- bevidst konstrueret udenfor app_state-hierarkiet fordi diff-check-
     # idiom kraever Shiny 1.13.0 identical()-semantik paa reactiveVal$set()
     # (skip-invalidation hvis old===new). app_state-fields er hierarkiske
     # reactiveValues; identical-check sker kun mod containerens last-set,
@@ -348,17 +353,17 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     #   - Skipper reactiveVal-update hvis identical med eksisterende (Shiny
     #     1.13.0 source: reactiveVal$set() returnerer FOER invalidation
     #     hvis identical(old, new))
-    #   - pdf_preview_image laeser effective_analysis_val() — invalideres
+    #   - pdf_preview_image laeser effective_analysis_val() -- invalideres
     #     KUN ved reel value-change, ej ved no-op dep-invalidation
     #
     # PRIORITY ORDERING (Codex Shiny flush-simulation): Observer SKAL have
     # eksplicit priority > 0 for at fyre FOER outputs (default priority 0).
     # Priority PLOT_GENERATION (600) er mellem autogen (UI_SYNC=750) og
-    # default outputs — garanterer:
+    # default outputs -- garanterer:
     #   - EFTER autogen-observer (sat last_auto_analysis)
     #   - FOER output-rendering (sikrer effective_analysis_val populated)
     # Uden eksplicit priority ville priority-0 race med outputs reproducere
-    # cycle 11 H1 i ny form (tom 1. render → fuld 2. render).
+    # cycle 11 H1 i ny form (tom 1. render -> fuld 2. render).
     effective_analysis_val <- shiny::reactiveVal(
       shiny::isolate(app_state$ui$last_auto_analysis %||% "")
     )
@@ -377,7 +382,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
     )
 
     pdf_preview_image <- shiny::reactive({
-      # TAB-GUARD (Issue #644): Typst→PNG-render er dyr (~2s) og maa ej koere
+      # TAB-GUARD (Issue #644): Typst->PNG-render er dyr (~2s) og maa ej koere
       # mens brugeren er paa upload/analyser-tab. Tidligere lakage skyldtes at
       # output$pdf_preview kun tab-guardede output-niveauet, ikke reactive-bodyen.
       shiny::req(app_state$session$active_tab == "eksporter")
@@ -495,7 +500,7 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         },
         error_type = "processing"
       )
-    }) |> shiny::debounce(millis = DEBOUNCE_DELAYS$metadata_input) # #646: 1500ms — Typst-render dyr, faerre cascades
+    }) |> shiny::debounce(millis = DEBOUNCE_DELAYS$metadata_input) # #646: 1500ms -- Typst-render dyr, faerre cascades
 
     # PDF preview renderImage - displays PNG preview of Typst PDF layout
     output$pdf_preview <- shiny::renderImage(

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -158,10 +158,15 @@ build_export_plot <- function(app_state, title_input, dept_input,
   y_col <- normalize_mapping(app_state$columns$mappings$y_column) %||%
     normalize_mapping(app_state$columns$auto_detect$results$y_col)
 
-  if (is.null(x_col) || is.null(y_col)) {
+  # y er hard-requirement; uden y er der intet at plotte. x maa vaere NULL --
+  # generateSPCPlot fallback'er til spc_row_index (samme adfaerd som analyse-
+  # pathen, jf. R/fct_spc_plot_generation.R:115-126). Asymmetrisk afvisning
+  # her foer fix gav tom preview + "Ingen plot tilgaengeligt"-fejl ved export
+  # for datasaet uden detekterbar x-kolonne (fx tekst-x, tom header).
+  if (is.null(y_col)) {
     log_warn(
       .context = "EXPORT_MODULE",
-      message = "build_export_plot: Missing required column mappings (x or y)"
+      message = "build_export_plot: Missing required y-column mapping"
     )
     return(NULL)
   }

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -337,6 +337,14 @@ files:
   reviewed: yes
   reviewer: johanreventlow
   reviewed_date: '2026-04-17'
+- file: test-export-null-x-fallback.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-18'
+  rationale: Regression-test for build_export_plot NULL x_column fallback (PR #779) — tilfoejet manuelt.
 - file: test-export-preview-redundans-elimination.R
   audit_category: post-audit
   type: unit

--- a/tests/testthat/test-export-null-x-fallback.R
+++ b/tests/testthat/test-export-null-x-fallback.R
@@ -1,0 +1,140 @@
+# test-export-null-x-fallback.R
+#
+# Regression-test: build_export_plot skal tolerere NULL x_column paa samme
+# maade som analyse-pathen i generateSPCPlot, der falder tilbage til en
+# syntetisk spc_row_index naar x mangler (R/fct_spc_plot_generation.R:115-126).
+#
+# Foer fix: build_export_plot returnerede NULL ved manglende x -> preview blev
+# aldrig rendret og PDF/PNG-download fejlede med "Ingen plot tilgaengeligt".
+# Resultat: bruger saa fungerende chart i analyse-fanen men hverken preview
+# eller eksport i eksport-fanen (asymmetrisk adfaerd, daarligt signal).
+
+skip_if_not_installed("mockery")
+skip_if_not_installed("shiny")
+
+make_export_app_state <- function(x_column = NULL, y_column = "value",
+                                  x_col_auto = NULL, y_col_auto = "value") {
+  shiny::reactiveValues(
+    data = shiny::reactiveValues(
+      current_data = data.frame(
+        label = c("Uge 1", "Uge 2", "Uge 3"),
+        value = c(10, 20, 30),
+        stringsAsFactors = FALSE
+      )
+    ),
+    columns = shiny::reactiveValues(
+      mappings = shiny::reactiveValues(
+        x_column = x_column,
+        y_column = y_column,
+        n_column = NULL,
+        chart_type = "run"
+      ),
+      auto_detect = shiny::reactiveValues(
+        results = list(x_col = x_col_auto, y_col = y_col_auto)
+      )
+    ),
+    visualization = shiny::reactiveValues(
+      last_valid_config = list(chart_type = "run")
+    )
+  )
+}
+
+test_that("build_export_plot tolererer NULL x_column naar y er sat", {
+  if (!exists("build_export_plot", mode = "function")) {
+    skip("build_export_plot ikke tilgaengelig")
+  }
+  withr::local_options(shiny.reactiveConsole = TRUE)
+
+  app_state <- make_export_app_state(x_column = NULL, y_column = "value")
+
+  captured <- new.env(parent = emptyenv())
+  captured$config <- NULL
+  mockery::stub(build_export_plot, "generateSPCPlot", function(...) {
+    args <- list(...)
+    captured$config <- args$config
+    list(
+      plot = "sentinel-plot",
+      bfh_qic_result = list(plot = "sentinel-plot")
+    )
+  })
+
+  result <- shiny::isolate(build_export_plot(
+    app_state = app_state,
+    title_input = "Test",
+    dept_input = "Dept",
+    plot_context = "export_pdf"
+  ))
+
+  expect_false(is.null(result),
+    info = "build_export_plot skal IKKE returnere NULL ved manglende x -- generateSPCPlot haandterer fallback"
+  )
+  expect_equal(result$plot, "sentinel-plot")
+  expect_null(captured$config$x_col,
+    info = "x_col propageres som NULL saa generateSPCPlot-fallback til spc_row_index aktiveres"
+  )
+  expect_equal(captured$config$y_col, "value")
+})
+
+test_that("build_export_plot returnerer NULL ved manglende y_column", {
+  if (!exists("build_export_plot", mode = "function")) {
+    skip("build_export_plot ikke tilgaengelig")
+  }
+  withr::local_options(shiny.reactiveConsole = TRUE)
+
+  app_state <- make_export_app_state(
+    x_column = "label", y_column = NULL,
+    x_col_auto = "label", y_col_auto = NULL
+  )
+
+  generate_spc_called <- FALSE
+  mockery::stub(build_export_plot, "generateSPCPlot", function(...) {
+    generate_spc_called <<- TRUE
+    list(plot = "should-not-reach", bfh_qic_result = list())
+  })
+
+  result <- shiny::isolate(build_export_plot(
+    app_state = app_state,
+    title_input = "Test",
+    dept_input = "Dept",
+    plot_context = "export_pdf"
+  ))
+
+  expect_null(result, info = "y er hard-requirement -- uden y er der intet at plotte")
+  expect_false(generate_spc_called,
+    info = "generateSPCPlot maa ikke kaldes naar y mangler"
+  )
+})
+
+test_that("build_export_plot bruger auto_detect$results$x_col som fallback for mappings", {
+  if (!exists("build_export_plot", mode = "function")) {
+    skip("build_export_plot ikke tilgaengelig")
+  }
+  withr::local_options(shiny.reactiveConsole = TRUE)
+
+  # Scenarie: mappings$x_column er tom streng (normalize_mapping -> NULL),
+  # men auto_detect har en gyldig x_col. Fallback skal aktiveres.
+  app_state <- make_export_app_state(
+    x_column = "", y_column = "value",
+    x_col_auto = "label", y_col_auto = "value"
+  )
+
+  captured <- new.env(parent = emptyenv())
+  captured$config <- NULL
+  mockery::stub(build_export_plot, "generateSPCPlot", function(...) {
+    args <- list(...)
+    captured$config <- args$config
+    list(plot = "ok", bfh_qic_result = list())
+  })
+
+  result <- shiny::isolate(build_export_plot(
+    app_state = app_state,
+    title_input = "Test",
+    dept_input = "Dept",
+    plot_context = "export_pdf"
+  ))
+
+  expect_false(is.null(result))
+  expect_equal(captured$config$x_col, "label",
+    info = "tom mapping -> fallback til auto_detect$results$x_col"
+  )
+})

--- a/tests/testthat/test-export-null-x-fallback.R
+++ b/tests/testthat/test-export-null-x-fallback.R
@@ -41,6 +41,7 @@ make_export_app_state <- function(x_column = NULL, y_column = "value",
 
 test_that("build_export_plot tolererer NULL x_column naar y er sat", {
   if (!exists("build_export_plot", mode = "function")) {
+    # SKIP-REASON: env -- build_export_plot kraever load_all() context
     skip("build_export_plot ikke tilgaengelig")
   }
   withr::local_options(shiny.reactiveConsole = TRUE)
@@ -77,6 +78,7 @@ test_that("build_export_plot tolererer NULL x_column naar y er sat", {
 
 test_that("build_export_plot returnerer NULL ved manglende y_column", {
   if (!exists("build_export_plot", mode = "function")) {
+    # SKIP-REASON: env -- build_export_plot kraever load_all() context
     skip("build_export_plot ikke tilgaengelig")
   }
   withr::local_options(shiny.reactiveConsole = TRUE)
@@ -105,8 +107,64 @@ test_that("build_export_plot returnerer NULL ved manglende y_column", {
   )
 })
 
+test_that("preview_ready evaluerer uden at blokere naar x_column er NULL", {
+  # Regression: tidligere blokerede shiny::req(mappings$x_column) preview-
+  # reactive'erne (export_plot + pdf_export_plot) naar auto-detect ikke kunne
+  # gaette x. Effekt: preview blev aldrig rendret, selvom analyse-pathen viste
+  # fungerende chart via spc_row_index-fallback. Fix: x_column fjernet fra
+  # req()-listerne i begge reactive'er.
+  if (!exists("mod_export_server", mode = "function")) {
+    # SKIP-REASON: env -- mod_export_server kraever fuldt load_all() context
+    skip("mod_export_server ikke tilgaengelig")
+  }
+
+  app_state <- shiny::reactiveValues(
+    data = shiny::reactiveValues(
+      current_data = data.frame(
+        Observation = c("A", "B", "C", "D", "E"),
+        value = c(10, 12, 11, 13, 12),
+        stringsAsFactors = FALSE
+      )
+    ),
+    columns = shiny::reactiveValues(
+      mappings = shiny::reactiveValues(
+        x_column = NULL,
+        y_column = "value",
+        n_column = NULL,
+        chart_type = "run"
+      ),
+      auto_detect = shiny::reactiveValues(
+        results = list(x_col = NULL, y_col = "value")
+      )
+    ),
+    visualization = shiny::reactiveValues(
+      last_valid_config = list(chart_type = "run"),
+      plot_object = NULL,
+      plot_ready = TRUE
+    ),
+    session = shiny::reactiveValues(active_tab = "eksporter"),
+    events = shiny::reactiveValues()
+  )
+
+  shiny::testServer(mod_export_server, args = list(app_state = app_state), {
+    suppressWarnings(session$flushReact())
+    returned <- session$returned
+    ready_value <- tryCatch(returned$preview_ready(),
+      error = function(e) NULL
+    )
+    # Med NULL x_column og valid y_column skal preview_ready evaluere uden
+    # at req() blokerer hele reactive-grafen. Vi accepterer baade FALSE
+    # (fx hvis Quarto mangler) og TRUE -- nogensinde NULL betyder req()
+    # blokerede early og reactive blev droppet.
+    expect_true(is.logical(ready_value),
+      label = "preview_ready skal evaluere til logical -- ikke droppet af req(x_column)"
+    )
+  })
+})
+
 test_that("build_export_plot bruger auto_detect$results$x_col som fallback for mappings", {
   if (!exists("build_export_plot", mode = "function")) {
+    # SKIP-REASON: env -- build_export_plot kraever load_all() context
     skip("build_export_plot ikke tilgaengelig")
   }
   withr::local_options(shiny.reactiveConsole = TRUE)


### PR DESCRIPTION
## Summary
- Fjerner anden sætning af cl_auto_mean-caveat ("Anhøj-analysen er beregnet
  mod gennemsnittet for at undgå falske negative signaler ved diskrete data")
- Trigger-betingelsen (>=50% på medianen) er det handlingsanvisende; selve
  implementations-rationalet hører til i kodekommentarer, ikke i PDF-tekst
- Parallel ændring i da.yaml + en.yaml

## Test plan
- [ ] Manuel inspektion: generér en SPC-PDF for et datasæt der trigger
      cl_auto_mean (≥50% af obs præcis på medianen) — verificér at caveat
      stadig forklarer triggerbetingelsen
- [ ] `devtools::test()` — ingen test refererer den fjernede sætning, men
      bekræft at intet uventet brækker