### PR TITLE
chore(deps): bump BFHtheme to >= 0.5.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ Suggests:
     curl (>= 4.3.0),
     BFHllm (>= 0.2.0),
     BFHchartsAssets (>= 0.1.2),
+    BFHtheme (>= 0.5.1),
     pins (>= 1.2.0),
     gert (>= 1.9.0),
     shinylogs (>= 0.2.0),
@@ -78,7 +79,7 @@ Suggests:
 Config/testthat/edition: 3
 Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
 Remotes: johanreventlow/BFHcharts@v0.20.0,
-    johanreventlow/BFHtheme@v0.5.0,
+    johanreventlow/BFHtheme@v0.5.1,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,14 @@
 
 ## Dependency bumps
 
+* `BFHtheme (>= 0.5.1)` tilføjet til Suggests + `johanreventlow/BFHtheme@v0.5.1`
+  i Remotes. BFHtheme 0.5.1 indeholder `font_available()`-fix der konsulterer
+  både `system_fonts()` og `registry_fonts()` (PR johanreventlow/BFHtheme#73).
+  Uden bumpet ville `BFHtheme::get_bfh_font()` ikke se Mari registreret via
+  `systemfonts::register_font()` i runtime og fortsat falde tilbage til
+  Roboto/sans på Posit Connect Cloud. Lukker det sidste led i font-fix-
+  kæden ovenfor.
+
 * `ragg (>= 1.2.0)` tilføjet til Imports — påkrævet for at Shiny
   renderPlot kan tegne ggplot med fonts registreret via
   `systemfonts::register_font()` på Linux deploy-targets (Posit

--- a/manifest.json
+++ b/manifest.json
@@ -130,7 +130,7 @@
         "Package": "BFHtheme",
         "Type": "Package",
         "Title": "BFH Theme and Color Palettes for ggplot2",
-        "Version": "0.5.0",
+        "Version": "0.5.1",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "Provides comprehensive theming support for ggplot2 graphics\n    following Bispebjerg og Frederiksberg Hospital and Region Hovedstaden\n    visual identity guidelines. Includes color palettes for both Hospital\n    and Region H branding, themes, scale functions, and helper utilities\n    for creating consistent and professional visualizations. Uses modern\n    'systemfonts' package for robust font detection with graceful fallback.\n    Recommends 'ragg', 'svglite', and Cairo devices for high-quality output.",
         "License": "MIT + file LICENSE",
@@ -145,17 +145,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHtheme",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.5.0",
-        "RemoteSha": "82435c3a1e6d25d0bf6f7f0fdb539fcef6223f10",
+        "RemoteRef": "v0.5.1",
+        "RemoteSha": "c70eab872e9418df32ddc68d15efc79e0c97f9bf",
         "GithubRepo": "BFHtheme",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.5.0",
-        "GithubSHA1": "82435c3a1e6d25d0bf6f7f0fdb539fcef6223f10",
+        "GithubRef": "v0.5.1",
+        "GithubSHA1": "c70eab872e9418df32ddc68d15efc79e0c97f9bf",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-26 20:09:01 UTC; johanreventlow",
+        "Packaged": "2026-05-27 23:02:39 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-26 20:09:01 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-27 23:02:39 UTC; unix"
       }
     },
     "BH": {
@@ -4840,7 +4840,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "2113045db4f8bf84f90040485bc6106c"
+      "checksum": "655ef77afb7cd67581b5815b25fed175"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"


### PR DESCRIPTION
## Summary

Lukker det sidste led i font-fix-kaeden (jf. PR #807):

- `DESCRIPTION` Suggests: `BFHtheme (>= 0.5.1)` tilfoejet
- `DESCRIPTION` Remotes: `johanreventlow/BFHtheme@v0.5.0` -> `@v0.5.1`
- `manifest.json` regenereret -> BFHtheme 0.5.1 fra GitHub-tag

## Why

BFHtheme 0.5.1 indeholder `font_available()`-fix der konsulterer baade `system_fonts()` og `registry_fonts()`. Uden bumpet ville `BFHtheme::get_bfh_font()` ikke se Mari registreret via `systemfonts::register_font()` i runtime og fortsat falde tilbage til Roboto/sans paa Posit Connect Cloud — selv om PR #807 (cache-clear + ragg) er deployed.

Cross-repo bump-protokol § E (~/.claude/rules/VERSIONING_POLICY.md).

## Refs

- BFHtheme PR #73 (font_available registry-fix)
- BFHtheme tag v0.5.1
- biSPCharts PR #807 (cache-clear + ragg)
- BFHcharts PR #392 (parallel lower-bound bump)

## Test plan

- [x] Manifest valideret af `dev/validate_connect_manifest.R`: OK
- [x] BFHtheme 0.5.1 i manifest fra GitHub-tag
- [x] Pre-push hook bestaaet
- [ ] CI gron
- [ ] Deploy-verifikation paa Connect Cloud: ggplot-tekst skal vise Mari