### PR TITLE
fix(export): integrer BFHcharts 0.21.0 text-x helpers + x_labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.20.0),
+    BFHcharts (>= 0.21.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -78,7 +78,7 @@ Suggests:
     pkgload (>= 1.3.0)
 Config/testthat/edition: 3
 Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.20.0,
+Remotes: johanreventlow/BFHcharts@v0.21.0,
     johanreventlow/BFHtheme@v0.5.1,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2

--- a/R/fct_spc_execute.R
+++ b/R/fct_spc_execute.R
@@ -136,15 +136,25 @@ execute_bfh_request <- function(bfh_params, prepared) {
   # H4 (#450): x_scale + x_theme appliceres ÉN gang efter
   # transform_bfh_output(). Tidligere appliceret to gange (her + efter
   # transform), hvilket gav duplikeret layer-objekt og bloated layer-list.
+  #
+  # Subsample-strategi: ved >BFH_MAX_X_LABELS_TEXT labels brug
+  # BFHcharts::bfh_subsample_label_indices() til at vaelge evenly-spaced
+  # subset med foerste+sidste anchored. Holder labels horisontale (ingen
+  # rotation) jf. user-praeference. <= maks vises alle labels horisontalt.
   x_labels_col <- paste0(".x_labels_", prepared$x_var)
   x_scale <- NULL
   x_theme <- NULL
+  x_labels <- NULL
   if (x_labels_col %in% names(prepared$data)) {
     x_labels <- prepared$data[[x_labels_col]]
-    x_breaks <- seq_along(x_labels)
-    x_scale <- ggplot2::scale_x_continuous(breaks = x_breaks, labels = x_labels)
+    n_labels <- length(x_labels)
+    visible_idx <- BFHcharts::bfh_subsample_label_indices(n_labels)
+    x_scale <- ggplot2::scale_x_continuous(
+      breaks = visible_idx,
+      labels = x_labels[visible_idx]
+    )
     x_theme <- ggplot2::theme(
-      axis.text.x = ggplot2::element_text(angle = 45, hjust = 1)
+      axis.text.x = ggplot2::element_text(angle = 0, hjust = 0.5)
     )
   }
 
@@ -188,6 +198,14 @@ execute_bfh_request <- function(bfh_params, prepared) {
       standardized$bfh_qic_result$plot <-
         standardized$bfh_qic_result$plot + x_scale + x_theme
     }
+  }
+
+  # Eksporter x_labels-vector saa eksport-callere kan forwarde til
+  # BFHcharts::bfh_generate_details(x_labels = ...) og dermed faa Periode-
+  # felt "januar - december" frem for "1970-01-01 - 1970-01-12".
+  # NULL hvis numerisk x (ingen labels-konvertering noedvendig).
+  if (!is.null(x_labels)) {
+    standardized$x_labels <- x_labels
   }
 
   standardized

--- a/R/mod_export_download.R
+++ b/R/mod_export_download.R
@@ -168,10 +168,28 @@ generate_pdf_export <- function(input, app_state, file) {
   # som lille graa UPPERCASE-tekst nederst-hoejre. NULL hvis tom -> ingen
   # tom blok i PDF (graceful empty-state).
   footnote_value <- trimws(input$export_footnote %||% "")
+
+  # Pre-compute details med x_labels-support saa Periode-felt viser foerste/
+  # sidste original-tekst-label (fx "januar - december") naar x-kolonne er
+  # tekst-kategorier. bfh_export_pdf auto-genererer details internt uden
+  # x_labels-vector, hvilket gav "Periode: 1970-01-01 - 1970-01-12"-nonsens
+  # ved tekst-x. Sender metadata$details eksplicit -> overrider auto-gen.
+  download_x_labels <- pdf_plot_result$x_labels
+  download_details <- safe_operation(
+    operation_name = "Generate PDF download details",
+    code = BFHcharts::bfh_generate_details(
+      pdf_plot_result$bfh_qic_result,
+      x_labels = download_x_labels
+    ),
+    fallback = NULL,
+    error_type = "processing"
+  )
+
   metadata <- list(
     hospital = hospital_value,
     department = input$export_department,
     analysis = input$pdf_improvement,
+    details = download_details,
     data_definition = data_definition_with_note,
     footer_content = if (nzchar(footnote_value)) footnote_value else NULL,
     date = Sys.Date()

--- a/R/mod_export_server.R
+++ b/R/mod_export_server.R
@@ -440,6 +440,10 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
       } else {
         get_hospital_name_for_export()
       }
+      # x_labels: original tekst-x-labels (maanedsnavne etc.) propageret via
+      # standardized output fra fct_spc_execute.R. NULL ved numerisk x ->
+      # bfh_generate_details falder tilbage til dato-baseret Periode-format.
+      preview_x_labels <- pdf_result$x_labels
       metadata <- list(
         hospital = preview_hospital_value,
         department = dept_input,
@@ -447,7 +451,10 @@ mod_export_server <- function(id, app_state, parent_session = NULL) {
         analysis = analysis_input,
         details = safe_operation(
           operation_name = "Generate PDF preview details",
-          code = BFHcharts::bfh_generate_details(pdf_result$bfh_qic_result),
+          code = BFHcharts::bfh_generate_details(
+            pdf_result$bfh_qic_result,
+            x_labels = preview_x_labels
+          ),
           fallback = NULL,
           error_type = "processing"
         ),

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.20.0",
+        "Version": "0.21.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -31,7 +31,7 @@
         "URL": "https://github.com/johanreventlow/BFHcharts",
         "BugReports": "https://github.com/johanreventlow/BFHcharts/issues",
         "Depends": "R (>= 4.1.0)",
-        "Imports": "BFHtheme (>= 0.5.0), ggplot2 (>= 3.4.0), qicharts2 (>= 0.7.0),\nscales (>= 1.2.0), lubridate (>= 1.9.0), dplyr (>= 1.1.0),\npurrr (>= 1.0.0), stringr (>= 1.5.0), tibble (>= 3.2.0), yaml,\nlemon, marquee (>= 0.1.0), grid, commonmark (>= 1.9), xml2,\nsystemfonts, rlang, svglite",
+        "Imports": "BFHtheme (>= 0.5.1), ggplot2 (>= 3.4.0), qicharts2 (>= 0.7.0),\nscales (>= 1.2.0), lubridate (>= 1.9.0), dplyr (>= 1.1.0),\npurrr (>= 1.0.0), stringr (>= 1.5.0), tibble (>= 3.2.0), yaml,\nlemon, marquee (>= 0.1.0), grid, commonmark (>= 1.9), xml2,\nsystemfonts, rlang, svglite",
         "Suggests": "testthat (>= 3.1.7), vdiffr, covr, pdftools (>= 3.3.0),\nwithr, bench, BFHllm, jsonlite, knitr, rmarkdown",
         "VignetteBuilder": "knitr",
         "Remotes": "johanreventlow/BFHtheme, johanreventlow/BFHllm",
@@ -41,17 +41,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.20.0",
-        "RemoteSha": "d4f72ed50c9a5b963177e7b3ff27415b23530019",
+        "RemoteRef": "v0.21.0",
+        "RemoteSha": "70c67bde0ce907516d488817df474953ae3bc8db",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.20.0",
-        "GithubSHA1": "d4f72ed50c9a5b963177e7b3ff27415b23530019",
+        "GithubRef": "v0.21.0",
+        "GithubSHA1": "70c67bde0ce907516d488817df474953ae3bc8db",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-26 20:08:52 UTC; johanreventlow",
+        "Packaged": "2026-05-28 16:19:26 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-26 20:08:53 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-28 16:19:26 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -81,10 +81,10 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-26 20:09:15 UTC; johanreventlow",
+        "Packaged": "2026-05-28 16:19:51 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-26 20:09:16 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-28 16:19:52 UTC; unix"
       }
     },
     "BFHllm": {
@@ -117,10 +117,10 @@
         "GithubRef": "v0.2.0",
         "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-26 20:09:08 UTC; johanreventlow",
+        "Packaged": "2026-05-28 16:19:43 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-26 20:09:09 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-28 16:19:44 UTC; unix"
       }
     },
     "BFHtheme": {
@@ -152,10 +152,10 @@
         "GithubRef": "v0.5.1",
         "GithubSHA1": "c70eab872e9418df32ddc68d15efc79e0c97f9bf",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-27 23:02:39 UTC; johanreventlow",
+        "Packaged": "2026-05-28 16:20:30 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-27 23:02:39 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-28 16:20:31 UTC; unix"
       }
     },
     "BH": {
@@ -4840,7 +4840,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "655ef77afb7cd67581b5815b25fed175"
+      "checksum": "657127f56d9c450b4a12f6733e62cf28"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4993,7 +4993,7 @@
       "checksum": "d85bbd8c1967f0d78e01081616a4e723"
     },
     "R/app_server_main.R": {
-      "checksum": "e4d7b10a9d62bae8a52f5084acecf35e"
+      "checksum": "0ab839bfb85391ec70e0da6361fd8d44"
     },
     "R/app_server.R": {
       "checksum": "c97a964c3c2b954be459b38cc6fef0e4"
@@ -5104,7 +5104,7 @@
       "checksum": "d8a1f060147ffd0df5a6ff8490bce3ad"
     },
     "R/fct_spc_execute.R": {
-      "checksum": "b98e0e5fcbf04eb62dbabd621a547eaf"
+      "checksum": "8952dc02659b932024ef5bd5845d483e"
     },
     "R/fct_spc_file_save_load.R": {
       "checksum": "ce1e71cec2afe3f34144e8febef607dd"
@@ -5116,7 +5116,7 @@
       "checksum": "6c9925f7a78041a5e4403971bfe629c5"
     },
     "R/fct_spc_prepare.R": {
-      "checksum": "dcd119cd238085f15f4ac1ea953579fb"
+      "checksum": "b7346e4341019b2b15915a28246f2ab3"
     },
     "R/fct_spc_validate.R": {
       "checksum": "14a70f563188ae4c75d4d9c550f6b722"
@@ -5143,10 +5143,10 @@
       "checksum": "9c0ecdd409037ca33ca3743ce6145525"
     },
     "R/mod_export_download.R": {
-      "checksum": "98d2829d358050520d27c0f3f285fd9d"
+      "checksum": "f0358316a0476dea3715532573300aa7"
     },
     "R/mod_export_server.R": {
-      "checksum": "c7c4c1c0a6a279d463c45c316cba92a3"
+      "checksum": "40ba4680fa08ffed664ebfcece59c7bd"
     },
     "R/mod_export_ui.R": {
       "checksum": "35573e91ef3737e5e8fc2484dcca9f29"
@@ -5170,7 +5170,7 @@
       "checksum": "083c17739e20efc9f95a5ec9ed11694f"
     },
     "R/mod_spc_chart_compute.R": {
-      "checksum": "9d500938ae08606bc7a9bf5cc91421cb"
+      "checksum": "65e9b0421f5d795accbfae0d78ad2a68"
     },
     "R/mod_spc_chart_config.R": {
       "checksum": "e9d769f9a0ac84e375ecb01800c0fc5a"
@@ -5326,7 +5326,7 @@
       "checksum": "e33196c14e2d621e42bc529c4cd9f808"
     },
     "R/utils_server_server_management.R": {
-      "checksum": "ef5589d55076b2b38d72c565996fdb28"
+      "checksum": "2b19c7a918c14df96f9131394203d8be"
     },
     "R/utils_server_session_helpers.R": {
       "checksum": "ef64f081934a0374ae5647a1320ac1a6"

--- a/tests/testthat/test-spc-execute-x-scale.R
+++ b/tests/testthat/test-spc-execute-x-scale.R
@@ -90,6 +90,69 @@ test_that("execute_bfh_request: text-x labels appliceres ogsaa paa bfh_qic_resul
   expect_equal(bfh_labels, std_labels)
 })
 
