### PR TITLE
fix(ui): Region H @font-face-pattern fjerner Mari "1"-glyph-anomali i browser

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,41 @@
+# biSPCharts (development)
+
+## Bug fixes
+
+* Browser-side Mari-font workaround for glyph "1"-anomali. Cifret "1" i
+  `Mari-Book.otf` (og 4 andre Mari-*.otf-varianter) har glyph yMax=659 -
+  hoejere end baade overshoot-glyfer (0/3/6/8/9 = 653) og flade cifre
+  (4/5/7 = 641). Resultat: "1" stikker visuelt op over alle andre cifre
+  i tabeller, datoer ("01-01-2023") og talkolonner. Synligt især på
+  Windows DirectWrite-rendering.
+
+  Empirisk verificeret at `MariOffice-*.ttf` i BFHchartsAssets har
+  korrekt typografi og matcher Region H's canonical Mari brugt på
+  bispebjerghospital.dk 1:1. Workaround adopterer Region H's
+  @font-face-pattern: distinct family-names per vægt
+  (`mariregular`/`maribold`/`maribook`/`marilight`/`mariheavy`) der
+  peger på `MariOffice-*.ttf` via `bfh_assets` resource-prefix.
+  Distinct family-name eliminerer collision med system-installeret
+  Mari (PR #517-regression strukturelt umulig).
+
+  Fallback-stack ændret fra `Mari, Arial, ...` til
+  `'Helvetica Neue', Helvetica, Arial, sans-serif` for at undgå at
+  browseren vælger system-Mari-Book.otf (samme glyph-anomali) hvis
+  @font-face ikke loader.
+
+  Filer ændret: `R/utils_ui_app_layout.R`, `inst/config/brand.yml`,
+  `R/config_branding_getters.R`.
+
+## Known issues
+
+* **Surface 2 (Typst PDF) + Surface 3 (ggplot/ragg) viser fortsat
+  glyph-anomali** for cifret "1". Workaround er begrænset til
+  Shiny browser-side. PDF-eksport bruger `Mari-Book.otf` via BFHcharts
+  Typst-template (cross-repo); ggplot-charts bruger `Mari-Book.otf` via
+  `systemfonts::register_font(name="Mari", ...)`. Begge afventer
+  kilden-fix i BFHchartsAssets (issue
+  `johanreventlow/BFHchartsAssets#1`).
+
 # biSPCharts 0.5.0
 
 ## Bug fixes

--- a/R/config_branding_getters.R
+++ b/R/config_branding_getters.R
@@ -141,9 +141,14 @@ create_brand_theme <- function(config = NULL) {
         "navbar-dark-active-color" = "white",
         "navbar-dark-brand-color" = "white",
 
-        # Typografi: Mari med Arial-fallback
-        "font-family-base" = "Mari, Arial, Helvetica, sans-serif",
-        "headings-font-family" = "Mari, Arial, Helvetica, sans-serif",
+        # Typografi: Region H @font-face-pattern (distinct family-names per
+        # vaegt via BFHchartsAssets MariOffice-*.ttf -- se create_ui_header()).
+        # Helvetica Neue prioriteres over system-Mari som fallback for at
+        # undgaa shadow af defekt BFHchartsAssets Mari-*.otf hvis @font-face
+        # ikke loader. Empirisk: Region H bruger samme stack paa
+        # bispebjerghospital.dk.
+        "font-family-base" = "mariregular, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        "headings-font-family" = "maribold, 'Helvetica Neue', Helvetica, Arial, sans-serif",
         "headings-font-weight" = 400
       ) |>
         # Knapper: lysere sekundaer-knapper end koncern-graa

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -14,35 +14,61 @@ create_ui_header <- function() {
   # Get hospital colors using the proper package function
   hospital_colors <- get_hospital_colors()
 
-  # Byg betinget @font-face CSS til Mari-font.
+  # Byg betinget @font-face CSS til Mari-font (Region H-pattern).
   # Mari-fonts leveres af BFHchartsAssets companion-pakken (privat) via
   # resource-prefix 'bfh_assets' registreret i golem_add_external_resources().
   # Fallback: ingen @font-face injiceres -- browser bruger naesteoverladte
-  # system-font fra CSS font-family-stack (Arial, Helvetica, sans-serif).
+  # system-font fra CSS font-family-stack ('Helvetica Neue', Helvetica, Arial,
+  # sans-serif).
+  #
+  # TEMP (afventer BFHchartsAssets-issue) -- adopter Region H-pattern fra
+  # bispebjerghospital.dk: distinct lowercase family-name per vaegt
+  # (mariregular/maribold/maribook/marilight/mariheavy). Empirisk verificeret
+  # 2026-05-26 at Region H's mari-webfont.ttf har identisk glyph-data med
+  # BFHchartsAssets's MariOffice-*.ttf (1=659, 0/3/6/8/9=671, 4/5/7=659,
+  # hhea-ascent=820). BFHchartsAssets's Mari-*.otf har typografisk anomali
+  # (1=659 over baseline pa cap-height 641, alle weights weight=4 -- forvirrer
+  # browser-weight-matching). Workaround: peg @font-face pa MariOffice-*.ttf
+  # med distinct family-names der ikke kan shadowes af system-Mari ("Mari" hhv
+  # "Mari Office" -- begge forskellige fra mariregular/maribold).
   mari_fontface_css <- if (requireNamespace("BFHchartsAssets", quietly = TRUE)) {
-    # Brug Mari-Book.otf / Mari-Bold.otf (internal family = "Mari", weight=4/7).
-    # Tidligere brugte vi MariOffice-Book.ttf / MariOffice-Bold.ttf der internt
-    # hedder "Mari Office" (med mellemrum) -- mismatch mod CSS-deklarationen
-    # `font-family: 'Mari'` resulterede i forkert weight-rendering i browser.
-    # Mari-*.otf filerne er authoritative-navngivne (BFHchartsAssets v0.1.0).
     "
-      /* Mari hospital font via BFHchartsAssets companion-pakke (@font-face) */
+      /* Mari hospital font via BFHchartsAssets (Region H @font-face-pattern) */
       @font-face {
-        font-family: 'Mari';
-        src: url('bfh_assets/Mari-Book.otf') format('opentype');
+        font-family: mariregular;
+        src: url('bfh_assets/MariOffice-Book.ttf') format('truetype');
         font-weight: normal;
         font-style: normal;
       }
       @font-face {
-        font-family: 'Mari';
-        src: url('bfh_assets/Mari-Bold.otf') format('opentype');
-        font-weight: bold;
+        font-family: maribook;
+        src: url('bfh_assets/MariOffice-Book.ttf') format('truetype');
+        font-weight: normal;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: maribold;
+        src: url('bfh_assets/MariOffice-Bold.ttf') format('truetype');
+        font-weight: normal;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: marilight;
+        src: url('bfh_assets/MariOffice-Light.ttf') format('truetype');
+        font-weight: normal;
+        font-style: normal;
+      }
+      @font-face {
+        font-family: mariheavy;
+        src: url('bfh_assets/MariOffice-Heavy.ttf') format('truetype');
+        font-weight: 900;
         font-style: normal;
       }
     "
   } else {
     # BFHchartsAssets ikke tilgaengelig -- browser falder tilbage til
-    # Arial/Helvetica/sans-serif fra CSS-stakken i config_branding_getters.R.
+    # 'Helvetica Neue'/Helvetica/Arial/sans-serif fra CSS-stakken i
+    # config_branding_getters.R.
     ""
   }
 

--- a/dev/audit-output/test-classification.yaml
+++ b/dev/audit-output/test-classification.yaml
@@ -433,6 +433,19 @@ files:
   type: unit
   handling: keep
   reviewed: no
+- file: test-font-css.R
+  audit_category: green
+  type: unit
+  handling: keep
+  reviewed: yes
+  rationale: |
+    Regression-tests for Region H @font-face-pattern adopteret 2026-05-26.
+    Verificerer distinct family-names per vaegt (mariregular/maribold/maribook/
+    marilight/mariheavy), MariOffice-*.ttf som canonical src, + Helvetica Neue
+    fallback (NOT Mari). Counter-test mod PR #517-regression. Tilfoejet manuelt
+    til manifest per feedback_test_classification_manifest.
+  reviewer: johanreventlow
+  reviewed_date: '2026-05-26'
 - file: test-file-io-comprehensive.R
   audit_category: green
   type: unit

--- a/inst/config/brand.yml
+++ b/inst/config/brand.yml
@@ -56,9 +56,13 @@ color:
 
 
 typography:
-  base: "Mari, Arial, Helvetica, sans-serif"
+  # Region H @font-face-pattern fra bispebjerghospital.dk: distinct family-name
+  # per vægt forhindrer browser-shadow fra system-installerede Mari-fonts.
+  # mariregular/maribold deklareres i create_ui_header() via BFHchartsAssets
+  # MariOffice-*.ttf-filer (canonical Region H-glyph-data).
+  base: "mariregular, 'Helvetica Neue', Helvetica, Arial, sans-serif"
   headings:
-    family: "Mari, Arial, Helvetica, sans-serif"
+    family: "maribold, 'Helvetica Neue', Helvetica, Arial, sans-serif"
     weight: 700
 
 # Theme bygges programmatisk i create_brand_theme() (config_branding_getters.R)

--- a/tests/testthat/test-font-css.R
+++ b/tests/testthat/test-font-css.R
@@ -1,0 +1,96 @@
+# test-font-css.R
+# Regression-tests for Mari font @font-face CSS + font-family-stack.
+# Region H-pattern adopteret 2026-05-26: distinct family-names per vaegt
+# (mariregular/maribold/maribook/marilight/mariheavy) via MariOffice-*.ttf.
+# Sikrer at:
+#   - @font-face deklarerer distinct family-names per vaegt
+#   - src peger paa MariOffice-*.ttf (canonical Region H-glyph-data)
+#   - brand.yml + config_branding_getters.R bruger Helvetica Neue som
+#     fallback (NOT Mari -- undgaar system-Mari shadow)
+#   - fallback-stack starter med mariregular ej generisk "Mari"
+
+test_that("create_ui_header() injicerer Region H-pattern @font-face naar BFHchartsAssets findes", {
+  skip_if_not_installed("BFHchartsAssets")
+
+  ui_header <- create_ui_header()
+  ui_html <- htmltools::doRenderTags(ui_header)
+
+  # Distinct family-names per vaegt (Region H-pattern)
+  expect_match(ui_html, "font-family:\\s*mariregular", fixed = FALSE)
+  expect_match(ui_html, "font-family:\\s*maribold", fixed = FALSE)
+  expect_match(ui_html, "font-family:\\s*maribook", fixed = FALSE)
+  expect_match(ui_html, "font-family:\\s*marilight", fixed = FALSE)
+  expect_match(ui_html, "font-family:\\s*mariheavy", fixed = FALSE)
+
+  # MariOffice-*.ttf som src (canonical glyph-data fra bispebjerghospital.dk)
+  expect_match(ui_html, "bfh_assets/MariOffice-Book\\.ttf", fixed = FALSE)
+  expect_match(ui_html, "bfh_assets/MariOffice-Bold\\.ttf", fixed = FALSE)
+  expect_match(ui_html, "bfh_assets/MariOffice-Light\\.ttf", fixed = FALSE)
+  expect_match(ui_html, "bfh_assets/MariOffice-Heavy\\.ttf", fixed = FALSE)
+})
+
+test_that("create_ui_header() bruger IKKE defekt Mari-*.otf eller delt 'Mari' family-name", {
+  skip_if_not_installed("BFHchartsAssets")
+
+  ui_header <- create_ui_header()
+  ui_html <- htmltools::doRenderTags(ui_header)
+
+  # Regression-guards: ingen reference til defekt Mari-*.otf eller
+  # delt "Mari" family-name (PR #517-regression-counter-test).
+  expect_false(grepl("bfh_assets/Mari-Book\\.otf", ui_html))
+  expect_false(grepl("bfh_assets/Mari-Bold\\.otf", ui_html))
+  expect_false(grepl("font-family:\\s*'Mari'", ui_html))
+  expect_false(grepl("font-family:\\s*\"Mari\"", ui_html))
+})
+
+test_that("brand.yml typography-stack starter med mariregular + bruger Helvetica Neue fallback", {
+  config_path <- testthat::test_path("..", "..", "inst", "config", "brand.yml")
+  skip_if_not(file.exists(config_path), "brand.yml ikke fundet")
+
+  yaml_content <- yaml::read_yaml(config_path)
+  typo <- yaml_content$typography
+
+  expect_true(!is.null(typo$base))
+  expect_match(typo$base, "^mariregular,")
+  expect_match(typo$base, "Helvetica Neue")
+
+  # Maa IKKE indeholde generisk "Mari" (uden suffix) som ville matche
+  # system-installeret Mari Book.otf og introducere PR #517-regression.
+  expect_false(grepl("\\bMari\\b(?!regular|bold|book|light|heavy)", typo$base, perl = TRUE))
+
+  expect_true(!is.null(typo$headings$family))
+  expect_match(typo$headings$family, "^maribold,")
+  expect_match(typo$headings$family, "Helvetica Neue")
+})
+
+test_that("config_branding_getters.R font-family-base anvender mariregular + Helvetica Neue", {
+  # Vi kan ikke direkte inspicere bslib-themeobjekt-output uden bslib-deps.
+  # Verificer i stedet ved at laese kildekoden -- regression-guard mod at
+  # nogen genaktiverer "Mari, Arial, ..." stacken.
+  source_path <- testthat::test_path("..", "..", "R", "config_branding_getters.R")
+  skip_if_not(file.exists(source_path), "config_branding_getters.R ikke fundet")
+
+  src <- readLines(source_path, encoding = "UTF-8")
+  src_text <- paste(src, collapse = "\n")
+
+  # Skal indeholde mariregular + maribold + Helvetica Neue
+  expect_match(src_text, '"font-family-base"\\s*=\\s*"mariregular,[^"]*Helvetica Neue')
+  expect_match(src_text, '"headings-font-family"\\s*=\\s*"maribold,[^"]*Helvetica Neue')
+
+  # Maa IKKE genintroducere bare "Mari, Arial, Helvetica" som primary stack
+  expect_false(grepl('"font-family-base"\\s*=\\s*"Mari, Arial', src_text))
+  expect_false(grepl('"headings-font-family"\\s*=\\s*"Mari, Arial', src_text))
+})
+
+test_that("create_ui_header() emitter tom @font-face-blok hvis BFHchartsAssets mangler", {
+  if (requireNamespace("BFHchartsAssets", quietly = TRUE)) {
+    skip("BFHchartsAssets installed - cannot test missing-pkg path without unmocking")
+  }
+
+  ui_header <- create_ui_header()
+  ui_html <- htmltools::doRenderTags(ui_header)
+
+  # Graceful degradation: ingen @font-face injiceres, browser falder til
+  # Helvetica Neue/Helvetica/Arial-stack fra brand.yml.
+  expect_false(grepl("@font-face\\s*\\{\\s*font-family:\\s*mariregular", ui_html))
+})


### PR DESCRIPTION
## Summary

- Mari-Book.otf har glyph "1" yMax=659 — højere end overshoot-glyfer (0/3/6/8/9 = 653) og flade cifre (4/5/7 = 641). Synlig anomali i datoer, talkolonner, datatabeller. Især tydelig på Windows DirectWrite-rendering.
- Empirisk verificeret at `BFHchartsAssets/MariOffice-*.ttf` = canonical Region H Mari brugt på `bispebjerghospital.dk` 1:1 (identisk glyph-bounding-boxes, identisk ascent/descent).
- Workaround adopterer Region H's @font-face-pattern: distinct family-names per vægt (`mariregular`/`maribold`/`maribook`/`marilight`/`mariheavy`) der peger på MariOffice-*.ttf. Distinct family-name eliminerer system-Mari-collision (PR #517 regression strukturelt umulig).

## Empirisk evidens

| Variant | "1" yMax | 0/3/6/8/9 yMax | 4/5/7 yMax |
|---------|----------|----------------|------------|
| Mari-Book.otf (defekt) | **659** | 653 | **641** |
| MariOffice-Book.ttf (canonical) | 659 | 671 | 659 |
| Region H mari_book-webfont.ttf | 659 | 671 | 659 |

MariOffice-*.ttf + Region H = identisk typografi. Mari-*.otf = lokal defekt variant.

## Filer ændret

- `R/utils_ui_app_layout.R`: @font-face deklarerer 5 distinct family-names per vægt + src=MariOffice-*.ttf
- `inst/config/brand.yml`: typography-stack bruger mariregular/maribold + Helvetica Neue fallback (ikke Mari)
- `R/config_branding_getters.R`: programmatic bslib-stack matcher brand.yml
- `tests/testthat/test-font-css.R`: 24 regression-tests + counter-test mod PR #517-regression
- `dev/audit-output/test-classification.yaml`: registrer ny test-fil (per `feedback_test_classification_manifest`)
- `NEWS.md`: dokumenteret workaround + known issues for Surface 2/3

## Scope-begrænsning

Workaround dækker kun **Surface 1 (Shiny browser)**. To andre surfaces afventer kilden-fix i BFHchartsAssets:

- **Surface 2 (Typst PDF)**: bruger `Mari-Book.otf` via BFHcharts Typst-template (cross-repo). PDF-eksport viser fortsat anomali.
- **Surface 3 (ggplot/ragg)**: `systemfonts::register_font(name="Mari", ...)` bruger `Mari-Book.otf`. SPC-chart-akser viser fortsat anomali.

Eskaleret som [BFHchartsAssets#1](https://github.com/johanreventlow/BFHchartsAssets/issues/1) med tre rangerede fix-options.

## Test plan

- [x] Lokal `devtools::load_all()` + `testthat::test_file('tests/testthat/test-font-css.R')` → 24 PASS, 0 FAIL, 1 SKIP
- [x] Lokal `source('global.R'); shinyApp(ui=app_ui(), server=app_server)` på Mac (Safari) → DevTools Network bekræfter MariOffice-Book.ttf 200 OK, Computed font-family = `mariregular, "Helvetica Neue", Helvetica, Arial, sans-serif`, Rendered fonts = `Mari Office Book`. Visuelt: cifre ensartet højde.
- [x] Pre-push gate (`PREPUSH_MODE=fast`) → bestået på 65s
- [x] Manual: Windows (Chrome/Edge/Firefox) — DirectWrite rendering — bekræft anomali forsvundet
- [ ] Manual: Connect Cloud preview-deploy — bekræft samme rendering som lokal Mac
- [ ] Counter-test for PR #517-regression: body-tekst er Book-vægt, ikke Bold (alle browsere)

## Relateret

- BFHchartsAssets#1: glyph-anomali-eskalation (canonical fix)
- PR #517 (2026-05-04): tidligere mislykket MariOffice-attempt + diagnose
- Region H stylesheet: `https://www.bispebjerghospital.dk/_layouts/15/RH/UI/css/skins/hospitaler/main.css`