### PR TITLE
fix: harden export autosave + preserve markdown asterisks in SPC titles

### DIFF
--- a/R/fct_spc_helpers.R
+++ b/R/fct_spc_helpers.R
@@ -281,11 +281,14 @@ process_chart_title <- function(chart_title_reactive, config) {
     paste("SPC Diagram -", config$y_col)
   }
 
-  # Sanitize titel mod XSS
+  # Sanitize titel mod XSS.
+  # Tilladte tegn inkluderer `*` saa marquee-parseren (BFHtheme plot.title)
+  # kan rendere markdown-bold (`**fed**`) og kursiv. html_escape neutraliserer
+  # fortsat HTML-tags; marquee parser markdown ej HTML.
   title_result <- sanitize_user_input(
     input_value = title_result,
     max_length = 200,
-    allowed_chars = "A-Za-z0-9_\u00e6\u00f8\u00e5\u00c6\u00d8\u00c5 .,-:!?/",
+    allowed_chars = "A-Za-z0-9_\u00e6\u00f8\u00e5\u00c6\u00d8\u00c5 .,-:!?/*",
     html_escape = TRUE
   )
 

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -1627,3 +1627,11 @@ files:
   reviewer: johanreventlow
   reviewed_date: '2026-05-16'
   rationale: Smoke-tests for "Rapportér fejl"-modul (#747). 24 tests dækker build_bug_report_mailto() URL-encoding (subject, body, danske tegn æøå -> %C3%A6, linjeskift -> %0A), input-validering (NA/tom/multi-element afvises), SUPPORT_EMAIL_BODY-skabelon-indhold, og mod_report_bug_ui() HTML-rendering (mailto-link, modtager, tilbage-link, bug-ikon).
+- file: test-process-chart-title-markdown.R
+  audit_category: post-audit
+  type: unit
+  handling: keep
+  reviewed: yes
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-21'
+  rationale: Regression-test for markdown-asterisks i SPC chart-titel. Sprint 3 XSS-hardening (631e4cd8, 2025-09-30) overrode default allowed_chars i process_chart_title() og droppede `*`, hvilket strippede `**fed**` foer marquee::element_marquee i BFHtheme kunne rendere markdown. Verificerer at asterisks bevares OG at script-tags stadig strippes.

--- a/tests/testthat/test-process-chart-title-markdown.R
+++ b/tests/testthat/test-process-chart-title-markdown.R
@@ -1,0 +1,35 @@
+# test-process-chart-title-markdown.R
+# Regression: process_chart_title() skal bevare markdown-asterisks (`**fed**`)
+# saa marquee-parseren (BFHtheme plot.title) kan rendere fed/kursiv. Sprint 3
+# XSS-hardening (commit 631e4cd8, 2025-09-30) introducerede sanitize-kald uden
+# `*` i allowed_chars, hvilket stripped markdown-syntaksen for plot-titler.
+
+test_that("process_chart_title bevarer markdown-bold asterisks", {
+  skip_if_not_installed("shiny")
+
+  title_reactive <- shiny::reactive("**Fed titel**")
+  config <- list(y_col = "Vaerdi")
+
+  result <- shiny::isolate(process_chart_title(title_reactive, config))
+
+  expect_true(
+    grepl("\\*\\*Fed titel\\*\\*", result, fixed = FALSE),
+    info = paste0("Markdown-asterisks skal overleve sanitize. Faktisk: '", result, "'")
+  )
+})
+
+test_that("process_chart_title stadig stripper farlige HTML-tags", {
+  skip_if_not_installed("shiny")
+
+  title_reactive <- shiny::reactive("<script>alert(1)</script> **fed**")
+  config <- list(y_col = "Vaerdi")
+
+  result <- shiny::isolate(process_chart_title(title_reactive, config))
+
+  expect_false(grepl("<script>", result, fixed = TRUE),
+    info = "HTML-tags skal stadig escapes/strippes"
+  )
+  expect_true(grepl("\\*\\*fed\\*\\*", result),
+    info = "Markdown-bold skal bevares ved siden af HTML-sanitize"
+  )
+})


### PR DESCRIPTION
## Summary

- Export autosave + recompute fixes (existing commits in branch):
  - Drop unsupported PDF title metadata
  - Fix export recompute + download logging
  - Harden metadata-only autosave
  - Optimise autosave metadata persistence
  - Document export fixes + cache regression
- New: restore markdown bold in SPC chart titles. Sprint 3 XSS hardening
  (`631e4cd8`, 2025-09-30) overrode `sanitize_user_input` `allowed_chars`
  in `process_chart_title()` without `*`, stripping `**bold**` before it
  reached `marquee::element_marquee` in BFHtheme. Restoring `*` keeps
  markdown rendering working; `html_escape=TRUE` still neutralises
  HTML tags, and marquee parses markdown rather than HTML so the XSS
  surface is unchanged.

## Test plan

- [x] `Rscript -e 'devtools::load_all(); testthat::test_file("tests/testthat/test-process-chart-title-markdown.R")'` — 3 PASS
- [x] Empirical repro: `sanitize_user_input("**Fed titel**", allowed_chars=...)` returns `**Fed titel**` after fix (stripped pre-fix)
- [x] `Rscript dev/classify_tests.R --validate` — manifest valid (208 files)
- [x] Pre-push gate (fast mode) — passed in 67s
- [ ] Manual smoke: load app, set chart title to `**Fed**`, verify bold renders in plot + PDF/PNG export