### PR TITLE
chore(deps): bump BFHcharts to 0.22.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.21.0),
+    BFHcharts (>= 0.22.1),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -78,7 +78,7 @@ Suggests:
     pkgload (>= 1.3.0)
 Config/testthat/edition: 3
 Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.21.0,
+Remotes: johanreventlow/BFHcharts@v0.22.1,
     johanreventlow/BFHtheme@v0.5.1,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,22 @@
 
 ## Dependency bumps
 
+* `BFHcharts (>= 0.22.1)` (op fra 0.21.0) + `johanreventlow/BFHcharts@v0.22.1`
+  i Remotes. Adopterer step-baseret label-thinning i
+  `bfh_subsample_label_indices()` der fixer asymmetrisk round()-gap-bug
+  for n=24 (BFHcharts issue #396, PRs #397 + #400). Observable behavior-
+  change i SPC-eksport med kategoriske x-akser:
+    * **n=24**: 12 visible labels → 8 visible labels med konstant step=3.
+      Sidste label (`n`) vises kun når `(n-1) %% step == 0`. For 24-mdrs
+      serier betyder det at "dec 26" droppes (sidste vises bliver "nov 26",
+      index 22).
+    * **n=36**: 12 → 9 visible labels, konstant step=4. Sidste = 33.
+    * **n=52**: 12 → 11 visible labels, konstant step=5. Sidste = 51.
+    * **n=100**: uændret 12 visible labels (100 lander naturligt på grid).
+  Rationale: forhindrer at to konsekutive labels skjules midt i serien
+  (visuel anti-pattern fra 0.21.0) + holder konstant rytme uden tail-break
+  (forbedring over 0.22.0's force-last anchor).
+
 * `BFHtheme (>= 0.5.1)` tilføjet til Suggests + `johanreventlow/BFHtheme@v0.5.1`
   i Remotes. BFHtheme 0.5.1 indeholder `font_available()`-fix der konsulterer
   både `system_fonts()` og `registry_fonts()` (PR johanreventlow/BFHtheme#73).

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.21.0",
+        "Version": "0.22.1",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -41,17 +41,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.21.0",
-        "RemoteSha": "70c67bde0ce907516d488817df474953ae3bc8db",
+        "RemoteRef": "v0.22.1",
+        "RemoteSha": "efb23fb120bd930c52804d0c693f49c83434342d",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.21.0",
-        "GithubSHA1": "70c67bde0ce907516d488817df474953ae3bc8db",
+        "GithubRef": "v0.22.1",
+        "GithubSHA1": "efb23fb120bd930c52804d0c693f49c83434342d",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-28 16:19:26 UTC; johanreventlow",
+        "Packaged": "2026-05-29 05:48:34 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-28 16:19:26 UTC; unix"
+        "Built": "R 4.5.2; ; 2026-05-29 05:48:35 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -4840,7 +4840,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "657127f56d9c450b4a12f6733e62cf28"
+      "checksum": "18c9f0ffce42a2e728543fd5b3fe53a9"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4979,6 +4979,9 @@
     },
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
+    },
+    "manifest.json": {
+      "checksum": "9e65c84b4b558e9897e5b84d7724b490"
     },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"

--- a/tests/testthat/test-spc-execute-x-scale.R
+++ b/tests/testthat/test-spc-execute-x-scale.R
@@ -119,7 +119,10 @@ test_that("execute_bfh_request: x_labels propageret paa standardized output", {
 test_that("execute_bfh_request: subsample begraenser breaks ved >12 tekst-labels", {
   # Regression: BFHcharts::bfh_subsample_label_indices() integration. Ved
   # n_labels > BFH_MAX_X_LABELS_TEXT (default 12) skal x_scale kun vise
-  # subset af labels (foerste + sidste anchored) for at undgaa overlap.
+  # subset af labels (foerste anker + step-grid-alignede positioner).
+  # Bemaerk: BFHcharts 0.22.1 dropped force-last anchor -- sidste label
+  # vises kun naar (n - 1) %% step == 0. For n=52 (step=5) bliver sidste
+  # break 51, ikke 52 (BFHcharts issue #396 follow-up).
   skip_if_not_installed("BFHcharts")
 
   weeks <- paste0("Uge ", 1:52)
@@ -150,7 +153,9 @@ test_that("execute_bfh_request: subsample begraenser breaks ved >12 tekst-labels
   breaks <- extract_scale_breaks(result$plot)
   expect_lte(length(breaks), 12L)
   expect_equal(breaks[1], 1L) # foerste anker
-  expect_equal(breaks[length(breaks)], 52L) # sidste anker
+  # n=52, step = ceil(51/11) = 5 -> sidste step-aligned position = 51
+  # (52 ej grid-aligned: 51 %% 5 != 0). BFHcharts >= 0.22.1.
+  expect_equal(breaks[length(breaks)], 51L)
 })
 
 test_that("execute_bfh_request: numeric-x-axis plot påvirkes ikke af #450-fix", {


### PR DESCRIPTION
## Summary

- Bump `BFHcharts` lower-bound: `0.21.0` → `0.22.1` (skipper 0.22.0 helt).
- Manifest regen via `dev/_regen_manifest.R` for Posit Connect Cloud deploy.
- Adopterer step-baseret label-thinning fix fra BFHcharts issue #396 (PRs johanreventlow/BFHcharts#397 + #400).

## Hvorfor skipper vi 0.22.0?

BFHcharts 0.22.0 introducerede step-baseret algoritme MEN bevarede force-last anchor → ujævn tail-gap. Følge-fix 0.22.1 droppede force-last for konstant rhythm. Da biSPCharts ikke havde bumpet til 0.22.0 endnu, springer vi direkte til 0.22.1's færdige adfærd uden mellemstation.

## Observable behavior-change i SPC-eksport

For kategoriske x-akser med subsampling (`bfh_subsample_label_indices()`):

| n   | før (0.21.0)               | nu (0.22.1)                                |
|-----|----------------------------|--------------------------------------------|
|  24 | 12 labels, gap 11→14 (skjulte dec25+jan26) | 8 labels, konstant step=3, sidste = "nov 26" |
|  36 | 12 labels                  | 9 labels, konstant step=4, sidste = 33     |
|  52 | 12 labels                  | 11 labels, konstant step=5, sidste = 51    |
| 100 | 12 labels                  | uændret (100 grid-aligned)                 |

**Rationale:**
- Forhindrer 2 konsekutive labels skjult midt i serien (visuel anti-pattern i 0.21.0)
- Holder konstant rytme uden tail-break (forbedring over 0.22.0's force-last anchor)
- Sidste label vises kun hvis `(n - 1) %% step == 0` (grid-aligned)

## Files

- `DESCRIPTION`: `Imports: BFHcharts (>= 0.22.1)`, `Remotes: johanreventlow/BFHcharts@v0.22.1`
- `manifest.json`: regenereret via `dev/_regen_manifest.R` (BFHcharts Version: 0.22.1, RemoteSha: efb23fb, GithubSHA1: efb23fb)
- `NEWS.md`: ny entry under `## Dependency bumps` i (development)-sektion

## Test plan

- [x] `dev/_regen_manifest.R` kørt uden fejl
- [x] Pre-push fast hook grøn: lintr OK, manifest-sync OK, hurtige regressionstests grøn (67s)
- [ ] **[MANUELT]** Visuel verifikation på Posit Connect Cloud efter deploy: SPC-eksport med 24-mdrs data viser konstant step=3-rytme uden synlige labels skjult midt i serien
- [ ] **[MANUELT]** Verificér at "dec 26" droppes som forventet for 24-mdrs serier (sidste vises = "nov 26")

## Cross-repo refs

- BFHcharts issue #396
- BFHcharts PR #397 (initial fix, merged til main som v0.22.0)
- BFHcharts PR #400 (drop force-last, merged til main som v0.22.1)
- BFHcharts tag v0.22.1: efb23fb