### PR TITLE
fix(analytics): brug YAML-config-API frem for runtime-options

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -37,7 +37,7 @@ main_app_server <- function(input, output, session) {
   # get_golem_config() læser inst/golem-config.yml; tryCatch→FALSE hvis nøgle mangler.
   # Matcher mønster i utils_lazy_loading.R (advanced_debug condition).
   debug_mode_on <- isTRUE(tryCatch(
-    golem::get_golem_options("debug_mode_enabled"),
+    get_golem_config("debug_mode_enabled"),
     error = function(e) FALSE
   )) || isTRUE(safe_getenv("SPC_DEBUG_MODE", FALSE, "logical"))
   if (debug_mode_on) {

--- a/R/fct_file_validation.R
+++ b/R/fct_file_validation.R
@@ -372,8 +372,11 @@ handle_upload_error <- function(error, file_info, session_id = NULL) {
   )
 
   # Gate tekniske fejldetaljer bag hide_error_details (default TRUE i produktion)
+  # NB: get_golem_config (YAML) frem for golem::get_golem_options (runtime).
+  # YAML har nestet security.hide_error_details (prod=true, dev=false).
+  # app.R uden with_golem_options → get_golem_options returnerer NULL.
   hide_details <- tryCatch(
-    isTRUE(golem::get_golem_options("hide_error_details", default = TRUE)),
+    isTRUE(get_golem_config("security")$hide_error_details),
     error = function(e) TRUE # nolint: swallowed_error_linter
   )
 

--- a/R/utils_analytics_pins.R
+++ b/R/utils_analytics_pins.R
@@ -290,7 +290,15 @@ aggregate_and_pin_logs <- function(log_directory = "logs/",
   safe_operation(
     "Sync analytics data",
     code = {
-      github_sync_enabled <- isTRUE(golem::get_golem_options("analytics.github_sync_enabled"))
+      # NB: brug get_golem_config (YAML-config) frem for golem::get_golem_options
+      # (runtime-options). app.R kalder shiny::shinyApp direkte uden with_golem_options,
+      # saa get_golem_options returnerer NULL paa Connect Cloud.
+      github_sync_enabled <- isTRUE(
+        tryCatch(
+          get_golem_config("analytics")$github_sync_enabled,
+          error = function(e) FALSE
+        )
+      )
       if (github_sync_enabled &&
         nchar(safe_getenv("GITHUB_PAT")) > 0 &&
         nchar(safe_getenv("PIN_REPO_URL")) > 0) {

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -110,8 +110,12 @@ activate_session_timeout_from_config <- function(input, session,
                                                  .scheduler = later::later) {
   # Hent timeout fra security-blok i golem-config (production: 60 min, dev: 480 min)
   # Kilde: inst/golem-config.yml -> <env>:security:session_timeout_minutes
+  # NB: get_golem_config (YAML) frem for golem::get_golem_options (runtime).
+  # app.R kalder shiny::shinyApp() direkte uden with_golem_options, saa
+  # get_golem_options returnerer NULL paa Connect Cloud — timeout blev
+  # silent deaktiveret. Se ADR-019 + commit 8ee8790f.
   timeout_minutes <- tryCatch(
-    golem::get_golem_options("security")$session_timeout_minutes,
+    get_golem_config("security")$session_timeout_minutes,
     error = function(e) {
       log_debug(
         paste("get_golem_config('security') fejlede:", conditionMessage(e)),

--- a/R/utils_shinylogs_config.R
+++ b/R/utils_shinylogs_config.R
@@ -121,8 +121,11 @@ resolve_analytics_config <- function() {
   if (toupper(disable_flag) %in% c("TRUE", "1", "YES", "ON")) {
     return(list(enabled = FALSE, source = "env:BISPC_DISABLE_ANALYTICS"))
   }
+  # NB: brug get_golem_config (YAML-config) frem for golem::get_golem_options
+  # (runtime-options). app.R kalder shiny::shinyApp direkte uden with_golem_options,
+  # saa get_golem_options returnerer NULL paa Connect Cloud.
   config_val <- tryCatch(
-    golem::get_golem_options("analytics.shinylogs_enabled"),
+    get_golem_config("analytics")$shinylogs_enabled,
     error = function(e) NULL # nolint: swallowed_error_linter. Golem-config kan mangle uden for app-kontekst
   )
   if (!is.null(config_val)) {

--- a/tests/testthat/test-audit-analytics-logging-privacy.R
+++ b/tests/testthat/test-audit-analytics-logging-privacy.R
@@ -36,9 +36,10 @@ test_that("resolve_analytics_config(): ENABLE_SHINYLOGS=FALSE giver FALSE naar c
   withr::with_envvar(
     list(BISPC_DISABLE_ANALYTICS = "", ENABLE_SHINYLOGS = "FALSE"),
     {
+      # Stub get_golem_config -> NULL simulerer "config-blok mangler"
       mockery::stub(
         resolve_analytics_config,
-        "golem::get_golem_options",
+        "get_golem_config",
         NULL
       )
       expect_false(resolve_analytics_config()$enabled)
@@ -50,10 +51,11 @@ test_that("resolve_analytics_config(): config-flag FALSE returnerer FALSE selv m
   withr::with_envvar(
     list(BISPC_DISABLE_ANALYTICS = "", ENABLE_SHINYLOGS = "TRUE"),
     {
+      # resolve_analytics_config gør get_golem_config("analytics")$shinylogs_enabled
       mockery::stub(
         resolve_analytics_config,
-        "golem::get_golem_options",
-        FALSE
+        "get_golem_config",
+        list(shinylogs_enabled = FALSE)
       )
       expect_false(resolve_analytics_config()$enabled)
     }
@@ -66,8 +68,8 @@ test_that("resolve_analytics_config(): config-flag TRUE returnerer TRUE", {
     {
       mockery::stub(
         resolve_analytics_config,
-        "golem::get_golem_options",
-        TRUE
+        "get_golem_config",
+        list(shinylogs_enabled = TRUE)
       )
       expect_true(resolve_analytics_config()$enabled)
     }


### PR DESCRIPTION
## Root cause

`app.R` (Connect Cloud entry-point) kalder \`shiny::shinyApp()\` direkte i stedet for \`golem::run_app()\` med \`with_golem_options\`. Konsekvens:

- \`golem::get_golem_options("analytics.X")\` returnerer **NULL** paa Connect Cloud (runtime-options aldrig sat)
- Konfig-checks i \`aggregate_and_pin_logs\` og \`resolve_analytics_config\` faldt til legacy/fallback paths
- Det forklarer hvorfor logs viste \`source = "env:ENABLE_SHINYLOGS (legacy)"\` i stedet for \`"golem-config"\`
- Og hvorfor \`github_sync_enabled = false\` selvom production-profilen havde \`true\` (PR #781 + #782)

## Verified locally

| API | Returnerer |
|-----|------------|
| \`golem::get_golem_options("analytics.github_sync_enabled")\` | \`NULL\` (broken) |
| \`get_golem_config("analytics")\$github_sync_enabled\` | \`TRUE\` (virker) |

\`get_golem_config\` (lokal wrapper i \`R/app_ui.R:272\`) laeser YAML direkte via \`config::get\` med \`GOLEM_CONFIG_ACTIVE\` som profil-selector.

## Changes

- \`R/utils_analytics_pins.R\`: \`github_sync_enabled\`-check skifter til \`get_golem_config\` med tryCatch-fallback
- \`R/utils_shinylogs_config.R\`: \`resolve_analytics_config\` samme skift

## Test plan

- [x] Lokal verify: \`shinylogs enabled: TRUE (source: golem-config)\` post-fix vs \`(source: env:ENABLE_SHINYLOGS legacy)\` pre-fix
- [x] \`testthat::test_file("tests/testthat/test-utils_analytics_pins.R")\`: 46 PASS, 0 FAIL
- [ ] Connect Cloud deploy: verificer at logs nu viser \`Analytics synket til GitHub: <filename>.rds\` ved session-end
- [ ] Verificer at \`bispcharts-analytics-data\`-repo modtager nye .rds-filer

## Follow-up (out of scope)

ADR-019 dokumenterer at \`app.R\` bevidst bruger pkgload + shinyApp i stedet for run_app for Connect Cloud-deploy. En mere thorough fix ville vaere at konvertere alle \`get_golem_options\` til \`get_golem_config\` overalt i codebasen (search viser ~5-10 steder). Denne PR fixer kun analytics-flowet.