### PR TITLE
fix(nav,session): om_os tilbage-nav + Gendan-knap re-run

### DIFF
--- a/R/app_server_main.R
+++ b/R/app_server_main.R
@@ -234,7 +234,12 @@ main_app_server <- function(input, output, session) {
     {
       new_tab <- input$main_navbar
       old_tab <- app_state$navigation$current_tab
-      help_tabs <- c("hjaelp", "rapporter_fejl")
+      # om_os har samme tilbagenavigation-pattern som hjaelp + rapporter_fejl:
+      # alle tre tabs er adskilt fra wizard-flow og bruger help_back_link til
+      # at returnere til oprindelig tab. Mangel paa "om_os" i listen gjorde at
+      # previous_tab ej opdateredes ved nav til om_os -> tilbage-knap brugte
+      # stale-vaerdi (typisk "start") i stedet for trin-2.
+      help_tabs <- c("hjaelp", "rapporter_fejl", "om_os")
       if (new_tab %in% help_tabs) {
         app_state$navigation$previous_tab <- old_tab
       }

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -295,6 +295,17 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             # FINALLY emit event (listeners ser nu korrekt state)
             emit$data_updated(context = "session_restore")
 
+            # Ryd peek_result + JS-side cached payload saa restore-card ej
+            # vises naar bruger senere navigerer tilbage til landing-page
+            # (fx fra om_os-tab). Tidligere blev peek_result alene ryddet ved
+            # eksplicit discard, hvilket lod restore-card hænge for resten af
+            # sessionen — anden klik paa "Gendan session" sendte performSession-
+            # Restore, men JS-handler havde allerede nulstillet
+            # window.__pendingRestore i foerste restore-passage -> ingen data
+            # naaede til R og brugeren oplevede "intet sker".
+            set_session_peek_result(app_state, list(has_payload = FALSE))
+            session$sendCustomMessage("discardPendingRestore", list())
+
             # Cleanup restoring_session flag AFTER alle data_updated-listeners
             # har koert. wizard_gates-observeren paa data_updated fyrer i naeste
             # flush og maa se restoring_session = TRUE saa den skipper auto-nav


### PR DESCRIPTION
## Summary

To relaterede bugs i navigation/session-restore-flow rapporteret af bruger:

### Bug 1 — om_os tilbage-knap forkert destination

`main_navbar`-observeren i `app_server_main.R:237` opdaterede kun `previous_tab` for tabs i `help_tabs = c("hjaelp", "rapporter_fejl")`. `om_os` var udeladt → `previous_tab` beholdt stale-vaerdi (typisk `"start"`). Tilbage-knap i om_os navigerede dermed til landing-page i stedet for tab brugeren kom fra (typisk trin-2/analyser).

**Fix:** tilfoej `"om_os"` til help_tabs-listen.

### Bug 2 — Gendan-knap virker ikke ved gentag-besoeg paa landing

JS-handler `performSessionRestore` (shiny-handlers.js:106) nulstiller `window.__pendingRestore` efter foerste passage. R-side `app_state$session$peek_result` blev aldrig ryddet efter restore — kun ved eksplicit "Start ny session"-klik.

Konsekvens: efter restore + navigation tilbage til landing (fx via tilbage-knap fra om_os), vises restore-card stadig, men klik paa "Gendan session" goer ingenting. JS-handler logger console-warning "performSessionRestore called but no pending restore data".

**Fix:** ryd `peek_result` + send `discardPendingRestore` til JS efter succesfuld restore. Landing falder graceful tilbage til default-landing ved gen-besoeg.

## Test plan

- [ ] Nav: trin-2 → om_os → tilbage → verificer destination = trin-2 (ej start)
- [ ] Nav: hjaelp → tilbage → verificer destination = forrige tab (regression)
- [ ] Nav: rapporter_fejl → tilbage → verificer destination = forrige tab (regression)
- [ ] Restore: peek-card vises → "Gendan session" → data loaded → nav til om_os → tilbage til start (via discard?) → verificer ingen restore-card → manuel upload virker
- [ ] Eksplicit "Start ny session"-flow stadig fungerer