+test_that("execute_bfh_request: x_labels propageret paa standardized output", {
+  # Regression: x_labels-vector skal eksponeres paa standardized output saa
+  # eksport-callere kan forwarde til BFHcharts::bfh_generate_details(x_labels=)
+  # og dermed faa Periode-felt "januar - december" frem for "1970-01-01"-nonsens.
+  skip_if_not_installed("BFHcharts")
+
+  months_da <- c(
+    "januar", "februar", "marts", "april", "maj", "juni",
+    "juli", "august", "september", "oktober", "november", "december"
+  )
+  test_data <- data.frame(
+    maaned = months_da,
+    indikator = c(10, 12, 15, 13, 14, 16, 18, 17, 19, 20, 21, 22)
+  )
+
+  result <- compute_spc_results_bfh(
+    data = test_data,
+    chart_type = "i",
+    x_var = "maaned",
+    y_var = "indikator",
+    use_cache = FALSE
+  )
+
+  expect_equal(result$x_labels, months_da)
+})
+
+test_that("execute_bfh_request: subsample begraenser breaks ved >12 tekst-labels", {
+  # Regression: BFHcharts::bfh_subsample_label_indices() integration. Ved
+  # n_labels > BFH_MAX_X_LABELS_TEXT (default 12) skal x_scale kun vise
+  # subset af labels (foerste + sidste anchored) for at undgaa overlap.
+  skip_if_not_installed("BFHcharts")
+
+  weeks <- paste0("Uge ", 1:52)
+  test_data <- data.frame(uge = weeks, v = seq.int(52))
+
+  result <- compute_spc_results_bfh(
+    data = test_data,
+    chart_type = "i",
+    x_var = "uge",
+    y_var = "v",
+    use_cache = FALSE
+  )
+
+  # x_labels skal indeholde alle 52 (raw labels propageret)
+  expect_equal(length(result$x_labels), 52L)
+
+  # Men x_scale paa plot skal kun have <= 12 breaks (subsample)
+  extract_scale_breaks <- function(plot) {
+    for (s in plot$scales$scales) {
+      if ("x" %in% s$aesthetics && inherits(s, "ScaleContinuousPosition")) {
+        if (is.numeric(s$breaks)) {
+          return(s$breaks)
+        }
+      }
+    }
+    NULL
+  }
+  breaks <- extract_scale_breaks(result$plot)
+  expect_lte(length(breaks), 12L)
+  expect_equal(breaks[1], 1L) # foerste anker
+  expect_equal(breaks[length(breaks)], 52L) # sidste anker
+})
+
 test_that("execute_bfh_request: numeric-x-axis plot påvirkes ikke af #450-fix", {
   skip_if_not_installed("BFHcharts")
 


### PR DESCRIPTION
## Summary

Komponent **K2 + K3** i tekst-x-eksport-track. Komplementerer **K1 (#817 merged)** der appliceredede x_scale på bfh_qic_result.

Bruger der angiver tekst-kategorier som x-kolonne (månedsnavne, ugedage, observation-id) får nu:
- **Trin 3 PDF/PNG eksport:** horisontale tekst-labels (uden 45° rotation) + progressivt thinning ved mange labels
- **PDF metadata Periode-felt:** "Periode: januar – december" (i stedet for "Periode: 1970-01-01 – 1970-01-12")

## Tre fix-områder

### 1. fct_spc_execute.R — progressive subsample uden rotation

\`BFHcharts::bfh_subsample_label_indices()\` integreret. Ved n_labels > \`BFH_MAX_X_LABELS_TEXT\` (default 12) thinner subsample-helper labels til max 12 evenly-spaced med første+sidste anchored. Holder labels horisontale jf. user-præference.

| n_labels | Resultat |
|----------|----------|
| 12 (måneder) | Alle 12 vist horisontalt |
| 52 (uger) | "Uge 1, 6, 10, ..., 47, 52" (12 evenly-spaced) |
| 100 | 12 evenly-spaced |

### 2. fct_spc_execute.R — eksportér x_labels på standardized output

\`standardized\$x_labels\` eksponeret så eksport-callere kan forwarde til \`BFHcharts::bfh_generate_details(x_labels = ...)\`.

### 3. mod_export_server.R + mod_export_download.R — pass x_labels til details

PDF preview + download forwarder \`pdf_result\$x_labels\` til \`bfh_generate_details()\`. Download pre-computer details i biSPCharts og passer i metadata (override bfh_export_pdf's auto-gen der ej accepterer x_labels-param).

### Dependency bump

- DESCRIPTION: \`BFHcharts (>= 0.21.0)\` i Imports
- Remotes: \`johanreventlow/BFHcharts@v0.21.0\`
- manifest.json regenereret

## Empirisk verifikation

\`\`\`
Uden x_labels: "Periode: jan. 1970 – jan. 1970 • Gns. dag: 16 ..."
Med x_labels:  "Periode: januar – december • Gns. kategori: 16 ..."
\`\`\`

PNG-output for 52 uger viser 12 horisontale labels uden overlap.

## Test plan

- [x] 2 nye regression-tests i \`test-spc-execute-x-scale.R\`:
  - x_labels propageret på standardized output
  - subsample begrænser breaks ved >12 tekst-labels
- [x] 14 PASS i \`test-spc-execute-x-scale.R\`
- [x] BFHcharts 0.21.0 installeret + manifest validate OK
- [ ] Manual: månedsnavne i upload-data → trin 3 PDF preview viser januar–december + Periode-felt korrekt
- [ ] Manual: 52 uger-data → trin 3 viser 12 horisontale labels uden overlap

## Tracking

| Komponent | PR | Status |
|-----------|-----|--------|
| K1: x_scale dual-apply | biSPCharts #817 | merged |
| K2+K3 BFHcharts-API | BFHcharts #394 (release #395, v0.21.0) | merged + tagged |
| **K2+K3 biSPCharts-integration** | **denne PR** | **draft** |