### PR TITLE
fix(chart): forward indicator_title til analyse-view

### DIFF
--- a/R/mod_spc_chart_compute.R
+++ b/R/mod_spc_chart_compute.R
@@ -160,7 +160,7 @@ create_spc_results_reactive <- function(
           show_phases = inputs$skift_config$show_phases %||% FALSE,
           skift_column = inputs$skift_config$skift_column,
           frys_column = inputs$frys_column,
-          chart_title_reactive = NULL, # Will be passed at call site
+          chart_title_reactive = inputs$title,
           y_axis_unit = inputs$y_axis_unit,
           kommentar_column = inputs$kommentar_column,
           base_size = inputs$base_size,


### PR DESCRIPTION
## Summary

- Regression fra `c4cfacaa` (refactor stage-4, apr 2026) der hardcodede `chart_title_reactive = NULL` i analyse-view-pipelinen
- `input\$indicator_title` naaede ikke til `bfh_qic()` → chart havde ingen titel og markdown-bold (`**fed**`) kunne ikke rendres via `marquee::element_marquee`
- Forward `inputs\$title` (allerede captured i `create_spc_inputs_reactive` linje 215) til `generateSPCPlot`

## Verifikation

Empirisk PNG-repro foer/efter:
- Foer: `Title: <NULL>` → ingen titel renderet
- Efter: `Title: Test **fed** analyse-view` + `element_marquee` → "fed" rendret som bold

## Test plan

- [x] Manual PNG-render-test bekraefter bold rendres
- [x] `tests/testthat/test-mod-spc-chart-compute.R` 18 PASS
- [x] `tests/testthat/test-process-chart-title-markdown.R` 3 PASS
- [ ] Brugertest paa analyse-side med `**fed**` i titel-input