### PR TITLE
fix(ci): repariér tre fejlende scheduled jobs

### DIFF
--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -68,6 +68,9 @@ jobs:
         shell: bash
 
       - name: Kor export capability tests
+        # test_dir() (i modsaetning til test_file()) sources helper-*.R, hvilket
+        # koerer pkgload::load_all() og dermed eksponerer internal funktioner
+        # som check_quarto_capability() og validate_export_dpi() uden ::: prefix.
         run: |
-          Rscript -e "library(biSPCharts); testthat::test_file('tests/testthat/test-export-quarto-capability.R', stop_on_failure = TRUE)"
+          Rscript -e "testthat::test_dir('tests/testthat', filter = 'export-quarto-capability', stop_on_failure = TRUE)"
         shell: bash

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,8 +1,8 @@
 # Ugentlig sårbarhedsscanning af R-afhængigheder (fixes #591).
 #
-# Bruger oysteR til OSV-opslag mod installerede pakker (renv-låste versioner).
-# Ikke-blokerende: fund rapporteres i workflow-summary + opretter GitHub Issue
-# (advisory, blokerer ikke PRs).
+# Bruger oysteR til OSV-opslag mod pakker erklaeret i DESCRIPTION + installerede
+# dependencies. Ikke-blokerende: fund rapporteres i workflow-summary + opretter
+# GitHub Issue (advisory, blokerer ikke PRs).
 #
 # Kør manuelt: gh workflow run security-audit.yaml
 name: security-audit
@@ -37,16 +37,12 @@ jobs:
           r-version: 'release'
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v2
+      # Projektet bruger ikke renv (ingen renv.lock). Brug setup-r-dependencies
+      # som installerer fra DESCRIPTION via pak. oysteR tilfoejes som extra.
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          cache-version: 1
-
-      - name: Install oysteR
-        shell: Rscript {0}
-        run: |
-          if (!requireNamespace("oysteR", quietly = TRUE)) {
-            install.packages("oysteR", repos = "https://cloud.r-project.org")
-          }
+          extra-packages: any::oysteR
+          dependencies: '"hard"'
 
       - name: Scan for known vulnerabilities (oysteR)
         id: oyster_scan
@@ -91,8 +87,8 @@ jobs:
 
           Anbefalede handlinger:
           1. Tjek workflow-loggen for berørte pakker
-          2. Opdater via renv::update() + renv::snapshot()
-          3. Commit ny renv.lock
+          2. Bump version-bounds i DESCRIPTION (Imports / Suggests / Remotes)
+          3. Verificer test-suite + commit version-bump
 
           _Automatisk oprettet af security-audit.yaml_"
 

--- a/tests/testthat/test-100x-mismatch-prevention.R
+++ b/tests/testthat/test-100x-mismatch-prevention.R
@@ -292,6 +292,10 @@ test_that("Live SPC validation tillader y > n for P-chart (BFHcharts >= 0.19.0)"
 })
 
 test_that("Performance: normalization is reasonably fast", {
+  # Skip under covr -- instrumentering tilfoejer overhead der goer 1s-threshold
+  # urealistisk for 1000 kald (coverage-jobbet fejlede pga dette).
+  skip_if(identical(Sys.getenv("R_COVR"), "true"), "Skipped under covr instrumentation")
+
   # Basic performance check - normalization should be fast enough
   # for interactive use
 


### PR DESCRIPTION
## Summary

Tre scheduled CI-jobs har fejlet konsistent i flere uger:

- **Export Smoke Test (Quarto + Typst)**: 12 FAIL / 0 PASS — `library() + test_file()` exposer ikke internal funktioner (`validate_export_dpi`, `check_quarto_capability`). Skift til `test_dir(filter)` som sources `helper-bootstrap.R` → `pkgload::load_all()` → internals tilgængelige.
- **coverage**: 1 FAIL af 6370 — perf-test `1000 normalizations < 1s` flaky under covr-instrumentering. `skip_if(R_COVR == "true")`.
- **security-audit**: `setup-renv@v2` fejler "trying to use CRAN without setting a mirror" — projekt har ingen `renv.lock`. Skift til `setup-r-dependencies@v2` + `extra-packages: any::oysteR`.

Bonus: `sibling-bump-poller` fejlede 23/5 pga transient Chrome apt-repo sync hos GitHub-runner. Næste run grøn — ingen fix.

## Test plan

- [x] Lokal: `testthat::test_dir(filter = 'export-quarto-capability')` → 26 PASS, 0 FAIL
- [x] Lokal repro af coverage-fejl bekræftede 1 FAIL i perf-test
- [ ] `workflow_dispatch` på alle tre jobs efter merge til develop
- [ ] Næste scheduled runs (mandag 06:00 UTC for coverage + security-audit; daglig 03:00 UTC for export-smoke)

## Notes

- Atomiske commits per fix (3 commits).
- Andre perf-tests har lignende tight thresholds (cache 0.1s, spc-bfh 2.0s) — lader urørt indtil de faktisk fejler under covr.