### PR TITLE
fix(export): applicer x_scale paa bfh_qic_result for tekst-x i eksport

### DIFF
--- a/R/fct_spc_execute.R
+++ b/R/fct_spc_execute.R
@@ -170,8 +170,24 @@ execute_bfh_request <- function(bfh_params, prepared) {
     spc_abort("Output transformation failed", class = "spc_render_error")
   }
 
-  if (!is.null(x_scale) && !is.null(standardized$plot)) {
-    standardized$plot <- standardized$plot + x_scale + x_theme
+  # Applicer x_scale + x_theme paa BEGGE plot-objekter saa tekst-x-labels
+  # (fx maanedsnavne) vises korrekt i baade analyse-view OG eksport-paths.
+  #
+  # standardized$plot er gg-objektet brugt af analyse-view-render.
+  # standardized$bfh_qic_result$plot er det raw BFHcharts S3-objekt der bruges
+  # af eksport-pipelinen (bfh_export_pdf, bfh_export_png + preview-PNG via
+  # ggsave i generate_pdf_preview). Tidligere blev x_scale kun appliceret paa
+  # standardized$plot -> eksport viste numerisk fallback (1,2,3,...) for
+  # tekst-x i stedet for original-labels (januar, februar, ...).
+  if (!is.null(x_scale)) {
+    if (!is.null(standardized$plot)) {
+      standardized$plot <- standardized$plot + x_scale + x_theme
+    }
+    if (!is.null(standardized$bfh_qic_result) &&
+      !is.null(standardized$bfh_qic_result$plot)) {
+      standardized$bfh_qic_result$plot <-
+        standardized$bfh_qic_result$plot + x_scale + x_theme
+    }
   }
 
   standardized

--- a/tests/testthat/test-spc-execute-x-scale.R
+++ b/tests/testthat/test-spc-execute-x-scale.R
@@ -39,6 +39,57 @@ test_that("execute_bfh_request: text-x-axis plot har max 2 x-scales efter #450 (
   expect_lte(pos_scales, 2L)
 })
 
+test_that("execute_bfh_request: text-x labels appliceres ogsaa paa bfh_qic_result$plot (export-paths)", {
+  # Regression: tidligere appliceredes x_scale + x_theme kun paa
+  # standardized$plot (analyse-view), ej paa standardized$bfh_qic_result$plot
+  # (raw S3-objekt brugt af eksport-pipelinen via bfh_export_pdf,
+  # bfh_export_png + PDF preview-PNG via ggsave i generate_pdf_preview).
+  # Konsekvens: PDF/PNG eksport viste numerisk fallback (1,2,3,...) for
+  # tekst-x i stedet for original-labels (januar, februar, ...).
+  skip_if_not_installed("BFHcharts")
+
+  test_data <- data.frame(
+    maaned = c(
+      "Jan", "Feb", "Mar", "Apr", "Maj", "Jun",
+      "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"
+    ),
+    indikator = c(10, 12, 15, 13, 14, 16, 18, 17, 19, 20, 21, 22)
+  )
+
+  result <- compute_spc_results_bfh(
+    data = test_data,
+    chart_type = "i",
+    x_var = "maaned",
+    y_var = "indikator",
+    use_cache = FALSE
+  )
+
+  expect_false(is.null(result$plot))
+  expect_false(is.null(result$bfh_qic_result))
+  expect_false(is.null(result$bfh_qic_result$plot))
+
+  # Helper: extract text-labels fra ScaleContinuousPosition i et plot
+  extract_text_labels <- function(plot) {
+    for (s in plot$scales$scales) {
+      if ("x" %in% s$aesthetics && inherits(s, "ScaleContinuousPosition")) {
+        if (is.character(s$labels) && length(s$labels) > 0) {
+          return(s$labels)
+        }
+      }
+    }
+    NULL
+  }
+
+  std_labels <- extract_text_labels(result$plot)
+  bfh_labels <- extract_text_labels(result$bfh_qic_result$plot)
+
+  expect_equal(std_labels, c(
+    "Jan", "Feb", "Mar", "Apr", "Maj", "Jun",
+    "Jul", "Aug", "Sep", "Okt", "Nov", "Dec"
+  ))
+  expect_equal(bfh_labels, std_labels)
+})
+
 test_that("execute_bfh_request: numeric-x-axis plot påvirkes ikke af #450-fix", {
   skip_if_not_installed("BFHcharts")
 


### PR DESCRIPTION
## Summary

Brugere der angiver tekst-kategorier som x-kolonne (fx månedsnavne) så ulæselig x-akse på eksporterede PDF/PNG:
- **Trin 2 (analyse):** januar, februar, marts, ... ✓
- **Trin 3 (eksport-preview + download):** 1, 2, 3, ... ✗

## Rod-årsag

`fct_spc_execute.R:173-175` appliceredes `x_scale + x_theme` kun på `standardized\$plot` (analyse-view-ggplot). `standardized\$bfh_qic_result\$plot` er raw BFHcharts S3-objekt, der bruges af **alle** eksport-paths:

- \`bfh_export_pdf\` (PDF download)
- \`bfh_export_png\` (PNG download)
- \`generate_pdf_preview\` (Typst PDF-preview-PNG via ggsave)

Tekst-x-konvertering i \`prepare_spc_data\` -> numerisk sekvens med labels i \`.x_labels_<x_var>\`-kolonne nåede aldrig frem til raw bfh_qic_result.

## Empirisk verifikation

PNG-output før/efter sammenlignet på samme tekst-x-data:

| Plot | Før fix | Efter fix |
|------|---------|-----------|
| \`standardized\$plot\` | januar...december ✓ | januar...december ✓ |
| \`bfh_qic_result\$plot\` | 2 4 6 8 10 12 ✗ | januar...december ✓ |

## Komponent 1 af tre

Tekst-x-eksport-track:

1. **Dual-apply x_scale** (denne PR) — quick fix, virker straks for ≤12 labels
2. **Subsample-helper for mange labels** — progressivt thinning uden rotation
3. **BFHcharts: Periode-felt accepterer x_labels-vector** — kræver sibling-bump

## Test plan

- [x] Regression-test i \`test-spc-execute-x-scale.R\`: \`bfh_qic_result\$plot\` har samme tekst-labels som \`std\$plot\`
- [x] Numerisk-x baseline test forbliver grøn
- [x] 71 PASS i spc-execute/spc-prepare/bfh-output tests
- [ ] Manual: pasted data med månedsnavne -> trin 3 PDF preview viser januar...december (ikke 1...12)
- [ ] Manual: PNG download samme data viser korrekte labels