### PR TITLE
fix(fonts): Mari på Connect Cloud — cache-clear + ragg + shiny.useragg

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -58,7 +58,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
@@ -112,7 +112,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 
@@ -170,7 +170,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -42,7 +42,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/.github/workflows/export-smoke-test.yaml
+++ b/.github/workflows/export-smoke-test.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -51,7 +51,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/.github/workflows/sibling-bump-poller.yaml
+++ b/.github/workflows/sibling-bump-poller.yaml
@@ -72,7 +72,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/.github/workflows/testthat.yaml
+++ b/.github/workflows/testthat.yaml
@@ -43,7 +43,7 @@ jobs:
           sudo apt-get install -y \
             libcurl4-openssl-dev libssl-dev libuv1-dev libgit2-dev \
             zlib1g-dev libicu-dev libpng-dev libjpeg-dev \
-            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libtiff5-dev libwebp-dev \
             libxml2-dev libx11-dev cmake
           sudo apt-get install -y chromium-browser || sudo snap install chromium || true
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,6 +46,7 @@ Imports:
     config (>= 0.3.0),
     systemfonts (>= 1.0.0),
     svglite (>= 2.1.0),
+    ragg (>= 1.2.0),
     openxlsx (>= 4.2.0),
     base64enc (>= 0.1-3)
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,16 +3,29 @@
 ## Bug fixes
 
 * **Connect Cloud: ggplot bruger nu Mari, ikke Roboto-fallback.**
