### PR TITLE
fix(session-timeout): positionelt kald af .scheduler for later::later-kompat

### DIFF
--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -28,8 +28,9 @@ session_timeout_message <- function() {
 #'
 #' @param session Shiny session-objekt (skal have \code{$close()}-metode)
 #' @param minutes Antal minutter til timeout (numerisk, positiv)
-#' @param .scheduler Funktion med signatur \code{function(callback, delay_secs)}.
-#'   Default: \code{later::later}. Override i tests for synkron eksekvering.
+#' @param .scheduler Funktion kaldt positionelt med \code{(callback_fn, delay_secs)}.
+#'   Default: \code{later::later} (signatur \code{(func, delay)}). Override i
+#'   tests med synkron stub. Arg-navne i stub er ligegyldige — kaldes positionelt.
 #' @return List med:
 #'   \describe{
 #'     \item{cancel}{Funktion der annullerer planlagt callback (no-op hvis allerede udlobet)}
@@ -47,8 +48,13 @@ setup_session_timeout <- function(session, minutes,
 
   schedule_disconnect <- function() {
     cancelled <<- FALSE
+    # NB: positionelt kald — later::later har signatur (func, delay).
+    # Tidligere brugte vi callback=/delay=-navne, hvilket virkede for
+    # test-fake-schedulers men kraschede later::later i production
+    # (ubrugt argument 'callback'). Aktiveret session timeout i prod
+    # via fix(config) commit 85950038 eksponerede bug.
     handle <<- .scheduler(
-      callback = function() {
+      function() {
         if (cancelled) {
           return(invisible(NULL))
         }
@@ -73,7 +79,7 @@ setup_session_timeout <- function(session, minutes,
           }
         )
       },
-      delay = delay_secs
+      delay_secs
     )
     invisible(NULL)
   }


### PR DESCRIPTION
## Summary

**Production deploy-fejl** — session timeout aktiveret af PR #783 ramte latent bug i `schedule_disconnect`.

`.scheduler(callback=..., delay=...)` virkede for test-fake-schedulers men kraschede `later::later` i production: `Error in .scheduler(callback = function() { : ubrugt argument`. `later::later`-signatur er `(func, delay)`, ej `(callback, delay)`.

Fix: positionelt kald — virker for begge.

## Deploy-stacktrace

```
Error in .scheduler(callback = function() { :
  ubrugt argument (callback = function() {...})
58: schedule_disconnect [utils_server_session_helpers.R#50]
57: setup_session_timeout [utils_server_session_helpers.R#82]
56: activate_session_timeout_from_config [utils_server_session_helpers.R#142]
55: main_app_server [app_server_main.R#204]
Error reading from Shiny: websocket: close 1011 (internal server error)
```

WebSocket lukket → klient kunne ikke connecte → app uanvendelig på Connect Cloud.

## Root cause

PR #783 migrerede `golem::get_golem_options("security")` → `get_golem_config("security")` i `activate_session_timeout_from_config()`. Før migration returnerede `golem::get_golem_options` NULL → timeout silent deaktiveret → `schedule_disconnect()` aldrig kaldt → bug aldrig eksponeret.

Efter migration læses `session_timeout_minutes: 60` korrekt fra YAML → timeout aktiveres → `schedule_disconnect()` kalder `.scheduler(callback=..., delay=...)` → kraschede.

## Verificeret

- [x] 13/13 PASS `test-session-timeout.R` (test-fake-schedulers stadig kompatible — kaldes positionelt)
- [x] Real `later::later` smoke-test: session$close kaldt efter 1s timeout
- [x] Pre-push: lintr OK, manifest OK, test-classification OK, hurtige regressionstests OK (68s)

## Test plan

- [ ] Pilot-deploy til Connect Cloud — verificér session starter uden crash
- [ ] Manuel verifikation: vent 60 min, observér timeout-notifikation + disconnect
- [ ] Verificér reset-funktionalitet ved bruger-input

## Reference

- Production deploy-log 2026-05-18T20:31:01+02:00
- PR #783 (forrige commit der eksponerede bug)