### PR TITLE
fix(export): fjern dobbelt-sanitering der dræber markdown i Typst PDF

### DIFF
--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -151,8 +151,14 @@ generate_pdf_export <- function(input, app_state, file) {
     base_description
   }
 
-  # PDF-specifik metadata til BFHcharts Typst-template
-  # escape_typst_metadata() beskytter mod markup-injection (#427)
+  # PDF-specifik metadata til BFHcharts Typst-template.
+  # BFHcharts haandterer al Typst-escaping internt: escape_typst_string() for
+  # plain-text-felter og markdown_to_typst() (AST-baseret) for rich-text-felter.
+  # Pre-escape via escape_typst_metadata() er fjernet fordi den dobbelt-escaper
+  # markdown-syntax (`**fed**` -> `\*\*fed\*\*`) saa BFHcharts AST-parseren ej
+  # genkender bold/italic. Historisk (#427/#486) escapede vi selv da Typst-
+  # template var lokal i biSPCharts; v0.3.0-migration (cc21b50c) flyttede
+  # rendering til BFHcharts uden at fjerne pre-escape.
   hospital_value <- if (nzchar(input$export_hospital %||% "")) {
     input$export_hospital
   } else {
@@ -163,11 +169,11 @@ generate_pdf_export <- function(input, app_state, file) {
   # tom blok i PDF (graceful empty-state).
   footnote_value <- trimws(input$export_footnote %||% "")
   metadata <- list(
-    hospital = escape_typst_metadata(hospital_value),
-    department = escape_typst_metadata(input$export_department),
-    analysis = escape_typst_metadata(input$pdf_improvement),
-    data_definition = escape_typst_metadata(data_definition_with_note),
-    footer_content = if (nzchar(footnote_value)) escape_typst_metadata(footnote_value) else NULL,
+    hospital = hospital_value,
+    department = input$export_department,
+    analysis = input$pdf_improvement,
+    data_definition = data_definition_with_note,
+    footer_content = if (nzchar(footnote_value)) footnote_value else NULL,
     date = Sys.Date()
   )
 

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -423,29 +423,36 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       hospital_input <- debounced_hospital()
       footnote_input <- trimws(debounced_footnote())
 
-      # Build metadata for PDF generation
+      # Build metadata for PDF generation.
       # Bemaerk: bfh_create_typst_document() (preview-vejen) auto-genererer ikke
       # details -- det goer kun bfh_export_pdf(). Vi saetter derfor selv details
       # via BFHcharts::bfh_generate_details() saa preview matcher eksport.
-      # escape_typst_metadata() beskytter mod markup-injection (#427)
+      #
+      # BFHcharts haandterer al Typst-escaping internt: escape_typst_string() for
+      # plain-text-felter og markdown_to_typst() (AST-baseret) for rich-text-felter.
+      # Pre-escape via escape_typst_metadata() er fjernet fordi den dobbelt-escaper
+      # markdown-syntax (`**fed**` -> `\*\*fed\*\*`) saa BFHcharts AST-parseren ej
+      # genkender bold/italic. Historisk (#427/#486) escapede vi selv da Typst-
+      # template var lokal i biSPCharts; v0.3.0-migration (cc21b50c) flyttede
+      # rendering til BFHcharts uden at fjerne pre-escape.
       preview_hospital_value <- if (nzchar(hospital_input)) {
         hospital_input
       } else {
         get_hospital_name_for_export()
       }
       metadata <- list(
-        hospital = escape_typst_metadata(preview_hospital_value),
-        department = escape_typst_metadata(dept_input),
-        title = escape_typst_metadata(title_input),
-        analysis = escape_typst_metadata(analysis_input),
+        hospital = preview_hospital_value,
+        department = dept_input,
+        title = title_input,
+        analysis = analysis_input,
         details = safe_operation(
           operation_name = "Generate PDF preview details",
           code = BFHcharts::bfh_generate_details(pdf_result$bfh_qic_result),
           fallback = NULL,
           error_type = "processing"
         ),
-        data_definition = escape_typst_metadata(data_def_input),
-        footer_content = if (nzchar(footnote_input)) escape_typst_metadata(footnote_input) else NULL,
+        data_definition = data_def_input,
+        footer_content = if (nzchar(footnote_input)) footnote_input else NULL,
         date = Sys.Date()
       )
 


### PR DESCRIPTION
## Summary

- biSPCharts kaldte `escape_typst_metadata()` paa rich-text-metadata foer BFHcharts; AST-baseret `markdown_to_typst()` i BFHcharts saa derefter pre-escaped asterisks som litterale tegn → `**fed**` blev rendret literal i PDF
- Dobbelt-sanitering opstod ved migration cc21b50c (dec 2025) til `BFHcharts::bfh_export_pdf` v0.3.0 uden at fjerne lokal pre-escape
- Fjerner `escape_typst_metadata()`-kald fra metadata-list i PDF-download + PDF-preview-paths

## Empirisk repro

| Input | Output | Result |
|-------|--------|--------|
| Raw \`**fed** her\` | \`#strong[fed] her\` | bold |
| Pre-escaped \`\\*\\*fed\\*\\* her\` | \`\\*\\*fed\\*\\* her\` | literal |

## Test plan

- [x] 37 PASS i `test-escape-typst-metadata.R` (funktion bevaret, kun call-sites fjernet)
- [x] Manual repro via `markdown_to_typst()` bekraefter `#strong[...]` output
- [ ] Brugertest: indtast `**fed**` i export_title + analyseteksten → verificer bold i PDF preview + download

## Note

`escape_typst_metadata()` funktionen er nu uden prod-callere men bevares til separat oprydnings-PR for at undgaa drop af test-coverage i denne fix.