-  `.onLoad` rydder nu `BFHtheme:::clear_bfh_font_cache()` efter
-  `register_mari_font()`/`register_roboto_font()`. Belt-and-suspenders
-  mod scenarier hvor BFHtheme's font-detection-cache er låst på en
-  fallback (fx hvis `theme_bfh()` blev kaldt før `.onLoad` var færdig).
-  Den fulde fix kræver BFHtheme >= 0.5.1 hvor `font_available()` nu
-  konsulterer både `system_fonts()` og `registry_fonts()` (PR
-  johanreventlow/BFHtheme#73). Lower-bound bump følger separat når
-  BFHtheme 0.5.1 er tagget.
+  Trippel fix der lukker hele kæden fra font-detection til rendering:
+    1. **Cache-clear i `.onLoad`** efter `register_mari_font()` /
+       `register_roboto_font()` — belt-and-suspenders mod scenarier hvor
+       BFHtheme's font-detection-cache er låst på en fallback (fx hvis
+       `theme_bfh()` blev kaldt før `.onLoad` var færdig).
+    2. **ragg som default renderer.** Cairo PNG (Shiny's legacy default
+       på Linux) bruger fontconfig til font-resolution, og fontconfig
+       kan IKKE se fonts registreret via `systemfonts::register_font()`.
+       ragg konsulterer derimod systemfonts-registry'et direkte via
+       `match_fonts()`. `ragg` tilføjet til Imports + manifest.json,
+       og `.onLoad` sætter eksplicit `options(shiny.useragg = TRUE)`.
+    3. **Den fulde fix kræver også BFHtheme >= 0.5.1** hvor
+       `font_available()` nu konsulterer både `system_fonts()` og
+       `registry_fonts()` (PR johanreventlow/BFHtheme#73). Lower-bound
+       bump følger separat når BFHtheme 0.5.1 er tagget.
 
 ## Dependency bumps
+
+* `ragg (>= 1.2.0)` tilføjet til Imports — påkrævet for at Shiny
+  renderPlot kan tegne ggplot med fonts registreret via
+  `systemfonts::register_font()` på Linux deploy-targets (Posit
+  Connect Cloud). Cairo PNG (legacy default) bruger fontconfig og
+  ser ikke registry-fonts.
 
 * `BFHchartsAssets (>= 0.1.2)` — adopterer kilden-fix for Mari-font
   glyph "1"-anomali. BFHchartsAssets PR #2 patcher alle 6 Mari-*.otf-

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # biSPCharts (development)
 
+## Bug fixes
+
+* **Connect Cloud: ggplot bruger nu Mari, ikke Roboto-fallback.**
+  `.onLoad` rydder nu `BFHtheme:::clear_bfh_font_cache()` efter
+  `register_mari_font()`/`register_roboto_font()`. Belt-and-suspenders
+  mod scenarier hvor BFHtheme's font-detection-cache er låst på en
+  fallback (fx hvis `theme_bfh()` blev kaldt før `.onLoad` var færdig).
+  Den fulde fix kræver BFHtheme >= 0.5.1 hvor `font_available()` nu
+  konsulterer både `system_fonts()` og `registry_fonts()` (PR
+  johanreventlow/BFHtheme#73). Lower-bound bump følger separat når
+  BFHtheme 0.5.1 er tagget.
+
 ## Dependency bumps
 
 * `BFHchartsAssets (>= 0.1.2)` — adopterer kilden-fix for Mari-font

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -224,6 +224,27 @@ reset_qic_performance_counters <- function() {
     register_roboto_font()
   }
 
+  # BFHtheme::get_bfh_font() cacher foerste match. Hvis noget kaldte
+  # theme_bfh() FOeR vores font-registreringer ovenfor (fx via en
+  # tidlig roxygen-load, en namespace-side-effekt, eller seeded test-
+  # harness), kunne cachen nu vaere laast paa "Roboto"/"sans" selvom
+  # Mari nu er tilgaengelig i registry'et. Belt-and-suspenders: ryd
+  # cachen efter registrering saa naeste get_bfh_font()-kald gen-
+  # detekterer Mari korrekt. Kraever BFHtheme >= 0.5.1 (font_available
+  # konsulterer registry_fonts) for at have effekt paa Connect Cloud.
+  if (requireNamespace("BFHtheme", quietly = TRUE)) {
+    tryCatch(
+      suppressMessages(BFHtheme:::clear_bfh_font_cache()),
+      error = function(e) {
+        # nolint next: swallowed_error_linter
+        # Begrundelse: BFHtheme er en valgfri runtime-dependency for
+        # font-cache-clear under .onLoad; logger ikke aktivt endnu, og en
+        # fejl her er kosmetisk (paavirker ej app-funktionalitet).
+        NULL
+      }
+    )
+  }
+
   # Defense-in-depth: vaer sikker paa BFHcharts >= 0.14.0 er installeret.
   # bfh_create_typst_document() er foerst public i 0.14.0.
   if (utils::packageVersion("BFHcharts") < "0.14.0") {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -245,6 +245,19 @@ reset_qic_performance_counters <- function() {
     )
   }
 
+  # Tving Shiny til at bruge ragg som default renderer. Cairo PNG (Shiny's
+  # legacy default paa Linux) bruger fontconfig til font-resolution, og
+  # fontconfig kan IKKE se fonts registreret via systemfonts::register_font().
+  # ragg konsulterer derimod systemfonts-registry'et direkte via
+  # match_fonts(). Uden dette ville Mari (registreret i registry ovenfor)
+  # vaere usynlig for renderen paa Posit Connect Cloud, selv om
+  # BFHtheme::get_bfh_font() returnerer "Mari" som base_family. Shiny
+  # >= 1.7.4 auto-detekterer ragg hvis installeret, men eksplicit option
+  # er belt-and-suspenders mod future-default-aendringer.
+  if (requireNamespace("ragg", quietly = TRUE)) {
+    options(shiny.useragg = TRUE)
+  }
+
   # Defense-in-depth: vaer sikker paa BFHcharts >= 0.14.0 er installeret.
   # bfh_create_typst_document() er foerst public i 0.14.0.
   if (utils::packageVersion("BFHcharts") < "0.14.0") {

--- a/manifest.json
+++ b/manifest.json
@@ -3342,6 +3342,44 @@
         "RemoteSha": "0.8.1"
       }
     },
+    "ragg": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Type": "Package",
+        "Package": "ragg",
+        "Title": "Graphic Devices Based on AGG",
+        "Version": "1.5.2",
+        "Authors@R": "c(\n    person(\"Thomas Lin\", \"Pedersen\", , \"thomas.pedersen@posit.co\", role = c(\"cre\", \"aut\"),\n           comment = c(ORCID = \"0000-0002-5147-4711\")),\n    person(\"Maxim\", \"Shemanarev\", role = c(\"aut\", \"cph\"),\n           comment = \"Author of AGG\"),\n    person(\"Tony\", \"Juricic\", , \"tonygeek@yahoo.com\", role = c(\"ctb\", \"cph\"),\n           comment = \"Contributor to AGG\"),\n    person(\"Milan\", \"Marusinec\", , \"milan@marusinec.sk\", role = c(\"ctb\", \"cph\"),\n           comment = \"Contributor to AGG\"),\n    person(\"Spencer\", \"Garrett\", role = \"ctb\",\n           comment = \"Contributor to AGG\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\"))\n  )",
+        "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
+        "Description": "Anti-Grain Geometry (AGG) is a high-quality and\n    high-performance 2D drawing library. The 'ragg' package provides a set\n    of graphic devices based on AGG to use as alternative to the raster\n    devices provided through the 'grDevices' package.",
+        "License": "MIT + file LICENSE",
+        "URL": "https://ragg.r-lib.org, https://github.com/r-lib/ragg",
+        "BugReports": "https://github.com/r-lib/ragg/issues",
+        "Imports": "systemfonts (>= 1.0.3), textshaping (>= 0.3.0)",
+        "Suggests": "covr, graphics, grid, testthat (>= 3.0.0)",
+        "LinkingTo": "systemfonts, textshaping",
+        "Config/build/compilation-database": "true",
+        "Config/Needs/website": "ggplot2, devoid, magick, bench, tidyr, ggridges,\nhexbin, sessioninfo, pkgdown, tidyverse/tidytemplate",
+        "Config/testthat/edition": "3",
+        "Config/usethis/last-upkeep": "2025-04-25",
+        "Encoding": "UTF-8",
+        "RoxygenNote": "7.3.3",
+        "SystemRequirements": "freetype2, libpng, libtiff, libjpeg, libwebp,\nlibwebpmux",
+        "NeedsCompilation": "yes",
+        "Packaged": "2026-03-16 07:50:17 UTC; thomas",
+        "Author": "Thomas Lin Pedersen [cre, aut] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Maxim Shemanarev [aut, cph] (Author of AGG),\n  Tony Juricic [ctb, cph] (Contributor to AGG),\n  Milan Marusinec [ctb, cph] (Contributor to AGG),\n  Spencer Garrett [ctb] (Contributor to AGG),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
+        "Repository": "CRAN",
+        "Date/Publication": "2026-03-23 08:50:08 UTC",
+        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-23 09:05:47 UTC; unix",
+        "Archs": "ragg.so.dSYM",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ragg",
+        "RemoteRef": "ragg",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.2"
+      }
+    },
     "ragnar": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -4802,7 +4840,16 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "e112cdc5c4137ac949aeaac3d436fc5b"
