### PR TITLE
Harden export autosave + cache propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ dev/audit-output/*.rds
 !dev/audit-output/test-audit.json
 # Undtagelse: skip-inventory.json er baseline for CI delta-comparison
 !dev/audit-output/skip-inventory.json
+
+# Tooling-state (Antigravity CLI lokal state)
+.antigravitycli/

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Bug fixes
 
+* Auto-save metadata-only path er gjort mere robust. Serveren markerer nu
+  foerst metadata-only saves som gemt efter JS-confirm (`mode='metadata'`),
+  full-save readiness-observeren koerer med hoej state-management priority,
+  og browserens `updateAppStateMetadata()` afviser payloads med forkert
+  schema-version i stedet for at opgradere gammel data ved kun at skrive
+  metadata. Samtidig fjernes debug-`console.log` fra den nye
+  metadata-only handler.
+
 * PDF/PNG-eksport tolererer nu manglende x-kolonne-mapping paa samme
   maade som analyse-pathen. Tidligere returnerede `build_export_plot()`
   stille NULL hvis hverken `mappings$x_column` eller

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,16 @@
   metadata. Samtidig fjernes debug-`console.log` fra den nye
   metadata-only handler.
 
+* PDF/PNG-eksport sender nu `app_state` videre til `generateSPCPlot()`, saa
+  export-pathen bruger samme SPC-cache som analyse-rendering. Tidligere
+  rekomputerede eksport-preview og download BFHcharts-resultatet fra bunden,
+  selv naar samme `export_pdf` plot netop var genereret.
+
+* PDF-eksport sender ikke laengere `title` som BFHcharts-metadatafelt.
+  Titlen kommer fra `bfh_qic_result$config$chart_title`; det ekstra
+  metadatafelt gav advarslen "Unknown metadata fields will be ignored: title"
+  under download.
+
 * PDF/PNG-eksport tolererer nu manglende x-kolonne-mapping paa samme
   maade som analyse-pathen. Tidligere returnerede `build_export_plot()`
   stille NULL hvis hverken `mappings$x_column` eller

--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -33,9 +33,9 @@ register_export_downloads <- function(output, input, session, app_state) {
         department = input$export_department %||% ""
       )
 
-      log_info(
+      log_debug(
         .context = "EXPORT_MODULE",
-        message = "Download initiated",
+        message = "Download filename resolved",
         details = list(format = format, filename = filename)
       )
 
@@ -50,6 +50,12 @@ register_export_downloads <- function(output, input, session, app_state) {
       safe_operation(
         operation_name = paste("Export", toupper(format)),
         code = {
+          log_info(
+            .context = "EXPORT_MODULE",
+            message = "Download initiated",
+            details = list(format = format)
+          )
+
           if (format == "pdf") {
             generate_pdf_export(input, app_state, file)
           } else if (format == "png") {

--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -165,7 +165,6 @@ generate_pdf_export <- function(input, app_state, file) {
   metadata <- list(
     hospital = escape_typst_metadata(hospital_value),
     department = escape_typst_metadata(input$export_department),
-    title = escape_typst_metadata(input$export_title),
     analysis = escape_typst_metadata(input$pdf_improvement),
     data_definition = escape_typst_metadata(data_definition_with_note),
     footer_content = if (nzchar(footnote_value)) escape_typst_metadata(footnote_value) else NULL,

--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -246,6 +246,7 @@ build_export_plot <- function(app_state, title_input, dept_input,
         base_size = 14,
         viewport_width = final_width,
         viewport_height = final_height,
+        app_state = app_state,
         plot_context = plot_context
       )
       # PNG export: override DPI for correct dimension conversion (Issue #64)

--- a/R/utils_local_storage.R
+++ b/R/utils_local_storage.R
@@ -238,6 +238,52 @@ saveDataLocally <- function(session, data, metadata = NULL) {
   )
 }
 
+save_metadata_locally <- function(session, metadata) {
+  safe_operation(
+    "Save metadata to local storage",
+    code = {
+      metadata_json <- jsonlite::toJSON(
+        metadata,
+        auto_unbox = TRUE,
+        pretty = FALSE,
+        digits = NA,
+        na = "null"
+      )
+      metadata_raw <- as.character(metadata_json)
+      invalid_metadata <- is.null(metadata_raw) ||
+        length(metadata_raw) == 0 ||
+        nchar(metadata_raw) == 0
+      if (invalid_metadata) {
+        stop("JSON konvertering resulterede i tom metadata")
+      }
+
+      log_debug(
+        sprintf("Sending %d bytes metadata update to browser localStorage", nchar(metadata_raw)),
+        .context = "LOCAL_STORAGE"
+      )
+
+      session$sendCustomMessage(
+        type = "updateAppStateMetadata",
+        message = list(
+          key = "current_session",
+          metadata = metadata_raw,
+          version = LOCAL_STORAGE_SCHEMA_VERSION
+        )
+      )
+    },
+    fallback = function(e) {
+      log_error(
+        paste("Kunne ikke gemme metadata lokalt:", e$message),
+        .context = "LOCAL_STORAGE"
+      )
+      FALSE
+    },
+    error_type = "local_storage",
+    session = session,
+    show_user = FALSE
+  )
+}
+
 ## Load data med logging
 loadDataLocally <- function(session) {
   safe_operation(

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -255,6 +255,49 @@ flush_session_save_on_exit <- function(session, input, app_state) {
 
 # Dependencies ----------------------------------------------------------------
 
+#' Build Stable Auto-Save Data Signature
+#'
+#' Computes a stable signature for the data payload that is persisted to
+#' localStorage.
+#'
+#' @param data data.frame or compatible object to persist.
+#'
+#' @return Character hash suitable for equality checks.
+#' @keywords internal
+auto_save_data_sig <- function(data) {
+  digest::digest(data, algo = "xxhash64", serialize = TRUE)
+}
+
+#' Build Stable Auto-Save Metadata Signature
+#'
+#' Computes a stable signature for persisted UI metadata.
+#'
+#' @param metadata Named list with persisted UI metadata.
+#'
+#' @return Character hash suitable for equality checks.
+#' @keywords internal
+auto_save_meta_sig <- function(metadata) {
+  digest::digest(metadata, algo = "xxhash64", serialize = TRUE)
+}
+
+#' Build Stable Auto-Save Payload Signature
+#'
+#' Computes a stable signature for the data + metadata payload that is persisted
+#' to localStorage. The volatile save timestamp is intentionally excluded; it is
+#' added inside `saveDataLocally()` and must not make unchanged payloads look new.
+#'
+#' @param data data.frame or compatible object to persist.
+#' @param metadata Named list with persisted UI metadata.
+#'
+#' @return Character hash suitable for equality checks.
+#' @keywords internal
+auto_save_payload_sig <- function(data, metadata) {
+  digest::digest(list(
+    data_hash = auto_save_data_sig(data),
+    metadata_hash = auto_save_meta_sig(metadata)
+  ), algo = "xxhash64", serialize = TRUE)
+}
+
 ## Hovedfunktion for hjaelper
 # Opsaetter alle hjaelper observers og status funktioner
 setup_helper_observers <- function(input, output, session, obs_manager = NULL, app_state = NULL) {
@@ -319,16 +362,80 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
     millis = get_save_interval_ms()
   )
 
+  # Shared gate for all auto-save paths in this session. Full saves send data +
+  # metadata. Metadata-only saves update the browser's existing localStorage
+  # payload in place, preserving the restore schema while avoiding data resend.
+  last_data_sig <- NULL
+  last_save_sig <- NULL
+  full_save_sent <- FALSE
+  full_save_ready <- FALSE
+  obs_full_save_ready <- shiny::observeEvent(input$local_storage_save_result,
+    {
+      result <- input$local_storage_save_result
+      if (is.null(result) || !identical(result$key, "current_session")) {
+        return(invisible(NULL))
+      }
+
+      mode <- result$mode %||% "full"
+      if (identical(mode, "full")) {
+        full_save_ready <<- isTRUE(result$success)
+      }
+    },
+    ignoreNULL = TRUE
+  )
+  if (!is.null(obs_manager)) {
+    obs_manager$add(obs_full_save_ready, "auto_save_full_ready")
+  }
+
+  save_if_payload_changed <- function(save_data, source) {
+    if (!is_persistence_allowed(session$input)) {
+      autoSaveAppState(session, save_data$data, save_data$metadata,
+        app_state = app_state
+      )
+      return(invisible(FALSE))
+    }
+
+    current_signature <- auto_save_payload_sig(
+      save_data$data,
+      save_data$metadata
+    )
+    current_data_sig <- auto_save_data_sig(save_data$data)
+    if (identical(last_save_sig, current_signature)) {
+      log_debug(
+        sprintf("%s sprunget over: data+metadata uaendret", source),
+        .context = "AUTO_SAVE"
+      )
+      return(invisible(FALSE))
+    }
+
+    data_changed <- !identical(last_data_sig, current_data_sig)
+    if (isTRUE(full_save_sent) && isTRUE(full_save_ready) && !data_changed) {
+      result <- save_metadata_locally(session, save_data$metadata)
+      if (!identical(result, FALSE)) {
+        last_save_sig <<- current_signature
+      }
+      return(invisible(TRUE))
+    }
+
+    # NB: last_save_time opdateres af local_storage_save_result observer
+    # naar JS-siden bekraefter success -- ikke her.
+    result <- autoSaveAppState(session, save_data$data, save_data$metadata,
+      app_state = app_state
+    )
+    if (!identical(result, FALSE)) {
+      last_data_sig <<- current_data_sig
+      last_save_sig <<- current_signature
+      full_save_sent <<- TRUE
+    }
+    invisible(TRUE)
+  }
+
   if (auto_save_feature_enabled) {
     obs_data_save <- shiny::observe({
       save_data <- auto_save_trigger()
       shiny::req(save_data) # Only proceed if we have valid save data
 
-      # NB: last_save_time opdateres af local_storage_save_result observer
-      # naar JS-siden bekraefter success -- ikke her.
-      autoSaveAppState(session, save_data$data, save_data$metadata,
-        app_state = app_state
-      )
+      save_if_payload_changed(save_data, "data_auto_save")
     })
 
     # Register observer with manager
@@ -442,13 +549,6 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
     millis = get_settings_save_interval_ms() # Faster debounce for settings
   )
 
-  # Diff-check: undgaar duplicate localStorage-writes naar payload er identisk.
-  # Eksempel: tab-revisit uden aendringer fyrer settings_save_trigger to gange
-  # med identisk metadata. last_settings_payload fanges i closure (per session).
-  # NB: sammenligner kun metadata, IKKE data + timestamp — timestamp aendres
-  # hver gang og ville goere diff-checket virkningslost.
-  last_settings_payload <- NULL
-
   obs_settings_save <- if (auto_save_feature_enabled) {
     # Ingen bindEvent her: settings_save_trigger har nu selv eksplicitte
     # input-deps, saa den fyrer via sin egen debounce naar inputs aendres.
@@ -465,25 +565,7 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
       save_data <- settings_save_trigger()
       shiny::req(save_data) # Only proceed if we have valid save data
 
-      # Diff-check: spring over hvis metadata er identisk med sidst gemte.
-      # Fanger duplikater ved tab-revisit, identisk input-reaafiring o.l.
-      # NB: de to events i #396-loggen (NULL → genereret tekst) har FORSKELLIG
-      # metadata og passerer begge igennem — det er intentionelt korrekt adfaerd.
-      current_payload <- jsonlite::toJSON(save_data$metadata, auto_unbox = TRUE)
-      if (identical(last_settings_payload, current_payload)) {
-        log_debug(
-          "settings_save sprunget over: payload uaendret",
-          .context = "AUTO_SAVE"
-        )
-        return(invisible(NULL))
-      }
-      last_settings_payload <<- current_payload
-
-      # NB: last_save_time opdateres af local_storage_save_result observer
-      # naar JS-siden bekraefter success -- ikke her.
-      autoSaveAppState(session, save_data$data, save_data$metadata,
-        app_state = app_state
-      )
+      save_if_payload_changed(save_data, "settings_save")
     })
   } else {
     NULL

--- a/R/utils_server_session_helpers.R
+++ b/R/utils_server_session_helpers.R
@@ -367,6 +367,7 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
   # payload in place, preserving the restore schema while avoiding data resend.
   last_data_sig <- NULL
   last_save_sig <- NULL
+  pending_metadata_sig <- NULL
   full_save_sent <- FALSE
   full_save_ready <- FALSE
   obs_full_save_ready <- shiny::observeEvent(input$local_storage_save_result,
@@ -379,9 +380,18 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
       mode <- result$mode %||% "full"
       if (identical(mode, "full")) {
         full_save_ready <<- isTRUE(result$success)
+      } else if (identical(mode, "metadata")) {
+        if (isTRUE(result$success) && !is.null(pending_metadata_sig)) {
+          last_save_sig <<- pending_metadata_sig
+        } else if (!isTRUE(result$success)) {
+          full_save_ready <<- FALSE
+          full_save_sent <<- FALSE
+        }
+        pending_metadata_sig <<- NULL
       }
     },
-    ignoreNULL = TRUE
+    ignoreNULL = TRUE,
+    priority = OBSERVER_PRIORITIES$HIGH
   )
   if (!is.null(obs_manager)) {
     obs_manager$add(obs_full_save_ready, "auto_save_full_ready")
@@ -410,9 +420,12 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
 
     data_changed <- !identical(last_data_sig, current_data_sig)
     if (isTRUE(full_save_sent) && isTRUE(full_save_ready) && !data_changed) {
+      if (identical(pending_metadata_sig, current_signature)) {
+        return(invisible(FALSE))
+      }
       result <- save_metadata_locally(session, save_data$metadata)
       if (!identical(result, FALSE)) {
-        last_save_sig <<- current_signature
+        pending_metadata_sig <<- current_signature
       }
       return(invisible(TRUE))
     }
@@ -425,6 +438,7 @@ setup_helper_observers <- function(input, output, session, obs_manager = NULL, a
     if (!identical(result, FALSE)) {
       last_data_sig <<- current_data_sig
       last_save_sig <<- current_signature
+      pending_metadata_sig <<- NULL
       full_save_sent <<- TRUE
     }
     invisible(TRUE)

--- a/inst/app/www/local-storage.js
+++ b/inst/app/www/local-storage.js
@@ -104,6 +104,38 @@ window.saveAppState = function(key, data) {
   }
 };
 
+window.updateAppStateMetadata = function(key, metadataJson, version) {
+  if (!_spcIsPersistenceAllowed()) {
+    console.debug('[SPC] updateAppStateMetadata blocked: consent not granted');
+    return false;
+  }
+
+  var storageKey = 'spc_app_' + key;
+  try {
+    var raw = localStorage.getItem(storageKey);
+    if (!raw) {
+      console.warn('[SPC] updateAppStateMetadata failed: no existing app state');
+      return false;
+    }
+
+    var payload = JSON.parse(raw);
+    if (!payload || !payload.data) {
+      console.warn('[SPC] updateAppStateMetadata failed: existing state has no data');
+      return false;
+    }
+
+    payload.metadata = JSON.parse(metadataJson);
+    payload.timestamp = new Date().toISOString();
+    payload.version = version;
+
+    localStorage.setItem(storageKey, JSON.stringify(payload));
+    return true;
+  } catch(e) {
+    console.error('Failed to update localStorage metadata:', e);
+    return false;
+  }
+};
+
 // Load data from localStorage
 // Issue #193: Ved parse-fejl (fx gammel double-encoded data fra tidligere
 // version) rydder vi automatisk storage så brugeren ikke sidder fast i

--- a/inst/app/www/local-storage.js
+++ b/inst/app/www/local-storage.js
@@ -124,6 +124,11 @@ window.updateAppStateMetadata = function(key, metadataJson, version) {
       return false;
     }
 
+    if (payload.version !== version) {
+      console.warn('[SPC] updateAppStateMetadata failed: schema version mismatch');
+      return false;
+    }
+
     payload.metadata = JSON.parse(metadataJson);
     payload.timestamp = new Date().toISOString();
     payload.version = version;

--- a/inst/app/www/shiny-handlers.js
+++ b/inst/app/www/shiny-handlers.js
@@ -27,10 +27,7 @@ Shiny.addCustomMessageHandler('saveAppState', function(message) {
 });
 
 Shiny.addCustomMessageHandler('updateAppStateMetadata', function(message) {
-  var dataLen = message.metadata ? message.metadata.length : 0;
-  console.log('[SPC] updateAppStateMetadata handler called, key:', message.key, 'size:', dataLen);
   var success = window.updateAppStateMetadata(message.key, message.metadata, message.version);
-  console.log('[SPC] updateAppStateMetadata success:', success);
   if (success) {
     window._spcLastSaveTime = Date.now();
     _spcUpdateSaveElapsed();

--- a/inst/app/www/shiny-handlers.js
+++ b/inst/app/www/shiny-handlers.js
@@ -21,7 +21,27 @@ Shiny.addCustomMessageHandler('saveAppState', function(message) {
   Shiny.setInputValue('local_storage_save_result', {
     success: success,
     timestamp: new Date().toISOString(),
-    key: message.key
+    key: message.key,
+    mode: 'full'
+  }, {priority: 'event'});
+});
+
+Shiny.addCustomMessageHandler('updateAppStateMetadata', function(message) {
+  var dataLen = message.metadata ? message.metadata.length : 0;
+  console.log('[SPC] updateAppStateMetadata handler called, key:', message.key, 'size:', dataLen);
+  var success = window.updateAppStateMetadata(message.key, message.metadata, message.version);
+  console.log('[SPC] updateAppStateMetadata success:', success);
+  if (success) {
+    window._spcLastSaveTime = Date.now();
+    _spcUpdateSaveElapsed();
+  } else {
+    console.error('updateAppStateMetadata failed for key:', message.key);
+  }
+  Shiny.setInputValue('local_storage_save_result', {
+    success: success,
+    timestamp: new Date().toISOString(),
+    key: message.key,
+    mode: 'metadata'
   }, {priority: 'event'});
 });
 

--- a/tests/testthat/test-export-null-x-fallback.R
+++ b/tests/testthat/test-export-null-x-fallback.R
@@ -53,6 +53,7 @@ test_that("build_export_plot tolererer NULL x_column naar y er sat", {
   mockery::stub(build_export_plot, "generateSPCPlot", function(...) {
     args <- list(...)
     captured$config <- args$config
+    captured$app_state <- args$app_state
     list(
       plot = "sentinel-plot",
       bfh_qic_result = list(plot = "sentinel-plot")
@@ -74,6 +75,9 @@ test_that("build_export_plot tolererer NULL x_column naar y er sat", {
     info = "x_col propageres som NULL saa generateSPCPlot-fallback til spc_row_index aktiveres"
   )
   expect_equal(captured$config$y_col, "value")
+  expect_identical(captured$app_state, app_state,
+    info = "app_state skal sendes videre saa export-pathen kan bruge SPC-cache"
+  )
 })
 
 test_that("build_export_plot returnerer NULL ved manglende y_column", {

--- a/tests/testthat/test-export-null-x-fallback.R
+++ b/tests/testthat/test-export-null-x-fallback.R
@@ -35,7 +35,8 @@ make_export_app_state <- function(x_column = NULL, y_column = "value",
     ),
     visualization = shiny::reactiveValues(
       last_valid_config = list(chart_type = "run")
-    )
+    ),
+    cache = list(qic = NULL)
   )
 }
 
@@ -198,5 +199,40 @@ test_that("build_export_plot bruger auto_detect$results$x_col som fallback for m
   expect_false(is.null(result))
   expect_equal(captured$config$x_col, "label",
     info = "tom mapping -> fallback til auto_detect$results$x_col"
+  )
+})
+
+test_that("build_export_plot genbruger SPC-cache for identisk export_pdf", {
+  if (!exists("build_export_plot", mode = "function") ||
+    !exists("get_or_init_qic_cache", mode = "function")) {
+    # SKIP-REASON: env -- kræver fuldt load_all() context med export/cache helpers
+    skip("Export/cache helpers ikke tilgaengelige")
+  }
+  withr::local_options(shiny.reactiveConsole = TRUE)
+
+  app_state <- make_export_app_state(
+    x_column = "label", y_column = "value",
+    x_col_auto = "label", y_col_auto = "value"
+  )
+
+  first <- shiny::isolate(build_export_plot(
+    app_state = app_state,
+    title_input = "Cache test",
+    dept_input = "Dept",
+    plot_context = "export_pdf"
+  ))
+  second <- shiny::isolate(build_export_plot(
+    app_state = app_state,
+    title_input = "Cache test",
+    dept_input = "Dept",
+    plot_context = "export_pdf"
+  ))
+
+  expect_false(is.null(first))
+  expect_false(is.null(second))
+
+  cache_stats <- shiny::isolate(get_or_init_qic_cache(app_state)$stats())
+  expect_true(cache_stats$hits >= 1L,
+    info = "Andet identiske export_pdf-kald skal ramme SPC-cache"
   )
 })

--- a/tests/testthat/test-mod_export.R
+++ b/tests/testthat/test-mod_export.R
@@ -280,6 +280,48 @@ test_that("mod_export_server registers download_export handler (§2.3.2)", {
   })
 })
 
+test_that("generate_pdf_export sender kun BFHcharts-understoettede metadatafelter", {
+  skip_if_not_installed("BFHcharts")
+  skip_if_not_installed("mockery")
+
+  app_state <- create_mock_app_state()
+  input <- list(
+    export_title = "Dette er min proevetitel",
+    export_department = "Afdeling X",
+    export_hospital = "Bispebjerg og Frederiksberg Hospital",
+    pdf_description = "Datadefinition",
+    pdf_improvement = "Analyse",
+    export_footnote = ""
+  )
+  output_file <- tempfile(fileext = ".pdf")
+  captured <- new.env(parent = emptyenv())
+  captured$metadata <- NULL
+
+  mockery::stub(generate_pdf_export, "build_export_plot", function(...) {
+    list(bfh_qic_result = list(config = list(chart_title = input$export_title)))
+  })
+
+  testthat::with_mocked_bindings(
+    bfh_export_pdf = function(x, output, metadata, ...) {
+      captured$metadata <- metadata
+      writeBin(as.raw(rep(1L, 600L)), output)
+      output
+    },
+    .package = "BFHcharts",
+    testthat::with_mocked_bindings(
+      showNotification = function(...) invisible(NULL),
+      .package = "shiny",
+      shiny::isolate(generate_pdf_export(input, app_state, output_file))
+    )
+  )
+
+  expect_false("title" %in% names(captured$metadata),
+    info = "BFHcharts validerer title som ukendt metadatafelt; titel kommer fra bfh_qic_result$config$chart_title"
+  )
+  expect_true(all(c("hospital", "department", "analysis", "data_definition", "date") %in%
+    names(captured$metadata)))
+})
+
 # INTEGRATION TESTS ==========================================================
 
 test_that("Export module integrates with app_ui navigation", {

--- a/tests/testthat/test-session-persistence.R
+++ b/tests/testthat/test-session-persistence.R
@@ -689,6 +689,100 @@ test_that("settings_save diff-check: NULL forrige payload trigger altid save", {
   )
 })
 
+test_that("auto-save payload signature ignores volatile timestamp by construction", {
+  skip_if_not(
+    exists("auto_save_payload_sig", mode = "function"),
+    "auto_save_payload_sig not available"
+  )
+
+  test_data <- data.frame(x = 1:3, y = c("a", "b", "c"))
+  metadata <- list(active_tab = "eksporter", export_title = "Titel")
+
+  sig_1 <- auto_save_payload_sig(test_data, metadata)
+  Sys.sleep(0.01)
+  sig_2 <- auto_save_payload_sig(test_data, metadata)
+
+  expect_identical(
+    sig_1,
+    sig_2,
+    info = "Uændret data+metadata skal ikke blive ny payload pga. save-tidspunkt"
+  )
+})
+
+test_that("auto-save payload signature changes when metadata or data changes", {
+  skip_if_not(
+    exists("auto_save_payload_sig", mode = "function"),
+    "auto_save_payload_sig not available"
+  )
+
+  test_data <- data.frame(x = 1:3, y = c("a", "b", "c"))
+  metadata <- list(active_tab = "eksporter", export_title = "Titel")
+
+  baseline <- auto_save_payload_sig(test_data, metadata)
+  changed_metadata <- auto_save_payload_sig(
+    test_data,
+    list(active_tab = "analyser", export_title = "Titel")
+  )
+  changed_data <- auto_save_payload_sig(
+    transform(test_data, x = c(1L, 2L, 99L)),
+    metadata
+  )
+
+  expect_false(
+    identical(baseline, changed_metadata),
+    info = "Metadata-only ændringer skal stadig gemmes"
+  )
+  expect_false(
+    identical(baseline, changed_data),
+    info = "Dataændringer skal stadig gemmes"
+  )
+})
+
+test_that("auto-save data signature is stable across metadata changes", {
+  skip_if_not(
+    exists("auto_save_data_sig", mode = "function"),
+    "auto_save_data_sig not available"
+  )
+
+  test_data <- data.frame(x = 1:3, y = c("a", "b", "c"))
+
+  expect_identical(
+    auto_save_data_sig(test_data),
+    auto_save_data_sig(test_data),
+    info = "Data-signaturen skal kun afspejle data, ikke metadata/tid"
+  )
+  expect_false(
+    identical(
+      auto_save_data_sig(test_data),
+      auto_save_data_sig(transform(test_data, x = c(1L, 2L, 99L)))
+    ),
+    info = "Data-signaturen skal ændre sig ved dataændring"
+  )
+})
+
+test_that("save_metadata_locally sends metadata-only update message", {
+  skip_if_not(
+    exists("save_metadata_locally", mode = "function"),
+    "save_metadata_locally not available"
+  )
+
+  mock <- create_mock_capture_session()
+  metadata <- list(active_tab = "eksporter", export_title = "Titel")
+
+  save_metadata_locally(mock$session, metadata)
+
+  expect_length(mock$captured$messages, 1)
+  msg <- mock$captured$messages[[1]]
+  expect_equal(msg$type, "updateAppStateMetadata")
+  expect_equal(msg$message$key, "current_session")
+  expect_true(is.character(msg$message$metadata))
+  expect_true("version" %in% names(msg$message))
+
+  parsed <- jsonlite::fromJSON(msg$message$metadata, simplifyVector = TRUE)
+  expect_equal(parsed$active_tab, "eksporter")
+  expect_equal(parsed$export_title, "Titel")
+})
+
 test_that("saveDataLocally payload uses current version tag", {
   skip_if_not(
     exists("saveDataLocally", mode = "function"),

--- a/tests/testthat/test-session-persistence.R
+++ b/tests/testthat/test-session-persistence.R
@@ -169,6 +169,39 @@ test_that("local-storage.js loadAppState still parses JSON once (static check)",
   )
 })
 
+test_that("metadata-only localStorage update rejects schema mismatch", {
+  js_file <- file.path("..", "..", "inst", "app", "www", "local-storage.js")
+  skip_if_not(file.exists(js_file), "local-storage.js not found")
+
+  js_text <- paste(readLines(js_file, warn = FALSE), collapse = "\n")
+
+  expect_true(
+    grepl("payload\\.version\\s*!==\\s*version", js_text),
+    info = "metadata-only update must not stamp current schema version onto stale stored data"
+  )
+  expect_true(
+    grepl("schema version mismatch", js_text, fixed = TRUE),
+    info = "schema mismatch should be visible in browser diagnostics"
+  )
+})
+
+test_that("metadata-only Shiny handler avoids debug console logging", {
+  js_file <- file.path("..", "..", "inst", "app", "www", "shiny-handlers.js")
+  skip_if_not(file.exists(js_file), "shiny-handlers.js not found")
+
+  js_text <- paste(readLines(js_file, warn = FALSE), collapse = "\n")
+  metadata_handler <- regmatches(
+    js_text,
+    regexpr("Shiny\\.addCustomMessageHandler\\('updateAppStateMetadata'[\\s\\S]+?\\n\\}\\);", js_text, perl = TRUE)
+  )
+
+  expect_length(metadata_handler, 1)
+  expect_false(
+    grepl("console\\.log", metadata_handler),
+    info = "metadata-only save handler should not emit production console.log noise"
+  )
+})
+
 # ==============================================================================
 # SECTION 2: autoSaveAppState scope bug (disable on failure)
 # ==============================================================================
@@ -689,7 +722,7 @@ test_that("settings_save diff-check: NULL forrige payload trigger altid save", {
   )
 })
 
-test_that("auto-save payload signature ignores volatile timestamp by construction", {
+test_that("auto-save payload signature is stable for identical data and metadata", {
   skip_if_not(
     exists("auto_save_payload_sig", mode = "function"),
     "auto_save_payload_sig not available"
@@ -705,7 +738,7 @@ test_that("auto-save payload signature ignores volatile timestamp by constructio
   expect_identical(
     sig_1,
     sig_2,
-    info = "Uændret data+metadata skal ikke blive ny payload pga. save-tidspunkt"
+    info = "Uændret data+metadata skal give samme payload-signatur"
   )
 })
 


### PR DESCRIPTION
## Summary

Bundle af 6 commits der hærder autosave-metadata-only path + fixer export-cache-regression + PDF-metadata-warning.

### Commits

- `Optimize autosave metadata persistence` (304fba36) — metadata-only save-path til localStorage; sparer data-resend ved UI-state-changes
- `Fix export recompute and download logging` (9eabb632) — propagér `app_state` til `generateSPCPlot` så SPC-cache faktisk bruges af export-path
- `Drop unsupported PDF title metadata` (334b1c0f) — fjern `title` fra BFHcharts metadata-list (BFHcharts validerer feltet som ukendt; titel kommer via `bfh_qic_result$config$chart_title`)
- `Harden metadata-only autosave` (bcf20511) — codex-hardening: `obs_full_save_ready` priority HIGH, `pending_metadata_sig` for korrekt JS-confirm-tracking, schema-version-guard i `updateAppStateMetadata` JS, fjern debug `console.log`
- `Document export fixes and cache regression` (fc9a1855) — NEWS.md-entries + empirisk cache-hit-test for export-path
- `Ignore Antigravity CLI local state directory` (3153c90d) — `.gitignore`-update for `.antigravitycli/`

### Risici / kalibrering

- Race-vindue mellem to in-flight metadata-only saves med forskellig sig → off-by-one sig-tracking for ét interval. Ingen data-loss; eventually consistent.
- Failure-recovery thrash: hvis JS persistent fejler, reset til full-save tvinger thrash. Acceptabel vs. silent stale state.
- Cache-hit-test bruger `exists(...)`-skip-guard; skipper på minimal load_all. Verificeret kører grønt under fuld `devtools::load_all()` (cache hit logget).

## Test plan

- [x] `tests/testthat/test-session-persistence.R` — 73 pass, 1 skip (eksisterende)
- [x] `tests/testthat/test-export-null-x-fallback.R` — cache-hit empirisk verificeret i log
- [x] `tests/testthat/test-mod_export.R` — 29 pass, 3 skip (eksisterende manual/CI-visual)
- [x] Pre-push gate bestået (fast mode, 89s)
- [x] Lint: ingen nye warnings i codex-touched lines
- [ ] Manuel verifikation af autosave-flow i browser (recommended før merge)
- [ ] CI grøn

## Notes

- Ingen DESCRIPTION/manifest-changes
- Ingen breaking changes
- NEWS.md opdateret under `## Bug fixes`