### PR TITLE
fix(analytics): enable github_sync i production + graceful pin-fallback

### DIFF
--- a/R/utils_analytics_pins.R
+++ b/R/utils_analytics_pins.R
@@ -314,25 +314,49 @@ aggregate_and_pin_logs <- function(log_directory = "logs/",
         }
       } else if (requireNamespace("pins", quietly = TRUE) &&
         nchar(safe_getenv("CONNECT_SERVER")) > 0) {
-        board <- pins::board_connect()
-        safe_pin_data <- filter_shinylogs_allowlist(all_data)
-        pins::pin_write(board, safe_pin_data, config$pin_name,
-          type = "rds",
-          description = paste(
-            "biSPCharts analytics:",
-            nrow(all_data$sessions), "sessions,",
-            nrow(all_data$inputs), "inputs,",
-            nrow(all_data$outputs), "outputs,",
-            nrow(all_data$errors), "errors"
+        # Legacy fallback: pins::board_connect() til Posit Connect Server.
+        # Fejler typisk paa nyere Connect-instanser ("is.character(x) er ikke TRUE")
+        # pga. API-aendringer i pins/connectapi. Logges som warning i stedet for
+        # at lade error propagere ud af safe_operation-fallback.
+        pin_result <- tryCatch(
+          {
+            board <- pins::board_connect()
+            safe_pin_data <- filter_shinylogs_allowlist(all_data)
+            pins::pin_write(board, safe_pin_data, config$pin_name,
+              type = "rds",
+              description = paste(
+                "biSPCharts analytics:",
+                nrow(all_data$sessions), "sessions,",
+                nrow(all_data$inputs), "inputs,",
+                nrow(all_data$outputs), "outputs,",
+                nrow(all_data$errors), "errors"
+              )
+            )
+            list(ok = TRUE)
+          },
+          error = function(e) {
+            list(ok = FALSE, error = conditionMessage(e))
+          }
+        )
+        if (isTRUE(pin_result$ok)) {
+          log_info(
+            paste(
+              "Analytics pin opdateret (Connect Server):",
+              nrow(all_data$sessions), "sessions"
+            ),
+            .context = LOG_CONTEXTS$analytics$pins
           )
-        )
-        log_info(
-          paste(
-            "Analytics pin opdateret (Connect Server):",
-            nrow(all_data$sessions), "sessions"
-          ),
-          .context = LOG_CONTEXTS$analytics$pins
-        )
+        } else {
+          log_warn(
+            paste0(
+              "Legacy Connect Server pin-sync fejlede (",
+              pin_result$error,
+              "). Aktiver analytics.github_sync_enabled + GITHUB_PAT/PIN_REPO_URL ",
+              "for at bruge GitHub-backend."
+            ),
+            .context = LOG_CONTEXTS$analytics$pins
+          )
+        }
       } else {
         log_debug("Ingen analytics-backend konfigureret (GITHUB_PAT/PIN_REPO_URL eller CONNECT_SERVER)",
           .context = LOG_CONTEXTS$analytics$pins

--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -282,10 +282,16 @@ production:
     localstorage_ttl_minutes: 480     # TTL for localStorage (8 timer = klinisk arbejdsdag)
 
   # Analytics (aktiv i production)
+  # NB (2026-05-18): github_sync_enabled flippet til true. Kraever
+  # GITHUB_PAT + PIN_REPO_URL env vars paa Connect-instans (fine-grained
+  # PAT med contents:write paa bispcharts-analytics-data repo). Legacy
+  # pins::board_connect-fallback fejler paa nyere Posit Connect/Cloud
+  # ('is.character(x) er ikke TRUE') saa GitHub-pathen er nu eneste
+  # supported analytics-backend i production.
   analytics:
     enabled: true
-    shinylogs_enabled: false      # Opt-in: sæt til true i deployment-config
-    github_sync_enabled: false    # Opt-in: kræver eksplicit konfiguration
+    shinylogs_enabled: true       # Production-default: log brugs-events
+    github_sync_enabled: true     # Production-default: sync til GitHub data-repo
 
   # AI configuration (production)
   # NB (2026-05-17): AI globalt disabled — production override matcher default.


### PR DESCRIPTION
## Summary

Analytics sync til biSPCharts-analytics-data repo'et havde fejlet siden production-deploy fordi:

1. `analytics.github_sync_enabled = false` i production-profilen → flowet faldt tilbage til legacy `pins::board_connect()`-pathen
2. Posit Connect setter `CONNECT_SERVER` automatisk → fallback aktiveret
3. Legacy `pins::board_connect()` fejler paa nyere Posit Connect-instanser med `is.character(x) er ikke TRUE` (API-aendring i pins/connectapi)
4. Konsekvens: biSPCharts-analytics-dashboardet havde tomme/forkerte data fordi data-repo'et modtog ingen nye sessions

## Changes

- **`inst/golem-config.yml`** production-profil: `github_sync_enabled: true` + `shinylogs_enabled: true`. Default + dev + testing forbliver opt-in.
- **`R/utils_analytics_pins.R`**: legacy `pins::board_connect()`-fallback indpakket i `tryCatch` saa den fejler graceful med beskrivende `log_warn` i stedet for at propagere error.

## Test plan

- [x] `testthat::test_file("tests/testthat/test-utils_analytics_pins.R")`: 46 PASS, 0 FAIL
- [ ] Deploy til Posit Connect + verificer at:
  - Ingen `Sync analytics data fejlede`-errors i logs efter session-end
  - Nye `.rds`-filer ankommer i `bispcharts-analytics-data`-repo'et
  - biSPCharts-analytics-dashboardet viser oprigtigt antal sessions/inputs
- [ ] Verificer at GITHUB_PAT + PIN_REPO_URL er sat paa Connect-instansen

## Pre-conditions for deploy

Connect-instansen SKAL have:

| Env var | Vaerdi |
|---------|--------|
| `GITHUB_PAT` | Fine-grained PAT med contents:write paa `bispcharts-analytics-data` |
| `PIN_REPO_URL` | `https://github.com/johanreventlow/bispcharts-analytics-data.git` |
| `PIN_REPO_BRANCH` | Valgfri (default `main`) |

Hvis env vars mangler: flowet logger `env_not_set` warning og skipper sync (ikke crash).