+      "checksum": "2113045db4f8bf84f90040485bc6106c"
+    },
+    "inst/.DS_Store": {
+      "checksum": "1ad883d77f4fa1366f539db331cbe44f"
+    },
+    "inst/app/.DS_Store": {
+      "checksum": "7d1074f35bdcf0254f79c4bc24363b97"
+    },
+    "inst/app/www/.DS_Store": {
+      "checksum": "18818c0d6bec754f431019ecba7c71ac"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4816,20 +4863,23 @@
     "inst/app/www/cookie-consent.js": {
       "checksum": "7189fd2166a28917be429a708f9a0234"
     },
+    "inst/app/www/help/.DS_Store": {
+      "checksum": "194577a7e20bdcc7afbb718f502c134c"
+    },
     "inst/app/www/help/01-run-chart-stabil.png": {
-      "checksum": "09201a8c8cc7623b622d2dd9f1bde626"
+      "checksum": "52fe486fe9191060c766afa64afe24f3"
     },
-    "inst/app/www/help/02-variation-sammenligning.png": {
-      "checksum": "9ca0b83e521d5751ba9a11bd459c5704"
+    "inst/app/www/help/02-niveauskift.png": {
+      "checksum": "5a2edf3a8bb0d81bef6edd57956363a4"
     },
-    "inst/app/www/help/03-diagram-annoteret.png": {
-      "checksum": "8fdd71c1c90d0eaa6b441589b3caeb44"
+    "inst/app/www/help/03-seriediagram-annoteret.png": {
+      "checksum": "3d87e983d54c577a95630e68d1f26310"
     },
     "inst/app/www/help/04-anhoej-signal.png": {
-      "checksum": "c25e22603cbc59de70a0f12151087bfa"
+      "checksum": "cd05e9142fc1def79dc9c2f025c665f4"
     },
     "inst/app/www/help/05-p-chart.png": {
-      "checksum": "b7933561b2de61e4521fd155571627b3"
+      "checksum": "0965ab680b3d61b09bc9f949dcbe65c2"
     },
     "inst/app/www/help/06a-trin1-upload.png": {
       "checksum": "740f2677c4a0c96e16d68f1d2e3dffc9"
@@ -4942,6 +4992,9 @@
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
     },
+    "manifest.json": {
+      "checksum": "46e2dbaca8e9735c733cd5f81fa89885"
+    },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
     },
@@ -4955,19 +5008,19 @@
       "checksum": "d85bbd8c1967f0d78e01081616a4e723"
     },
     "R/app_server_main.R": {
-      "checksum": "24369a76507c6172f1b52d197cbaed0d"
+      "checksum": "e4d7b10a9d62bae8a52f5084acecf35e"
     },
     "R/app_server.R": {
       "checksum": "c97a964c3c2b954be459b38cc6fef0e4"
     },
     "R/app_ui.R": {
-      "checksum": "b677cca6fa49b03929b43bc30c9f5b04"
+      "checksum": "feae2fa63f1e6e8fe78a81e4dd40a6f7"
     },
     "R/config_analytics.R": {
       "checksum": "5a2e6a33573869e94ac5b43e6f27f0b9"
     },
     "R/config_branding_getters.R": {
-      "checksum": "755ec9cef515962e33c5b25882f84052"
+      "checksum": "cb066b1eac8c4724f030e0006c1b6fbc"
     },
     "R/config_chart_types.R": {
       "checksum": "cf03e313f2c208f032d9227848831465"
@@ -5089,8 +5142,14 @@
     "R/golem_utils.R": {
       "checksum": "ba1180b923c7f4425ff5b7788c734336"
     },
+    "R/mod_about_server.R": {
+      "checksum": "a83e2c12d1e07745310dc0e1e7c98683"
+    },
+    "R/mod_about_ui.R": {
+      "checksum": "8b2d58e256221443ed2d2a9524534aa1"
+    },
     "R/mod_app_guide_ui.R": {
-      "checksum": "567b186a738998ca103f697524bcd28b"
+      "checksum": "8cd0b9fd8547487ab33a5fd9d544af78"
     },
     "R/mod_export_ai.R": {
       "checksum": "3e05bee8423d5db8e433202bf34e5d66"
@@ -5111,7 +5170,7 @@
       "checksum": "1dbd9afb732efdf03222ebab03e29762"
     },
     "R/mod_help_ui.R": {
-      "checksum": "b5825df9e9a38821f07b2c6d9831cc3d"
+      "checksum": "280b5ecbe74b97189eeba1b966c0a18c"
     },
     "R/mod_landing_server.R": {
       "checksum": "81da0c8c3f74ad1a37ec39e7c35444d8"
@@ -5123,7 +5182,7 @@
       "checksum": "0fda8b12eb1539b1164ffad60337e893"
     },
     "R/mod_report_bug_ui.R": {
-      "checksum": "36152139d2c80c484b0f9ce84211d6c5"
+      "checksum": "083c17739e20efc9f95a5ec9ed11694f"
     },
     "R/mod_spc_chart_compute.R": {
       "checksum": "9d500938ae08606bc7a9bf5cc91421cb"
@@ -5246,7 +5305,7 @@
       "checksum": "68908bd7f0038bcbeb637e0c56ab9569"
     },
     "R/utils_server_column_management.R": {
-      "checksum": "1867833208a01e4b9d23d9bbd906cb74"
+      "checksum": "547dd3d3bc4d4ba6e35105239dfb9fb5"
     },
     "R/utils_server_event_listeners.R": {
       "checksum": "456128f7233f32e0bf62161edb8e6e55"
@@ -5330,7 +5389,7 @@
       "checksum": "2a89e70626500a1b8267ecb603047ff5"
     },
     "R/utils_ui_app_layout.R": {
-      "checksum": "c9b138876dec18ffa5aa5dc576f3a0f1"
+      "checksum": "da12c58ef7963b33b0883ba01e249572"
     },
     "R/utils_ui_column_sync.R": {
       "checksum": "cfb8a0e40df0094e786ba865c1caef30"
@@ -5363,7 +5422,7 @@
       "checksum": "66f44772ca3108f367347e54ff91ebae"
     },
     "R/zzz.R": {
-      "checksum": "ad32ff26f43f3842a572d684737ab410"
+      "checksum": "8af6a97ee8d87cbefd81882e728c7667"
     }
   },
   "users": null

--- a/manifest.json
+++ b/manifest.json
@@ -4842,15 +4842,6 @@
     "DESCRIPTION": {
       "checksum": "2113045db4f8bf84f90040485bc6106c"
     },
-    "inst/.DS_Store": {
-      "checksum": "1ad883d77f4fa1366f539db331cbe44f"
-    },
-    "inst/app/.DS_Store": {
-      "checksum": "7d1074f35bdcf0254f79c4bc24363b97"
-    },
-    "inst/app/www/.DS_Store": {
-      "checksum": "18818c0d6bec754f431019ecba7c71ac"
-    },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
     },
