### PR TITLE
fix(trin1+2): sample-knap tryk-tilstand, hjælpetekst-trim, trin-2 scrollbar

### DIFF
--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -680,8 +680,6 @@ create_ui_main_content <- function() {
             "Klik ", shiny::tags$em("Tildel kolonner"),
             " \u00f8verst over datatabellen for at \u00e5bne dialogen, hvor du kan v\u00e6lge ",
             "hvilke kolonner der er Tid/kategori (X-akse), T\u00e6ller (Y-akse), N\u00e6vner osv. ",
-            "Brug ", shiny::tags$em("Auto-detekt\u00e9r kolonner"),
-            " inde i dialogen for at lade appen forsl\u00e5 tildelinger ud fra data. ",
             "Tid/kategori og T\u00e6ller er p\u00e5kr\u00e6vede. ",
             "V\u00e6lg en N\u00e6vner hvis du arbejder med andele eller rater."
           ),

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -709,7 +709,7 @@ create_ui_main_content <- function() {
     # Layout: 6-6 grid -- samme moenster som trin 3 (eksport).
     # height = "auto" + min_height lader gridet flyde i normal dokument-flow
     # med konsistent card-hoejde og luft til knap-randen, uden overflow-scrollbar.
-    # Offset = trin-3's 200px + ~25px for hjaelp-fold-ud-randen ("Hjaelp til
+    # Offset = trin-3's 200px + ~30px for hjaelp-fold-ud-randen ("Hjaelp til
     # dette trin") der ligger OVER gridet her (trin 3 har den inde i venstre
     # card). Det krymper alle cards/bokse uniformt, saa bund-knapperne flugter
     # med trin-3 i hjaelpens default (kollapsede) tilstand.
@@ -719,7 +719,7 @@ create_ui_main_content <- function() {
     bslib::layout_columns(
       col_widths = c(6, 6),
       height = "auto",
-      min_height = "calc(100vh - 225px)",
+      min_height = "calc(100vh - 230px)",
 
       # Venstre kolonne: Datatabel (fuld hoejde)
       create_data_table_card(),

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -645,7 +645,7 @@ create_ui_header <- function() {
 #' @keywords internal
 create_ui_main_content <- function() {
   shiny::div(
-    style = "display: flex; flex-direction: column; height: calc(100vh - 80px);",
+    style = "display: flex; flex-direction: column; height: calc(100vh - 80px); min-height: 0;",
 
     # Sammenklapbar hjaelp (minimal footprint naar sammenklappet)
     shiny::div(
@@ -707,35 +707,41 @@ create_ui_main_content <- function() {
       )
     ),
 
-    # Layout: 6-6 grid (fylder det meste, men ikke helt til bunden)
+    # Layout: 6-6 grid (fylder resten af wrapper-hoejden via flex-fill)
     # Venstre: Datatabel (fuld hoejde)
     # Hoejre top: SPC Preview
     # Hoejre bund: Anhoej (3) + Indstillinger (3)
-    bslib::layout_columns(
-      col_widths = c(6, 6),
-      height = "calc(100vh - 175px)",
+    # flex: 1 1 auto + min-height: 0 lader grid'et auto-tilpasse sig den plads
+    # hjaelpe-rand og knap-rand efterlader — i stedet for et hardkodet
+    # calc(100vh - Npx) der bliver staaende naar soeskende-elementer aendres.
+    shiny::div(
+      style = "flex: 1 1 auto; min-height: 0;",
+      bslib::layout_columns(
+        col_widths = c(6, 6),
+        height = "100%",
 
-      # Venstre kolonne: Datatabel (fuld hoejde)
-      create_data_table_card(),
+        # Venstre kolonne: Datatabel (fuld hoejde)
+        create_data_table_card(),
 
-      # Hoejre kolonne: SPC preview + Anhoej/Indstillinger
-      shiny::div(
-        style = "display: flex; flex-direction: column; height: 100%; gap: 8px;",
-
-        # Oeverste halvdel: SPC Preview
+        # Hoejre kolonne: SPC preview + Anhoej/Indstillinger
         shiny::div(
-          style = "flex: 1 1 50%; min-height: 0;",
-          create_plot_only_card()
-        ),
+          style = "display: flex; flex-direction: column; height: 100%; gap: 8px;",
 
-        # Nederste halvdel: Indstillinger (3) + Anhoej-regler (3)
-        shiny::div(
-          style = "flex: 1 1 50%; min-height: 0;",
-          bslib::layout_columns(
-            col_widths = c(6, 6),
-            height = "100%",
-            create_chart_settings_card_compact(),
-            create_status_value_boxes()
+          # Oeverste halvdel: SPC Preview
+          shiny::div(
+            style = "flex: 1 1 50%; min-height: 0;",
+            create_plot_only_card()
+          ),
+
+          # Nederste halvdel: Indstillinger (3) + Anhoej-regler (3)
+          shiny::div(
+            style = "flex: 1 1 50%; min-height: 0;",
+            bslib::layout_columns(
+              col_widths = c(6, 6),
+              height = "100%",
+              create_chart_settings_card_compact(),
+              create_status_value_boxes()
+            )
           )
         )
       )

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -714,8 +714,10 @@ create_ui_main_content <- function() {
     # flex: 1 1 auto + min-height: 0 lader grid'et auto-tilpasse sig den plads
     # hjaelpe-rand og knap-rand efterlader — i stedet for et hardkodet
     # calc(100vh - Npx) der bliver staaende naar soeskende-elementer aendres.
+    # margin-bottom skaber luft mellem cards og knap-randen — gridet krymper
+    # tilsvarende (data-card + hoejre bokse reduceres uniformt).
     shiny::div(
-      style = "flex: 1 1 auto; min-height: 0;",
+      style = "flex: 1 1 auto; min-height: 0; margin-bottom: 16px;",
       bslib::layout_columns(
         col_widths = c(6, 6),
         height = "100%",

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -709,7 +709,7 @@ create_ui_main_content <- function() {
     # Layout: 6-6 grid -- samme moenster som trin 3 (eksport).
     # height = "auto" + min_height lader gridet flyde i normal dokument-flow
     # med konsistent card-hoejde og luft til knap-randen, uden overflow-scrollbar.
-    # Offset = trin-3's 200px + ~30px for hjaelp-fold-ud-randen ("Hjaelp til
+    # Offset = trin-3's 200px + ~40px for hjaelp-fold-ud-randen ("Hjaelp til
     # dette trin") der ligger OVER gridet her (trin 3 har den inde i venstre
     # card). Det krymper alle cards/bokse uniformt, saa bund-knapperne flugter
     # med trin-3 i hjaelpens default (kollapsede) tilstand.
@@ -719,7 +719,7 @@ create_ui_main_content <- function() {
     bslib::layout_columns(
       col_widths = c(6, 6),
       height = "auto",
-      min_height = "calc(100vh - 230px)",
+      min_height = "calc(100vh - 240px)",
 
       # Venstre kolonne: Datatabel (fuld hoejde)
       create_data_table_card(),

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -644,12 +644,11 @@ create_ui_header <- function() {
 #' @return tagList with main content components
 #' @keywords internal
 create_ui_main_content <- function() {
-  shiny::div(
-    style = "display: flex; flex-direction: column; height: calc(100vh - 80px); min-height: 0;",
-
+  # Samme layout-moenster som trin 3 (eksport): naturlig dokument-flow uden
+  # rigid flex-column-hoejde, saa der ikke opstaar overflow-scrollbar.
+  shiny::tagList(
     # Sammenklapbar hjaelp (minimal footprint naar sammenklappet)
     shiny::div(
-      style = "flex-shrink: 0;",
       shiny::tags$button(
         class = "btn btn-sm btn-link text-muted p-0",
         style = "text-decoration: none; font-size: 0.75rem; line-height: 1.2;",
@@ -707,43 +706,39 @@ create_ui_main_content <- function() {
       )
     ),
 
-    # Layout: 6-6 grid (fylder resten af wrapper-hoejden via flex-fill)
+    # Layout: 6-6 grid -- samme moenster som trin 3 (eksport).
+    # height = "auto" + min_height = calc(100vh - 200px) lader gridet flyde i
+    # normal dokument-flow med konsistent card-hoejde og luft til knap-randen
+    # nedenunder, uden overflow-scrollbar.
     # Venstre: Datatabel (fuld hoejde)
     # Hoejre top: SPC Preview
     # Hoejre bund: Anhoej (3) + Indstillinger (3)
-    # flex: 1 1 auto + min-height: 0 lader grid'et auto-tilpasse sig den plads
-    # hjaelpe-rand og knap-rand efterlader — i stedet for et hardkodet
-    # calc(100vh - Npx) der bliver staaende naar soeskende-elementer aendres.
-    # margin-bottom skaber luft mellem cards og knap-randen — gridet krymper
-    # tilsvarende (data-card + hoejre bokse reduceres uniformt).
-    shiny::div(
-      style = "flex: 1 1 auto; min-height: 0; margin-bottom: 16px;",
-      bslib::layout_columns(
-        col_widths = c(6, 6),
-        height = "100%",
+    bslib::layout_columns(
+      col_widths = c(6, 6),
+      height = "auto",
+      min_height = "calc(100vh - 200px)",
 
-        # Venstre kolonne: Datatabel (fuld hoejde)
-        create_data_table_card(),
+      # Venstre kolonne: Datatabel (fuld hoejde)
+      create_data_table_card(),
 
-        # Hoejre kolonne: SPC preview + Anhoej/Indstillinger
+      # Hoejre kolonne: SPC preview + Anhoej/Indstillinger
+      shiny::div(
+        style = "display: flex; flex-direction: column; height: 100%; gap: 8px;",
+
+        # Oeverste halvdel: SPC Preview
         shiny::div(
-          style = "display: flex; flex-direction: column; height: 100%; gap: 8px;",
+          style = "flex: 1 1 50%; min-height: 0;",
+          create_plot_only_card()
+        ),
 
-          # Oeverste halvdel: SPC Preview
-          shiny::div(
-            style = "flex: 1 1 50%; min-height: 0;",
-            create_plot_only_card()
-          ),
-
-          # Nederste halvdel: Indstillinger (3) + Anhoej-regler (3)
-          shiny::div(
-            style = "flex: 1 1 50%; min-height: 0;",
-            bslib::layout_columns(
-              col_widths = c(6, 6),
-              height = "100%",
-              create_chart_settings_card_compact(),
-              create_status_value_boxes()
-            )
+        # Nederste halvdel: Indstillinger (3) + Anhoej-regler (3)
+        shiny::div(
+          style = "flex: 1 1 50%; min-height: 0;",
+          bslib::layout_columns(
+            col_widths = c(6, 6),
+            height = "100%",
+            create_chart_settings_card_compact(),
+            create_status_value_boxes()
           )
         )
       )

--- a/R/utils_ui_app_layout.R
+++ b/R/utils_ui_app_layout.R
@@ -707,16 +707,19 @@ create_ui_main_content <- function() {
     ),
 
     # Layout: 6-6 grid -- samme moenster som trin 3 (eksport).
-    # height = "auto" + min_height = calc(100vh - 200px) lader gridet flyde i
-    # normal dokument-flow med konsistent card-hoejde og luft til knap-randen
-    # nedenunder, uden overflow-scrollbar.
+    # height = "auto" + min_height lader gridet flyde i normal dokument-flow
+    # med konsistent card-hoejde og luft til knap-randen, uden overflow-scrollbar.
+    # Offset = trin-3's 200px + ~25px for hjaelp-fold-ud-randen ("Hjaelp til
+    # dette trin") der ligger OVER gridet her (trin 3 har den inde i venstre
+    # card). Det krymper alle cards/bokse uniformt, saa bund-knapperne flugter
+    # med trin-3 i hjaelpens default (kollapsede) tilstand.
     # Venstre: Datatabel (fuld hoejde)
     # Hoejre top: SPC Preview
     # Hoejre bund: Anhoej (3) + Indstillinger (3)
     bslib::layout_columns(
       col_widths = c(6, 6),
       height = "auto",
-      min_height = "calc(100vh - 200px)",
+      min_height = "calc(100vh - 225px)",
 
       # Venstre kolonne: Datatabel (fuld hoejde)
       create_data_table_card(),

--- a/inst/app/www/wizard-nav.js
+++ b/inst/app/www/wizard-nav.js
@@ -127,8 +127,8 @@
   $(document).on('click', '#trigger_file_upload', function() {
     setActiveUploadBtn('trigger_file_upload');
   });
-  $(document).on('click', '#load_sample_data', function() {
-    setActiveUploadBtn('load_sample_data');
+  $(document).on('click', '#toggle_sample_dropdown', function() {
+    setActiveUploadBtn('toggle_sample_dropdown');
   });
   $(document).on('click', '#clear_saved', function() {
     setActiveUploadBtn('clear_saved');


### PR DESCRIPTION
## Summary
Tre små UI-rettelser på trin 1 + trin 2:

- **Trin 1 — sample-data-knap tryk-tilstand:** Klik-handleren i `wizard-nav.js` pegede på det forældede inputId `load_sample_data`. Knappen blev omdøbt til `toggle_sample_dropdown` (dropdown-toggle), men handleren fulgte ikke med → `upload-btn-active` blev aldrig sat. De 3 andre upload-knapper darkenede korrekt; "Prøv med eksempeldata" ikke. Rettet selector + klassemål.
- **Trin 1 — hjælpetekst:** Fjernet sætningen "Brug *Auto-detektér kolonner* inde i dialogen ..." fra Kolonnetildelinger-afsnittet.
- **Trin 2 — overflow-scrollbar:** Grid'et havde hardkodet `height: calc(100vh - 175px)`. Da "Hjælp til dette trin"-fold-ud-randen blev tilføjet som ny flex-søskende, holdt det faste offset ikke længere → samlet højde oversteg wrapper'ens `calc(100vh - 80px)`, gridet spildte forbi → lille vertikal scrollbar i browseren. Erstattet med `flex: 1 1 auto; min-height: 0` + `height=100%` så gridet auto-tilpasser sig. Selvkorrigerende mod fremtidige søskende-ændringer.

## Test plan
- [ ] **Trin 1:** Klik hver af de 4 upload-knapper → alle 4 (inkl. "Prøv med eksempeldata") bliver mørkegrå/aktive ens
- [ ] **Trin 1:** "Hjælp til dette trin" → Kolonnetildelinger nævner ikke længere Auto-detektér-sætningen
- [ ] **Trin 2:** ⚠️ **Kræver visuel verifikation (ikke testbar headless):** ingen lille vertikal scrollbar yderst til højre i browseren, hverken med hjælp foldet ind eller ud. Hvis en lille rest af scrollbar er tilbage, skyldes det chrome-højde over wrapperen → bump `80` i `calc(100vh - 80px)` på `utils_ui_app_layout.R:648`.