### PR TITLE
fix(session): clear-then-restore mappings + rate-guard ved manglende nævner

### DIFF
--- a/R/fct_spc_prepare.R
+++ b/R/fct_spc_prepare.R
@@ -252,13 +252,29 @@ resolve_axis_units <- function(prepared) {
     target_text <- new_target_text
   }
 
-  # Guard: "percent" kraever naevner -- uden naevner er det en fejldetektering
+  # Guard: "percent" og "rate" kraever begge naevner -- uden naevner er det
+  # en fejldetektering (typisk session-restore med y_axis_unit fra forrige
+  # dataset hvor n_column manglede i ny metadata). Tidligere kun "percent"-
+  # guard; "rate" forblev og gav forkert beregning naar dataset manglede
+  # naevner. Anhoej-bokse viste tom state indtil bruger manuelt klikkede
+  # "Tildel kolonner" og udloeste auto-detect.
   if (identical(y_axis_unit, "percent") && is.null(prepared$n_var)) {
     log_warn(
       paste(
         "y_axis_unit='percent' uden n\u00e6vner (n_var=NULL) for chart_type=",
         prepared$chart_type,
         "\u2014 overskriver til 'count' for at undg\u00e5 forkert normalisering"
+      ),
+      .context = "BFH_SERVICE"
+    )
+    y_axis_unit <- "count"
+  }
+  if (identical(y_axis_unit, "rate") && is.null(prepared$n_var)) {
+    log_warn(
+      paste(
+        "y_axis_unit='rate' uden n\u00e6vner (n_var=NULL) for chart_type=",
+        prepared$chart_type,
+        "\u2014 overskriver til 'count' for at undg\u00e5 forkert beregning"
       ),
       .context = "BFH_SERVICE"
     )

--- a/R/utils_server_server_management.R
+++ b/R/utils_server_server_management.R
@@ -218,15 +218,29 @@ setup_session_management <- function(input, output, session, app_state, emit, ui
             # mapping-state i foerste iteration. Selve selectize-selected
             # opdateringen sker stadig i onFlushed nedenfor, fordi choices
             # skal vaere populeret foerst.
+            #
+            # Clear-then-restore (atomisk transaction): nulstil ALLE column-
+            # mappings foer write, saa felter der ej findes i ny metadata
+            # (eller har tom vaerdi) ej bevarer stale-vaerdier fra forrige
+            # session. Tidligere skip-tom-guard `if (!is.null(val) && nzchar(val))`
+            # lod fx mappings$n_column pege paa en kolonne der ej findes i nyt
+            # dataset, hvilket gav inkonsistent state med y_axis_unit der
+            # kraever naevner (p/u/pp/up) -> Anhoej-bokse tomme indtil bruger
+            # manuelt aabnede "Tildel kolonner" og udloeste auto-detect.
+            column_fields <- c(
+              "x_column", "y_column", "n_column",
+              "skift_column", "frys_column", "kommentar_column"
+            )
             if (!is.null(saved_state$metadata)) {
               saved_meta <- saved_state$metadata
-              for (field in c(
-                "x_column", "y_column", "n_column",
-                "skift_column", "frys_column", "kommentar_column"
-              )) {
+              for (field in column_fields) {
                 val <- saved_meta[[field]]
-                if (!is.null(val) && nzchar(val)) {
-                  app_state$columns$mappings[[field]] <- val
+                app_state$columns$mappings[[field]] <- if (
+                  !is.null(val) && nzchar(val)
+                ) {
+                  val
+                } else {
+                  NULL
                 }
               }
 

--- a/tests/testthat/test-fct_spc_prepare.R
+++ b/tests/testthat/test-fct_spc_prepare.R
@@ -119,6 +119,48 @@ test_that("prepare_spc_data bevarer n_var data for p-kort", {
   expect_true(is.numeric(prep$data$naevner))
 })
 
+test_that("resolve_axis_units nedgraderer 'percent' til 'count' naar n_var mangler", {
+  df <- data.frame(x = 1:10, y = as.numeric(1:10))
+  req <- new_spc_request(df, "x", "y", "run", options = list(y_axis_unit = "percent"))
+  prep <- prepare_spc_data(req)
+  axes <- resolve_axis_units(prep)
+  expect_equal(axes$y_axis_unit, "count")
+})
+
+test_that("resolve_axis_units nedgraderer 'rate' til 'count' naar n_var mangler", {
+  # Regression: session-restore med y_axis_unit='rate' fra forrige dataset hvor
+  # n_column manglede i ny metadata -> rate-render fejlede eller producerede
+  # forkert beregning. Anhoej-bokse viste tom state indtil bruger manuelt
+  # klikkede "Tildel kolonner".
+  df <- data.frame(x = 1:10, y = as.numeric(1:10))
+  req <- new_spc_request(df, "x", "y", "run", options = list(y_axis_unit = "rate"))
+  prep <- prepare_spc_data(req)
+  axes <- resolve_axis_units(prep)
+  expect_equal(axes$y_axis_unit, "count")
+})
+
+test_that("resolve_axis_units bevarer 'percent' naar n_var er sat", {
+  df <- data.frame(x = 1:10, y = as.numeric(1:10), n = rep(100, 10))
+  req <- new_spc_request(df, "x", "y", "p",
+    n_var = "n",
+    options = list(y_axis_unit = "percent")
+  )
+  prep <- prepare_spc_data(req)
+  axes <- resolve_axis_units(prep)
+  expect_equal(axes$y_axis_unit, "percent")
+})
+
+test_that("resolve_axis_units bevarer 'rate' naar n_var er sat", {
+  df <- data.frame(x = 1:10, y = as.numeric(1:10), n = rep(100, 10))
+  req <- new_spc_request(df, "x", "y", "u",
+    n_var = "n",
+    options = list(y_axis_unit = "rate")
+  )
+  prep <- prepare_spc_data(req)
+  axes <- resolve_axis_units(prep)
+  expect_equal(axes$y_axis_unit, "rate")
+})
+
 test_that("spc_prepare_error arver fra spc_error", {
   df <- data.frame(
     x = integer(0),


### PR DESCRIPTION
## Summary

To samvirkende root causes for **"Anhøj-bokse tomme efter reload"** når dataset ej har nævner-kolonne (rapporteret af bruger 2026-05-28):

### Bug 1 — Stale-mapping-race i restore-flow

`utils_server_server_management.R:222-231` brugte skip-tom-guard:

```r
if (!is.null(val) && nzchar(val)) {
  app_state\$columns\$mappings[[field]] <- val
}
# else: skip write -> behold stale-vaerdi
```

Hvis ny metadata havde \`n_column = ""\` eller manglede feltet, blev \`mappings\$n_column\` ej overskrevet → bevarede stale-værdi fra forrige session (pegende på kolonne der ej findes i nyt dataset). Inkonsistent state med y_axis_unit der kræver nævner (p/u/pp/up).

**Fix:** clear-then-restore atomisk transaction. Skriv ALTID til mappings — \`NULL\` hvis metadata ej har feltet. Eliminerer cross-dataset stale-state-lækage.

### Bug 2 — Manglende rate-downgrade ved n_var=NULL

\`fct_spc_prepare.R:resolve_axis_units\` havde guard for \`"percent"\` (downgrade til \`"count"\` hvis n_var mangler) men IKKE for \`"rate"\`. Asymmetri opdaget under analyse.

Konsekvens: hvis user havde \`y_axis_unit="rate"\` i forrige session og n_column manglede i nyt dataset, blev rate-render kaldt med NULL nævner → forkert beregning eller BFHcharts-fejl.

**Fix:** tilføj symmetrisk rate-guard ved siden af percent-guard.

## User-symptom

> "Anhoej-bokse viste ikke rigtig noget før jeg trykkede på 'Tildel kolonner'-knappen, hvorved autodetect blev kørt og bokse kom til at se korrekt ud"

Auto-detect skrev mappings autoritativt (inkl. NULL for missing n_column) → state-konsistens genoprettet. Fixet adresserer root cause så autodetect-klik ej er nødvendigt.

## Test plan

- [x] 4 nye regression-tests i \`test-fct_spc_prepare.R\` for percent/rate downgrade-paths
- [x] \`test-fct_spc_prepare.R\`: 26 PASS
- [x] \`test-utils_server_server_management.R\`: 25 PASS
- [x] \`test-session-persistence.R\`: 70 PASS
- [x] \`test-integration-session-restore.R\`: 13 PASS
- [x] \`test-fix-state-paths-and-restore-guards.R\`: 28 PASS
- [ ] Manual: dataset A (med n) → reload → dataset B (uden n) → verificer Anhøj-bokse korrekte uden manuel "Tildel kolonner"-klik
- [ ] Manual: y_axis_unit="rate" i metadata + n_column tom → verificer downgrade til "count" + warning i log