@@ -4862,9 +4853,6 @@
     },
     "inst/app/www/cookie-consent.js": {
       "checksum": "7189fd2166a28917be429a708f9a0234"
-    },
-    "inst/app/www/help/.DS_Store": {
-      "checksum": "194577a7e20bdcc7afbb718f502c134c"
     },
     "inst/app/www/help/01-run-chart-stabil.png": {
       "checksum": "52fe486fe9191060c766afa64afe24f3"
@@ -4991,9 +4979,6 @@
     },
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
-    },
-    "manifest.json": {
-      "checksum": "46e2dbaca8e9735c733cd5f81fa89885"
     },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"


### PR DESCRIPTION
## Summary

Trippel fix der lukker hele kæden fra font-detection til rendering på Posit Connect Cloud, hvor ggplot-tekst aktuelt renderede med Roboto i stedet for Mari.

1. **Cache-clear** — `.onLoad` rydder `BFHtheme:::clear_bfh_font_cache()` efter `register_mari_font()`/`register_roboto_font()` som belt-and-suspenders mod cache-staleness.
2. **ragg som renderer** — `ragg (>= 1.2.0)` tilføjet til Imports + manifest.json regenereret + eksplicit `options(shiny.useragg = TRUE)` i `.onLoad`. Uden dette tegner Shiny via Cairo PNG (fontconfig), som ikke ser fonts registreret i systemfonts-registry'et.
3. **BFHtheme >= 0.5.1 påkrævet** — `font_available()`-fix i BFHtheme PR #73. Lower-bound bump følger separat når BFHtheme 0.5.1 er tagget.

## Root cause kæde

```
systemfonts har TO databaser:        Renderer-resolution-veje paa Linux:
  - system_fonts()                     - ragg/svglite via match_fonts()  -> ser BEGGE
  - registry_fonts() (via register_font)  - Cairo PNG via fontconfig    -> kun OS-fonts
```

Bugs der til sammen producerede symptomet:

| # | Lag | Bug | Effekt |
|---|-----|-----|--------|
| 1 | Detection (BFHtheme) | `font_available()` kun system_fonts() | get_bfh_font() vaelger Roboto i stedet for Mari |
| 2 | Cache (BFHtheme) | get_bfh_font() cacher 1. match | Selv efter sen Mari-registrering forbliver Roboto valgt |
| 3 | Renderer (Shiny default) | Cairo PNG via fontconfig | Registry-fonts usynlige selv om family="Mari" sendes til ggplot |

Fix 1 i BFHtheme PR #73. Fix 2 + 3 i denne PR.

## Test plan

- [x] Lokal repro af `font_available()`-bug og verifikation af BFHtheme-fix (se BFHtheme PR #73).
- [x] Smoking-gun bekraeftelse: `register_font(name="MariSmoke", ...)` -> registry_fonts() har den, system_fonts() ikke.
- [x] manifest.json valideret: `"ragg"` til stede x4 (CRAN dep).
- [x] DESCRIPTION/manifest sync OK (ragg 1.5.2 fra CRAN).
- [x] Pre-commit + pre-push hooks gronne.
- [ ] CI gron.
- [ ] BFHtheme 0.5.1 merget + tagget -> separat lower-bound bump-PR mod BFHtheme (>= 0.5.1).
- [ ] Deploy-verifikation paa Connect Cloud: ggplot-tekst skal vise Mari. Test efter alle tre led er paa plads.