### PR TITLE
chore(deploy): regenerér manifest.json for Connect Cloud

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.22.1),
+    BFHcharts (>= 0.23.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -65,7 +65,7 @@ Suggests:
     curl (>= 4.3.0),
     BFHllm (>= 0.2.0),
     BFHchartsAssets (>= 0.1.2),
-    BFHtheme (>= 0.5.1),
+    BFHtheme (>= 0.5.2),
     pins (>= 1.2.0),
     gert (>= 1.9.0),
     shinylogs (>= 0.2.0),
@@ -78,8 +78,8 @@ Suggests:
     pkgload (>= 1.3.0)
 Config/testthat/edition: 3
 Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.22.1,
-    johanreventlow/BFHtheme@v0.5.1,
+Remotes: johanreventlow/BFHcharts@v0.23.0,
+    johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2
 Config/roxygen2/version: 8.0.0

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "locale": "da_DK",
-  "platform": "4.5.2",
+  "platform": "4.6.0",
   "metadata": {
     "appmode": "shiny",
     "primary_rmd": null,
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.22.1",
+        "Version": "0.23.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -41,17 +41,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.22.1",
-        "RemoteSha": "efb23fb120bd930c52804d0c693f49c83434342d",
+        "RemoteRef": "v0.23.0",
+        "RemoteSha": "1e9a825d34b33506b938d27a53ee1b63e33c8c73",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.22.1",
-        "GithubSHA1": "efb23fb120bd930c52804d0c693f49c83434342d",
+        "GithubRef": "v0.23.0",
+        "GithubSHA1": "1e9a825d34b33506b938d27a53ee1b63e33c8c73",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-29 05:48:34 UTC; johanreventlow",
+        "Packaged": "2026-05-30 09:23:14 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-29 05:48:35 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-30 09:23:14 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -81,10 +81,10 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-28 16:19:51 UTC; johanreventlow",
+        "Packaged": "2026-05-30 09:24:16 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-28 16:19:52 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-30 09:24:17 UTC; unix"
       }
     },
     "BFHllm": {
@@ -117,10 +117,10 @@
         "GithubRef": "v0.2.0",
         "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-28 16:19:43 UTC; johanreventlow",
+        "Packaged": "2026-05-30 09:23:40 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-28 16:19:44 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-30 09:23:41 UTC; unix"
       }
     },
     "BFHtheme": {
@@ -130,7 +130,7 @@
         "Package": "BFHtheme",
         "Type": "Package",
         "Title": "BFH Theme and Color Palettes for ggplot2",
-        "Version": "0.5.1",
+        "Version": "0.5.2",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "Provides comprehensive theming support for ggplot2 graphics\n    following Bispebjerg og Frederiksberg Hospital and Region Hovedstaden\n    visual identity guidelines. Includes color palettes for both Hospital\n    and Region H branding, themes, scale functions, and helper utilities\n    for creating consistent and professional visualizations. Uses modern\n    'systemfonts' package for robust font detection with graceful fallback.\n    Recommends 'ragg', 'svglite', and Cairo devices for high-quality output.",
         "License": "MIT + file LICENSE",
@@ -145,17 +145,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHtheme",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.5.1",
-        "RemoteSha": "c70eab872e9418df32ddc68d15efc79e0c97f9bf",
+        "RemoteRef": "v0.5.2",
+        "RemoteSha": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
         "GithubRepo": "BFHtheme",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.5.1",
-        "GithubSHA1": "c70eab872e9418df32ddc68d15efc79e0c97f9bf",
+        "GithubRef": "v0.5.2",
+        "GithubSHA1": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-28 16:20:30 UTC; johanreventlow",
+        "Packaged": "2026-05-30 09:44:58 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.5.2; ; 2026-05-28 16:20:31 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-30 09:44:58 UTC; unix"
       }
     },
     "BH": {
@@ -178,7 +178,7 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-14 10:20:02 UTC",
-        "Built": "R 4.5.2; ; 2025-12-14 13:06:09 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:48:04 UTC; unix"
       }
     },
     "DBI": {
@@ -210,13 +210,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-25 06:31:27 UTC",
-        "Built": "R 4.5.2; ; 2026-02-25 09:45:39 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "DBI",
-        "RemoteRef": "DBI",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.3.0"
+        "Built": "R 4.6.0; ; 2026-04-25 15:47:33 UTC; unix"
       }
     },
     "Matrix": {
@@ -249,13 +243,7 @@
         "Maintainer": "Martin Maechler <mmaechler+Matrix@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-21 14:40:03 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-22 20:58:55 UTC; unix",
-        "Archs": "Matrix.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "Matrix",
-        "RemoteRef": "Matrix",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.7-5"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 08:58:56 UTC; unix"
       }
     },
     "R6": {
@@ -282,13 +270,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-02-15 00:50:02 UTC",
-        "Built": "R 4.5.0; ; 2025-02-15 01:07:20 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "R6",
-        "RemoteRef": "R6",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.6.1"
+        "Built": "R 4.6.0; ; 2026-04-25 15:39:09 UTC; unix"
       }
     },
     "RColorBrewer": {
@@ -309,13 +291,7 @@
         "NeedsCompilation": "no",
         "Repository": "CRAN",
         "Date/Publication": "2022-04-03 19:20:13 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:42:41 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "RColorBrewer",
-        "RemoteRef": "RColorBrewer",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.1-3"
+        "Built": "R 4.6.0; ; 2026-04-25 15:40:08 UTC; unix"
       }
     },
     "Rcpp": {
@@ -344,13 +320,8 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-24 05:30:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-24 13:22:07 UTC; unix",
-        "Archs": "Rcpp.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "Rcpp",
-        "RemoteRef": "Rcpp",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.1.1-1.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:45 UTC; unix",
+        "Archs": "Rcpp.so.dSYM"
       }
     },
     "RcppCCTZ": {
@@ -378,13 +349,8 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-08 16:20:21 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-08 16:53:38 UTC; unix",
-        "Archs": "RcppCCTZ.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "RcppCCTZ",
-        "RemoteRef": "RcppCCTZ",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.2.14"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:37:01 UTC; unix",
+        "Archs": "RcppCCTZ.so.dSYM"
       }
     },
     "RcppDate": {
@@ -408,7 +374,7 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-29 14:50:09 UTC",
-        "Built": "R 4.5.0; ; 2025-05-29 15:28:12 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 16:37:02 UTC; unix"
       }
     },
     "RcppTOML": {
@@ -436,14 +402,8 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-08 14:30:06 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 22:01:30 UTC; unix",
-        "Archs": "RcppTOML.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "RcppTOML",
-        "RemoteRef": "RcppTOML",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.2.3"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:50:47 UTC; unix",
+        "Archs": "RcppTOML.so.dSYM"
       }
     },
     "S7": {
@@ -475,7 +435,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 11:00:10 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-22 14:36:04 UTC; unix",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:28:03 UTC; unix",
         "Archs": "S7.so.dSYM"
       }
     },
@@ -506,13 +466,8 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-14 12:30:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 04:52:38 UTC; unix",
-        "Archs": "anytime.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "anytime",
-        "RemoteRef": "anytime",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.3.13"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:05:26 UTC; unix",
+        "Archs": "anytime.so.dSYM"
       }
     },
     "askpass": {
@@ -539,14 +494,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-04 07:20:03 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-04-01 06:33:14 UTC; unix",
-        "Archs": "askpass.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "askpass",
-        "RemoteRef": "askpass",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:17:34 UTC; unix",
+        "Archs": "askpass.so.dSYM"
       }
     },
     "attempt": {
@@ -572,7 +521,7 @@
         "Maintainer": "Colin Fay <contact@colinfay.me>",
         "Repository": "CRAN",
         "Date/Publication": "2020-05-03 20:50:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 22:03:58 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:49:28 UTC; unix"
       }
     },
     "base64enc": {
@@ -595,14 +544,8 @@
         "Packaged": "2026-02-02 01:51:07 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-02 06:31:10 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-02-02 07:45:38 UTC; unix",
-        "Archs": "base64enc.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "base64enc",
-        "RemoteRef": "base64enc",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.1-6"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:42 UTC; unix",
+        "Archs": "base64enc.so.dSYM"
       }
     },
     "bit": {
@@ -630,7 +573,7 @@
         "Maintainer": "Michael Chirico <MichaelChirico4@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-06 10:50:01 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:46:07 UTC; unix",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:45:18 UTC; unix",
         "Archs": "bit.so.dSYM"
       }
     },
@@ -640,7 +583,7 @@
       "description": {
         "Package": "bit64",
         "Title": "A S3 Class for Vectors of 64bit Integers",
-        "Version": "4.8.0",
+        "Version": "4.8.2",
         "Authors@R": "c(\n    person(\"Michael\", \"Chirico\", email=\"michaelchirico4@gmail.com\", role=c(\"aut\", \"cre\")),\n    person(\"Jens\", \"Oehlschlägel\", role=\"aut\"),\n    person(\"Leonardo\", \"Silvestri\", role=\"ctb\"),\n    person(\"Ofek\", \"Shilon\", role=\"ctb\"),\n    person(\"Christian\", \"Ullerich\", role=\"ctb\")\n  )",
         "Depends": "R (>= 3.5.0)",
         "Description": "\n  Package 'bit64' provides serializable S3 atomic 64bit (signed) integers.\n  These are useful for handling database keys and exact counting in +-2^63.\n  WARNING: do not use them as replacement for 32bit integers, integer64 are not\n  supported for subscripting by R-core and they have different semantics when\n  combined with double, e.g. integer64 + double => integer64.\n  Class integer64 can be used in vectors, matrices, arrays and data.frames.\n  Methods are available for coercion from and to logicals, integers, doubles,\n  characters and factors as well as many elementwise and summary functions.\n  Many fast algorithmic operations such as 'match' and 'order' support inter-\n  active data exploration and manipulation and optionally leverage caching.",
@@ -656,18 +599,13 @@
         "Config/Needs/website": "tidyverse/tidytemplate",
         "RoxygenNote": "7.3.3",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-20 06:52:55 UTC; michael",
+        "Packaged": "2026-05-19 05:37:05 UTC; chiricom",
         "Author": "Michael Chirico [aut, cre],\n  Jens Oehlschlägel [aut],\n  Leonardo Silvestri [ctb],\n  Ofek Shilon [ctb],\n  Christian Ullerich [ctb]",
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-21 06:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-21 19:11:49 UTC; unix",
-        "Archs": "bit64.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "bit64",
-        "RemoteRef": "bit64",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "4.8.0"
+        "Date/Publication": "2026-05-19 09:40:02 UTC",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-19 11:15:45 UTC; unix",
+        "Archs": "bit64.so.dSYM"
       }
     },
     "blob": {
@@ -696,13 +634,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-14 09:10:14 UTC",
-        "Built": "R 4.5.2; ; 2026-01-14 11:24:11 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "blob",
-        "RemoteRef": "blob",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.3.0"
+        "Built": "R 4.6.0; ; 2026-04-25 23:18:16 UTC; unix"
       }
     },
     "bslib": {
@@ -711,7 +643,7 @@
       "description": {
         "Package": "bslib",
         "Title": "Custom 'Bootstrap' 'Sass' Themes for 'shiny' and 'rmarkdown'",
-        "Version": "0.10.0",
+        "Version": "0.11.0",
         "Authors@R": "c(\n    person(\"Carson\", \"Sievert\", , \"carson@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-4958-2844\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(, \"Bootstrap contributors\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Twitter, Inc\", role = \"cph\",\n           comment = \"Bootstrap library\"),\n    person(\"Javi\", \"Aguilar\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap colorpicker library\"),\n    person(\"Thomas\", \"Park\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootswatch library\"),\n    person(, \"PayPal\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap accessibility plugin\")\n  )",
         "Description": "Simplifies custom 'CSS' styling of both 'shiny' and\n    'rmarkdown' via 'Bootstrap' 'Sass'. Supports 'Bootstrap' 3, 4 and 5 as\n    well as their various 'Bootswatch' themes. An interactive widget is\n    also provided for previewing themes in real time.",
         "License": "MIT + file LICENSE",
@@ -719,29 +651,23 @@
         "BugReports": "https://github.com/rstudio/bslib/issues",
         "Depends": "R (>= 2.10)",
         "Imports": "base64enc, cachem, fastmap (>= 1.1.1), grDevices, htmltools\n(>= 0.5.8), jquerylib (>= 0.1.3), jsonlite, lifecycle, memoise\n(>= 2.0.1), mime, rlang, sass (>= 0.4.9)",
-        "Suggests": "brand.yml, bsicons, curl, fontawesome, future, ggplot2,\nknitr, lattice, magrittr, rappdirs, rmarkdown (>= 2.7), shiny\n(>= 1.11.1), testthat, thematic, tools, utils, withr, yaml",
+        "Suggests": "brand.yml, bsicons, curl, fontawesome, future, ggplot2,\nknitr, lattice, magrittr, rappdirs, rmarkdown (>= 2.7), shiny\n(>= 1.11.1.9000), testthat, thematic, tools, utils, withr, yaml",
         "Config/Needs/deploy": "BH, chiflights22, colourpicker, commonmark, cpp11,\ncpsievert/chiflights22, cpsievert/histoslider, dplyr, DT,\nggplot2, ggridges, gt, hexbin, histoslider, htmlwidgets,\nlattice, leaflet, lubridate, markdown, modelr, plotly,\nreactable, reshape2, rprojroot, rsconnect, rstudio/shiny,\nscales, styler, tibble",
         "Config/Needs/routine": "chromote, desc, renv",
         "Config/Needs/website": "brio, crosstalk, dplyr, DT, ggplot2, glue,\nhtmlwidgets, leaflet, lorem, palmerpenguins, plotly, purrr,\nrprojroot, rstudio/htmltools, scales, stringr, tidyr, webshot2",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Config/testthat/parallel": "true",
         "Config/testthat/start-first": "zzzz-bs-sass, fonts, zzz-precompile,\ntheme-*, rmd-*",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R'\n'bs-dependencies.R' 'bs-global.R' 'bs-remove.R'\n'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R'\n'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R'\n'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R'\n'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R'\n'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R'\n'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R'\n'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R'\n'navbar_options.R' 'navs-legacy.R' 'navs.R' 'onLoad.R' 'page.R'\n'popover.R' 'precompiled.R' 'print.R' 'shiny-devmode.R'\n'sidebar.R' 'staticimports.R' 'toast.R' 'tooltip.R'\n'utils-deps.R' 'utils-shiny.R' 'utils-tags.R' 'value-box.R'\n'version-default.R' 'versions.R'",
+        "Collate": "'accordion.R' 'breakpoints.R' 'bs-current-theme.R'\n'bs-dependencies.R' 'bs-global.R' 'bs-remove.R'\n'bs-theme-layers.R' 'bs-theme-preset-bootswatch.R'\n'bs-theme-preset-brand.R' 'bs-theme-preset-builtin.R'\n'bs-theme-preset.R' 'utils.R' 'bs-theme-preview.R'\n'bs-theme-update.R' 'bs-theme.R' 'bslib-package.R' 'buttons.R'\n'card.R' 'deprecated.R' 'files.R' 'fill.R' 'imports.R'\n'input-code-editor.R' 'input-dark-mode.R' 'input-submit.R'\n'input-switch.R' 'layout.R' 'nav-items.R' 'nav-update.R'\n'navbar_options.R' 'navs-legacy.R' 'navs.R' 'onLoad.R' 'page.R'\n'popover.R' 'precompiled.R' 'print.R' 'shiny-devmode.R'\n'sidebar.R' 'staticimports.R' 'toast.R' 'toolbar.R' 'tooltip.R'\n'utils-deps.R' 'utils-shiny.R' 'utils-tags.R' 'value-box.R'\n'version-default.R' 'versions.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2026-01-22 00:32:06 UTC; garrick",
+        "Packaged": "2026-05-15 15:16:19 UTC; cpsievert",
         "Author": "Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Joe Cheng [aut],\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Posit Software, PBC [cph, fnd],\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Javi Aguilar [ctb, cph] (Bootstrap colorpicker library),\n  Thomas Park [ctb, cph] (Bootswatch library),\n  PayPal [ctb, cph] (Bootstrap accessibility plugin)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-01-26 08:10:02 UTC",
-        "Built": "R 4.5.2; ; 2026-01-26 12:05:36 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "bslib",
-        "RemoteRef": "bslib",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.10.0"
+        "Date/Publication": "2026-05-16 08:10:07 UTC",
+        "Built": "R 4.6.0; ; 2026-05-16 12:36:52 UTC; unix"
       }
     },
     "cachem": {
@@ -768,14 +694,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-16 09:50:11 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:43:44 UTC; unix",
-        "Archs": "cachem.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "cachem",
-        "RemoteRef": "cachem",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.1.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:13:45 UTC; unix",
+        "Archs": "cachem.so.dSYM"
       }
     },
     "callr": {
@@ -804,13 +724,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 11:57:59 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "callr",
-        "RemoteRef": "callr",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "3.7.6"
+        "Built": "R 4.6.0; ; 2026-04-26 02:21:34 UTC; unix"
       }
     },
     "cellranger": {
@@ -837,7 +751,7 @@
         "Maintainer": "Jennifer Bryan <jenny@stat.ubc.ca>",
         "Repository": "CRAN",
         "Date/Publication": "2016-07-27 03:17:48",
-        "Built": "R 4.5.0; ; 2025-04-01 20:32:15 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 05:17:23 UTC; unix"
       }
     },
     "cli": {
@@ -866,14 +780,8 @@
         "Maintainer": "Gábor Csárdi <gabor@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-09 09:50:18 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 04:52:40 UTC; unix",
-        "Archs": "cli.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "cli",
-        "RemoteRef": "cli",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "3.6.6"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:10 UTC; unix",
+        "Archs": "cli.so.dSYM"
       }
     },
     "clipr": {
@@ -883,7 +791,7 @@
         "Type": "Package",
         "Package": "clipr",
         "Title": "Read and Write from the System Clipboard",
-        "Version": "0.8.0",
+        "Version": "0.8.1",
         "Authors@R": "c(\n    person(\"Matthew\", \"Lincoln\", , \"matthew.d.lincoln@gmail.com\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-4387-3384\")),\n    person(\"Louis\", \"Maddox\", role = \"ctb\"),\n    person(\"Steve\", \"Simpson\", role = \"ctb\"),\n    person(\"Jennifer\", \"Bryan\", role = \"ctb\")\n  )",
         "Description": "Simple utility functions to read from and write to\n    the Windows, OS X, and X11 clipboards.",
         "License": "GPL-3",
@@ -894,15 +802,15 @@
         "VignetteBuilder": "knitr",
         "Encoding": "UTF-8",
         "Language": "en-US",
-        "RoxygenNote": "7.1.2",
+        "RoxygenNote": "7.3.3",
         "SystemRequirements": "xclip (https://github.com/astrand/xclip) or xsel\n(http://www.vergenet.net/~conrad/software/xsel/) for accessing\nthe X11 clipboard, or wl-clipboard\n(https://github.com/bugaevc/wl-clipboard) for systems using\nWayland.",
         "NeedsCompilation": "no",
-        "Packaged": "2022-02-19 02:20:21 UTC; mlincoln",
-        "Author": "Matthew Lincoln [aut, cre] (<https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
+        "Packaged": "2026-05-25 05:04:26 UTC; mlincoln",
+        "Author": "Matthew Lincoln [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4387-3384>),\n  Louis Maddox [ctb],\n  Steve Simpson [ctb],\n  Jennifer Bryan [ctb]",
         "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2022-02-22 00:58:45 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:44:12 UTC; unix"
+        "Date/Publication": "2026-05-25 05:50:02 UTC",
+        "Built": "R 4.6.0; ; 2026-05-25 08:30:02 UTC; unix"
       }
     },
     "commonmark": {
@@ -928,14 +836,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-07-07 13:40:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-07-07 15:18:49 UTC; unix",
-        "Archs": "commonmark.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "commonmark",
-        "RemoteRef": "commonmark",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.0.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:27:57 UTC; unix",
+        "Archs": "commonmark.so.dSYM"
       }
     },
     "config": {
@@ -964,7 +866,7 @@
         "Maintainer": "Andrie de Vries <apdevries@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-30 16:50:36 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 22:03:58 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:49:14 UTC; unix"
       }
     },
     "coro": {
@@ -993,13 +895,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-11-05 10:30:09 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 23:27:56 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "coro",
-        "RemoteRef": "coro",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.1.0"
+        "Built": "R 4.6.0; ; 2026-04-25 17:06:36 UTC; unix"
       }
     },
     "cpp11": {
@@ -1028,12 +924,7 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-06 14:40:12 UTC",
-        "Built": "R 4.5.2; ; 2026-05-06 16:24:00 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "cpp11",
-        "RemoteRef": "cpp11",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.5.5"
+        "Built": "R 4.6.0; ; 2026-05-06 16:42:29 UTC; unix"
       }
     },
     "crayon": {
@@ -1060,7 +951,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-06-20 13:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:43:26 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:44:21 UTC; unix"
       }
     },
     "credentials": {
@@ -1089,7 +980,7 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-12 09:30:08 UTC",
-        "Built": "R 4.5.0; ; 2025-09-12 12:25:16 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 05:16:31 UTC; unix"
       }
     },
     "curl": {
@@ -1118,13 +1009,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:40:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-22 14:37:31 UTC; unix",
-        "Archs": "curl.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "curl",
-        "RemoteRef": "curl",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "7.1.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:29:32 UTC; unix",
+        "Archs": "curl.so.dSYM"
       }
     },
     "data.table": {
@@ -1151,13 +1037,8 @@
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-06 05:10:20 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-05-06 06:39:38 UTC; unix",
-        "Archs": "data_table.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "data.table",
-        "RemoteRef": "data.table",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.18.4"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-06 07:00:46 UTC; unix",
+        "Archs": "data_table.so.dSYM"
       }
     },
     "dbplyr": {
@@ -1190,13 +1071,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-13 07:01:08 UTC",
-        "Built": "R 4.5.2; ; 2026-02-13 08:21:59 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "dbplyr",
-        "RemoteRef": "dbplyr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.5.2"
+        "Built": "R 4.6.0; ; 2026-04-26 15:54:24 UTC; unix"
       }
     },
     "desc": {
@@ -1226,13 +1101,7 @@
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:55:26 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "desc",
-        "RemoteRef": "desc",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.3"
+        "Built": "R 4.6.0; ; 2026-04-25 15:48:08 UTC; unix"
       }
     },
     "digest": {
@@ -1259,14 +1128,8 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-19 13:20:08 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-11-22 19:17:48 UTC; unix",
-        "Archs": "digest.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "digest",
-        "RemoteRef": "digest",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.6.39"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:59 UTC; unix",
+        "Archs": "digest.so.dSYM"
       }
     },
     "dplyr": {
@@ -1298,14 +1161,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-03 07:30:08 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-03 11:02:49 UTC; unix",
-        "Archs": "dplyr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "dplyr",
-        "RemoteRef": "dplyr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:09:07 UTC; unix",
+        "Archs": "dplyr.so.dSYM"
       }
     },
     "duckdb": {
@@ -1340,13 +1197,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-13 19:20:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 04:56:09 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "duckdb",
-        "RemoteRef": "duckdb",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.5.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:26:08 UTC; unix"
       }
     },
     "ellmer": {
@@ -1378,12 +1229,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-07 10:40:02 UTC",
-        "Built": "R 4.5.2; ; 2026-05-07 11:22:35 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "ellmer",
-        "RemoteRef": "ellmer",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.4.1"
+        "Built": "R 4.6.0; ; 2026-05-07 11:41:36 UTC; unix"
       }
     },
     "evaluate": {
@@ -1411,13 +1257,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-27 16:40:02 UTC",
-        "Built": "R 4.5.0; ; 2025-09-01 01:31:01 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "evaluate",
-        "RemoteRef": "evaluate",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.0.5"
+        "Built": "R 4.6.0; ; 2026-04-25 15:39:47 UTC; unix"
       }
     },
     "excelR": {
@@ -1444,7 +1284,7 @@
         "Author": "Swechhya Bista [aut, cre],\n  Kent Russell [ctb],\n  Mārcis Bratka [ctb]",
         "Repository": "CRAN",
         "Date/Publication": "2020-03-09 13:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-02 02:47:01 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 18:06:54 UTC; unix"
       }
     },
     "farver": {
@@ -1470,14 +1310,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-13 09:33:09 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:42:31 UTC; unix",
-        "Archs": "farver.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "farver",
-        "RemoteRef": "farver",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.1.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:40:10 UTC; unix",
+        "Archs": "farver.so.dSYM"
       }
     },
     "fastmap": {
@@ -1501,14 +1335,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-15 09:00:07 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:43:00 UTC; unix",
-        "Archs": "fastmap.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "fastmap",
-        "RemoteRef": "fastmap",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:44 UTC; unix",
+        "Archs": "fastmap.so.dSYM"
       }
     },
     "fontawesome": {
@@ -1537,13 +1365,7 @@
         "Maintainer": "Richard Iannone <rich@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-11-16 17:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 11:50:29 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "fontawesome",
-        "RemoteRef": "fontawesome",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.5.3"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:26 UTC; unix"
       }
     },
     "fs": {
@@ -1576,13 +1398,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-18 15:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-20 23:19:48 UTC; unix",
-        "Archs": "fs.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "fs",
-        "RemoteRef": "fs",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "2.1.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:15 UTC; unix",
+        "Archs": "fs.so.dSYM"
       }
     },
     "generics": {
@@ -1610,13 +1427,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-09 23:50:06 UTC",
-        "Built": "R 4.5.0; ; 2025-05-10 00:42:34 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "generics",
-        "RemoteRef": "generics",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.1.4"
+        "Built": "R 4.6.0; ; 2026-04-25 15:40:57 UTC; unix"
       }
     },
     "gert": {
@@ -1645,13 +1456,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-11 23:50:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-12 01:45:25 UTC; unix",
-        "Archs": "gert.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "gert",
-        "RemoteRef": "gert",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "2.3.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:10:56 UTC; unix",
+        "Archs": "gert.so.dSYM"
       }
     },
     "ggplot2": {
@@ -1684,7 +1490,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:10:03 UTC",
-        "Built": "R 4.5.2; ; 2026-04-22 09:41:08 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 05:16:05 UTC; unix"
       }
     },
     "glue": {
@@ -1715,7 +1521,7 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-17 05:11:01 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-20 23:19:49 UTC; unix",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:32 UTC; unix",
         "Archs": "glue.so.dSYM"
       }
     },
@@ -1746,7 +1552,7 @@
         "Maintainer": "Colin Fay <contact@colinfay.me>",
         "Repository": "CRAN",
         "Date/Publication": "2024-08-27 10:50:32 UTC",
-        "Built": "R 4.5.0; ; 2025-01-26 09:15:48 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 11:11:17 UTC; unix"
       }
     },
     "gridExtra": {
@@ -1770,13 +1576,7 @@
         "Maintainer": "Baptiste Auguie <baptiste.auguie@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2017-09-09 14:12:08 UTC",
-        "Built": "R 4.5.0; ; 2025-01-26 09:04:20 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "gridExtra",
-        "RemoteRef": "gridExtra",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.3"
+        "Built": "R 4.6.0; ; 2026-04-25 11:14:31 UTC; unix"
       }
     },
     "gtable": {
@@ -1806,13 +1606,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-25 13:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 11:49:51 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "gtable",
-        "RemoteRef": "gtable",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.3.6"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:41 UTC; unix"
       }
     },
     "here": {
@@ -1841,13 +1635,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-15 05:10:09 UTC",
-        "Built": "R 4.5.0; ; 2025-09-15 07:48:10 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "here",
-        "RemoteRef": "here",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.0.2"
+        "Built": "R 4.6.0; ; 2026-04-25 15:50:06 UTC; unix"
       }
     },
     "highr": {
@@ -1875,13 +1663,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-06 06:30:47 UTC",
-        "Built": "R 4.5.2; ; 2026-03-06 09:27:47 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "highr",
-        "RemoteRef": "highr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.12"
+        "Built": "R 4.6.0; ; 2026-04-25 23:14:12 UTC; unix"
       }
     },
     "hms": {
@@ -1909,12 +1691,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-17 05:10:11 UTC",
-        "Built": "R 4.5.0; ; 2025-10-17 06:30:49 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "hms",
-        "RemoteRef": "hms",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.1.4"
+        "Built": "R 4.6.0; ; 2026-04-25 23:15:47 UTC; unix"
       }
     },
     "htmltools": {
@@ -1945,14 +1722,8 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-04 11:50:09 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-12-04 12:12:04 UTC; unix",
-        "Archs": "htmltools.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "htmltools",
-        "RemoteRef": "htmltools",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.5.9"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:13:58 UTC; unix",
+        "Archs": "htmltools.so.dSYM"
       }
     },
     "htmlwidgets": {
@@ -1980,13 +1751,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 23:26:28 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "htmlwidgets",
-        "RemoteRef": "htmlwidgets",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.6.4"
+        "Built": "R 4.6.0; ; 2026-04-26 15:49:50 UTC; unix"
       }
     },
     "httpuv": {
@@ -2019,13 +1784,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-18 06:12:59 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-22 21:00:02 UTC; unix",
-        "Archs": "httpuv.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "httpuv",
-        "RemoteRef": "httpuv",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.6.17"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 05:14:15 UTC; unix",
+        "Archs": "httpuv.so.dSYM"
       }
     },
     "httr": {
@@ -2053,13 +1813,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-13 16:20:15 UTC",
-        "Built": "R 4.5.2; ; 2026-02-13 18:18:17 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "httr",
-        "RemoteRef": "httr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.8"
+        "Built": "R 4.6.0; ; 2026-04-26 05:16:18 UTC; unix"
       }
     },
     "httr2": {
@@ -2090,13 +1844,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-08 09:50:02 UTC",
-        "Built": "R 4.5.2; ; 2025-12-08 13:14:23 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "httr2",
-        "RemoteRef": "httr2",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.2"
+        "Built": "R 4.6.0; ; 2026-04-26 05:17:04 UTC; unix"
       }
     },
     "isoband": {
@@ -2127,14 +1875,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-07 06:10:07 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-12-07 07:05:55 UTC; unix",
-        "Archs": "isoband.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "isoband",
-        "RemoteRef": "isoband",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.3.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:14:25 UTC; unix",
+        "Archs": "isoband.so.dSYM"
       }
     },
     "jpeg": {
@@ -2157,14 +1899,8 @@
         "Packaged": "2025-03-21 03:05:05 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-21 15:37:18 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 22:03:54 UTC; unix",
-        "Archs": "jpeg.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "jpeg",
-        "RemoteRef": "jpeg",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.1-11"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:57:32 UTC; unix",
+        "Archs": "jpeg.so.dSYM"
       }
     },
     "jquerylib": {
@@ -2188,13 +1924,7 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 11:50:17 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "jquerylib",
-        "RemoteRef": "jquerylib",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.1.4"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:12 UTC; unix"
       }
     },
     "jsonlite": {
@@ -2220,14 +1950,8 @@
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 06:40:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-27 07:33:55 UTC; unix",
-        "Archs": "jsonlite.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "jsonlite",
-        "RemoteRef": "jsonlite",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.0.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:00 UTC; unix",
+        "Archs": "jsonlite.so.dSYM"
       }
     },
     "knitr": {
@@ -2257,13 +1981,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-20 14:30:02 UTC",
-        "Built": "R 4.5.2; ; 2025-12-21 22:52:57 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "knitr",
-        "RemoteRef": "knitr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.51"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:51 UTC; unix"
       }
     },
     "labeling": {
@@ -2285,13 +2003,7 @@
         "Packaged": "2023-08-29 21:01:57 UTC; loki",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-29 22:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:42:34 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "labeling",
-        "RemoteRef": "labeling",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.4.3"
+        "Built": "R 4.6.0; ; 2026-04-25 15:40:07 UTC; unix"
       }
     },
     "later": {
@@ -2324,14 +2036,8 @@
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-05 07:50:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-05 08:43:57 UTC; unix",
-        "Archs": "later.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "later",
-        "RemoteRef": "later",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.8"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:14:28 UTC; unix",
+        "Archs": "later.so.dSYM"
       }
     },
     "lattice": {
@@ -2360,13 +2066,7 @@
         "Maintainer": "Deepayan Sarkar <deepayan.sarkar@r-project.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-09 06:10:13 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-02-09 06:53:38 UTC; unix",
-        "Archs": "lattice.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lattice",
-        "RemoteRef": "lattice",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.22-9"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 08:58:51 UTC; unix"
       }
     },
     "lemon": {
@@ -2395,13 +2095,7 @@
         "Maintainer": "Stefan McKinnon Edwards <sme@iysik.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-04 11:50:02 UTC",
-        "Built": "R 4.5.0; ; 2025-09-05 05:48:15 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lemon",
-        "RemoteRef": "lemon",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.5.2"
+        "Built": "R 4.6.0; ; 2026-04-26 06:54:00 UTC; unix"
       }
     },
     "lifecycle": {
@@ -2430,13 +2124,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-08 08:00:02 UTC",
-        "Built": "R 4.5.2; ; 2026-01-08 12:03:10 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lifecycle",
-        "RemoteRef": "lifecycle",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.0.5"
+        "Built": "R 4.6.0; ; 2026-04-25 10:32:18 UTC; unix"
       }
     },
     "lubridate": {
@@ -2470,14 +2158,8 @@
         "Author": "Vitalie Spinu [aut, cre],\n  Garrett Grolemund [aut],\n  Hadley Wickham [aut],\n  Davis Vaughan [ctb],\n  Ian Lyttle [ctb],\n  Imanuel Costigan [ctb],\n  Jason Law [ctb],\n  Doug Mitarotonda [ctb],\n  Joseph Larmarange [ctb],\n  Jonathan Boiser [ctb],\n  Chel Hee Lee [ctb]",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-04 09:00:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-02-07 09:09:08 UTC; unix",
-        "Archs": "lubridate.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "lubridate",
-        "RemoteRef": "lubridate",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.9.5"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:16:04 UTC; unix",
+        "Archs": "lubridate.so.dSYM"
       }
     },
     "magrittr": {
@@ -2506,14 +2188,8 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-04 08:00:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-04 10:13:02 UTC; unix",
-        "Archs": "magrittr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "magrittr",
-        "RemoteRef": "magrittr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.0.5"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:33 UTC; unix",
+        "Archs": "magrittr.so.dSYM"
       }
     },
     "marquee": {
@@ -2545,14 +2221,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-15 13:50:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-09-15 14:50:50 UTC; unix",
-        "Archs": "marquee.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "marquee",
-        "RemoteRef": "marquee",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 01:09:38 UTC; unix",
+        "Archs": "marquee.so.dSYM"
       }
     },
     "memoise": {
@@ -2577,13 +2247,7 @@
         "Maintainer": "Winston Chang <winston@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 06:31:57 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "memoise",
-        "RemoteRef": "memoise",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.0.1"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:19 UTC; unix"
       }
     },
     "microbenchmark": {
@@ -2609,7 +2273,7 @@
         "Maintainer": "Joshua M. Ulrich <josh.m.ulrich@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-09-04 18:30:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 22:13:25 UTC; unix",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:43:17 UTC; unix",
         "Archs": "microbenchmark.so.dSYM"
       }
     },
@@ -2635,14 +2299,8 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-17 20:20:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:43:02 UTC; unix",
-        "Archs": "mime.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "mime",
-        "RemoteRef": "mime",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.13"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:55 UTC; unix",
+        "Archs": "mime.so.dSYM"
       }
     },
     "mirai": {
@@ -2652,35 +2310,30 @@
         "Type": "Package",
         "Package": "mirai",
         "Title": "Minimalist Async Evaluation Framework for R",
-        "Version": "2.6.1",
+        "Version": "2.7.0",
         "Authors@R": "c(\n    person(\"Charlie\", \"Gao\", , \"charlie.gao@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-0750-061X\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"ctb\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(\"Hibiki AI Limited\", role = \"cph\")\n  )",
-        "Description": "Evaluates R expressions asynchronously and in parallel,\n    locally or distributed across networks. An official parallel cluster\n    type for R. Built on 'nanonext' and 'NNG', its non-polling,\n    event-driven architecture scales from a laptop to thousands of\n    processes across high-performance computing clusters and cloud\n    platforms.  Features FIFO scheduling with task cancellation, promises\n    for reactive programming, 'OpenTelemetry' distributed tracing, and\n    custom serialization for cross-language data types.",
+        "Description": "Evaluates R expressions asynchronously and in parallel,\n    locally or distributed across networks. An official parallel cluster\n    type for R. Built on 'nanonext' and 'NNG', its non-polling,\n    event-driven architecture scales from a laptop to thousands of\n    processes across high-performance computing clusters and cloud\n    platforms. Features FIFO scheduling with task cancellation and bounded\n    queues, promises for reactive programming, 'OpenTelemetry' distributed\n    tracing, and custom serialization for cross-language data types.",
         "License": "MIT + file LICENSE",
         "URL": "https://mirai.r-lib.org, https://github.com/r-lib/mirai",
         "BugReports": "https://github.com/r-lib/mirai/issues",
         "Depends": "R (>= 3.6)",
-        "Imports": "nanonext (>= 1.8.0)",
-        "Suggests": "cli, later, litedown, otel, otelsdk, secretbase",
+        "Imports": "nanonext (>= 1.9.0)",
+        "Suggests": "cli, later, litedown, mori, otel, otelsdk, secretbase",
         "Enhances": "parallel, promises",
         "VignetteBuilder": "litedown",
         "Config/Needs/coverage": "rlang",
         "Config/Needs/website": "tidyverse/tidytemplate",
+        "Config/roxygen2/markdown": "TRUE",
+        "Config/roxygen2/version": "8.0.0",
         "Config/usethis/last-upkeep": "2025-04-23",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-03-02 17:39:46 UTC; cg334",
+        "Packaged": "2026-05-08 08:33:20 UTC; cg334",
         "Author": "Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Joe Cheng [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Hibiki AI Limited [cph]",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-03-02 20:40:02 UTC",
-        "Built": "R 4.5.2; ; 2026-03-02 22:00:33 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "mirai",
-        "RemoteRef": "mirai",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.6.1"
+        "Date/Publication": "2026-05-08 11:30:02 UTC",
+        "Built": "R 4.6.0; ; 2026-05-08 15:59:29 UTC; unix"
       }
     },
     "nanonext": {
@@ -2714,13 +2367,8 @@
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-04 13:40:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-05-04 16:58:38 UTC; unix",
-        "Archs": "nanonext.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "nanonext",
-        "RemoteRef": "nanonext",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.9.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-04 17:18:51 UTC; unix",
+        "Archs": "nanonext.so.dSYM"
       }
     },
     "nanotime": {
@@ -2730,8 +2378,8 @@
         "Package": "nanotime",
         "Type": "Package",
         "Title": "Nanosecond-Resolution Time Support for R",
-        "Version": "0.3.14",
-        "Date": "2026-04-22",
+        "Version": "0.3.15",
+        "Date": "2026-05-21",
         "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\",\n                    comment = c(ORCID = \"0000-0001-6419-907X\")),\n             person(\"Leonardo\", \"Silvestri\", role = \"aut\"))",
         "Description": "Full 64-bit resolution date and time functionality with\n nanosecond granularity is provided, with easy transition to and from\n the standard 'POSIXct' type. Three additional classes offer interval,\n period and duration functionality for nanosecond-resolution timestamps.",
         "Depends": "methods",
@@ -2746,18 +2394,13 @@
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
         "VignetteBuilder": "Rcpp",
-        "Packaged": "2026-04-22 15:26:38 UTC; edd",
+        "Packaged": "2026-05-21 11:52:30 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Leonardo Silvestri [aut]",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-22 16:20:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-22 19:31:38 UTC; unix",
-        "Archs": "nanotime.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "nanotime",
-        "RemoteRef": "nanotime",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.3.14"
+        "Date/Publication": "2026-05-21 12:30:12 UTC",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-22 00:16:12 UTC; unix",
+        "Archs": "nanotime.so.dSYM"
       }
     },
     "openssl": {
@@ -2767,7 +2410,7 @@
         "Package": "openssl",
         "Type": "Package",
         "Title": "Toolkit for Encryption, Signatures and Certificates Based on\nOpenSSL",
-        "Version": "2.4.0",
+        "Version": "2.4.1",
         "Authors@R": "c(person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroenooms@gmail.com\",\n    comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Oliver\", \"Keyes\", role = \"ctb\"))",
         "Description": "Bindings to OpenSSL libssl and libcrypto, plus custom SSH key parsers.\n    Supports RSA, DSA and EC curves P-256, P-384, P-521, and curve25519. Cryptographic\n    signatures can either be created and verified manually or via x509 certificates. \n    AES can be used in cbc, ctr or gcm mode for symmetric encryption; RSA for asymmetric\n    (public key) encryption or EC for Diffie Hellman. High-level envelope functions \n    combine RSA and AES for encrypting arbitrary sized data. Other utilities include key\n    generators, hash functions (md5, sha1, sha256, etc), base64 encoder, a secure random\n    number generator, and 'bignum' math methods for manually performing crypto \n    calculations on large multibyte integers.",
         "License": "MIT + file LICENSE",
@@ -2780,19 +2423,13 @@
         "RoxygenNote": "7.3.2",
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-14 21:27:09 UTC; jeroen",
+        "Packaged": "2026-05-14 13:48:16 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-15 06:30:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-20 23:26:37 UTC; unix",
-        "Archs": "openssl.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "openssl",
-        "RemoteRef": "openssl",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.4.0"
+        "Date/Publication": "2026-05-14 14:50:14 UTC",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-14 19:24:59 UTC; unix",
+        "Archs": "openssl.so.dSYM"
       }
     },
     "openxlsx": {
@@ -2825,13 +2462,8 @@
         "Maintainer": "Jan Marvin Garbuszus <jan.garbuszus@ruhr-uni-bochum.de>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-31 06:10:51 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-10-31 08:24:20 UTC; unix",
-        "Archs": "openxlsx.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "openxlsx",
-        "RemoteRef": "openxlsx",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "4.2.8.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:57:07 UTC; unix",
+        "Archs": "openxlsx.so.dSYM"
       }
     },
     "otel": {
@@ -2859,13 +2491,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-29 13:30:07 UTC",
-        "Built": "R 4.5.0; ; 2025-09-01 01:35:46 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "otel",
-        "RemoteRef": "otel",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.2.0"
+        "Built": "R 4.6.0; ; 2026-04-25 15:39:31 UTC; unix"
       }
     },
     "pillar": {
@@ -2898,13 +2524,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-17 11:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-09-17 13:45:18 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "pillar",
-        "RemoteRef": "pillar",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.11.1"
+        "Built": "R 4.6.0; ; 2026-04-25 11:14:26 UTC; unix"
       }
     },
     "pins": {
@@ -2934,14 +2554,7 @@
         "Maintainer": "Julia Silge <julia.silge@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-09 14:10:02 UTC",
-        "Built": "R 4.5.2; ; 2026-03-09 14:30:33 UTC; unix",
-        "RemoteType": "standard",
-        "RemoteRef": "pins",
-        "RemotePkgRef": "pins",
-        "RemoteRepos": "https://cloud.r-project.org",
-        "RemoteReposName": "CRAN",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.2"
+        "Built": "R 4.6.0; ; 2026-04-26 05:18:45 UTC; unix"
       }
     },
     "pkgbuild": {
@@ -2970,13 +2583,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-26 14:10:06 UTC",
-        "Built": "R 4.5.0; ; 2025-05-26 15:14:03 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "pkgbuild",
-        "RemoteRef": "pkgbuild",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.8"
+        "Built": "R 4.6.0; ; 2026-04-26 05:15:34 UTC; unix"
       }
     },
     "pkgconfig": {
@@ -3000,13 +2607,7 @@
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
         "Repository": "CRAN",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:41:54 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "pkgconfig",
-        "RemoteRef": "pkgconfig",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.0.3"
+        "Built": "R 4.6.0; ; 2026-04-25 15:40:59 UTC; unix"
       }
     },
     "pkgload": {
@@ -3036,12 +2637,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 06:00:02 UTC",
-        "Built": "R 4.5.2; ; 2026-04-22 09:40:56 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "pkgload",
-        "RemoteRef": "pkgload",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.5.2"
+        "Built": "R 4.6.0; ; 2026-04-26 11:10:20 UTC; unix"
       }
     },
     "plyr": {
@@ -3069,14 +2665,8 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-10-02 06:50:08 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:45:45 UTC; unix",
-        "Archs": "plyr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "plyr",
-        "RemoteRef": "plyr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.8.9"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:43:36 UTC; unix",
+        "Archs": "plyr.so.dSYM"
       }
     },
     "png": {
@@ -3099,14 +2689,8 @@
         "Packaged": "2026-03-15 03:28:25 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-15 16:50:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-22 20:50:10 UTC; unix",
-        "Archs": "png.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "png",
-        "RemoteRef": "png",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.1-9"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:50:44 UTC; unix",
+        "Archs": "png.so.dSYM"
       }
     },
     "prettyunits": {
@@ -3131,7 +2715,7 @@
         "Maintainer": "Gabor Csardi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-09-24 21:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:44:35 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:44:33 UTC; unix"
       }
     },
     "processx": {
@@ -3160,12 +2744,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 12:00:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-22 14:39:01 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "processx",
-        "RemoteRef": "processx",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "3.9.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:18:04 UTC; unix"
       }
     },
     "progress": {
@@ -3193,7 +2772,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-06 10:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 20:30:01 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 23:16:07 UTC; unix"
       }
     },
     "promises": {
@@ -3225,13 +2804,7 @@
         "Maintainer": "Barret Schloerke <barret@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-01 06:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-11-01 08:07:07 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "promises",
-        "RemoteRef": "promises",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.5.0"
+        "Built": "R 4.6.0; ; 2026-04-26 02:18:42 UTC; unix"
       }
     },
     "ps": {
@@ -3261,12 +2834,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-20 13:40:03 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-20 23:19:23 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "ps",
-        "RemoteRef": "ps",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.9.3"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:33 UTC; unix"
       }
     },
     "purrr": {
@@ -3299,14 +2867,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-10 17:00:09 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 05:01:28 UTC; unix",
-        "Archs": "purrr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "purrr",
-        "RemoteRef": "purrr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 11:14:29 UTC; unix",
+        "Archs": "purrr.so.dSYM"
       }
     },
     "qicharts2": {
@@ -3333,13 +2895,7 @@
         "Maintainer": "Jacob Anhoej <jacob@anhoej.net>",
         "Repository": "CRAN",
         "Date/Publication": "2025-06-23 07:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-06-23 08:17:05 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "qicharts2",
-        "RemoteRef": "qicharts2",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.8.1"
+        "Built": "R 4.6.0; ; 2026-04-26 06:42:07 UTC; unix"
       }
     },
     "ragg": {
@@ -3371,13 +2927,8 @@
         "Author": "Thomas Lin Pedersen [cre, aut] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Maxim Shemanarev [aut, cph] (Author of AGG),\n  Tony Juricic [ctb, cph] (Contributor to AGG),\n  Milan Marusinec [ctb, cph] (Contributor to AGG),\n  Spencer Garrett [ctb] (Contributor to AGG),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-23 08:50:08 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-23 09:05:47 UTC; unix",
-        "Archs": "ragg.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "ragg",
-        "RemoteRef": "ragg",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.5.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:22:07 UTC; unix",
+        "Archs": "ragg.so.dSYM"
       }
     },
     "ragnar": {
@@ -3406,14 +2957,8 @@
         "Maintainer": "Tomasz Kalinowski <tomasz@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-23 19:40:08 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-23 22:41:59 UTC; unix",
-        "Archs": "ragnar.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "ragnar",
-        "RemoteRef": "ragnar",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.3.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 20:52:26 UTC; unix",
+        "Archs": "ragnar.so.dSYM"
       }
     },
     "rappdirs": {
@@ -3443,14 +2988,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-17 08:40:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-17 11:42:54 UTC; unix",
-        "Archs": "rappdirs.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rappdirs",
-        "RemoteRef": "rappdirs",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.3.4"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:27:56 UTC; unix",
+        "Archs": "rappdirs.so.dSYM"
       }
     },
     "readr": {
@@ -3483,13 +3022,8 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-19 18:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-02-19 21:33:46 UTC; unix",
-        "Archs": "readr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "readr",
-        "RemoteRef": "readr",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "2.2.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 15:50:28 UTC; unix",
+        "Archs": "readr.so.dSYM"
       }
     },
     "readxl": {
@@ -3498,29 +3032,30 @@
       "description": {
         "Package": "readxl",
         "Title": "Read Excel Files",
-        "Version": "1.4.5",
+        "Version": "1.5.0",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0003-4757-117X\")),\n    person(\"Jennifer\", \"Bryan\", , \"jenny@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-6983-2759\")),\n    person(\"Posit, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = \"Copyright holder of all R code and all C/C++ code without explicit copyright attribution\"),\n    person(\"Marcin\", \"Kalicinski\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included RapidXML code\"),\n    person(\"Komarov Valery\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included libxls code\"),\n    person(\"Christophe Leitienne\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included libxls code\"),\n    person(\"Bob Colbert\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included libxls code\"),\n    person(\"David Hoerl\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included libxls code\"),\n    person(\"Evan Miller\", role = c(\"ctb\", \"cph\"),\n           comment = \"Author of included libxls code\")\n  )",
-        "Description": "Import excel files into R. Supports '.xls' via the embedded\n    'libxls' C library <https://github.com/libxls/libxls> and '.xlsx' via\n    the embedded 'RapidXML' C++ library <https://rapidxml.sourceforge.net/>.\n    Works on Windows, Mac and Linux without external dependencies.",
+        "Description": "Import excel files into R. Supports '.xls' via the embedded\n    'libxls' C library <https://github.com/libxls/libxls> and '.xlsx' via\n    the embedded 'RapidXML' C++ library\n    <https://rapidxml.sourceforge.net/>.  Works on Windows, Mac and Linux\n    without external dependencies.",
         "License": "MIT + file LICENSE",
         "URL": "https://readxl.tidyverse.org, https://github.com/tidyverse/readxl",
         "BugReports": "https://github.com/tidyverse/readxl/issues",
-        "Depends": "R (>= 3.6)",
+        "Depends": "R (>= 4.1)",
         "Imports": "cellranger, tibble (>= 2.0.1), utils",
         "Suggests": "covr, knitr, rmarkdown, testthat (>= 3.1.6), withr",
-        "LinkingTo": "cpp11 (>= 0.4.0), progress",
+        "LinkingTo": "cpp11 (>= 0.5.5), progress",
         "VignetteBuilder": "knitr",
+        "Config/build/compilation-database": "true",
         "Config/Needs/website": "tidyverse/tidytemplate, tidyverse",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Encoding": "UTF-8",
         "Note": "libxls v1.6.3 c199d13",
-        "RoxygenNote": "7.3.2",
         "NeedsCompilation": "yes",
-        "Packaged": "2025-03-07 07:25:57 UTC; jenny",
-        "Author": "Hadley Wickham [aut] (<https://orcid.org/0000-0003-4757-117X>),\n  Jennifer Bryan [aut, cre] (<https://orcid.org/0000-0002-6983-2759>),\n  Posit, PBC [cph, fnd] (Copyright holder of all R code and all C/C++\n    code without explicit copyright attribution),\n  Marcin Kalicinski [ctb, cph] (Author of included RapidXML code),\n  Komarov Valery [ctb, cph] (Author of included libxls code),\n  Christophe Leitienne [ctb, cph] (Author of included libxls code),\n  Bob Colbert [ctb, cph] (Author of included libxls code),\n  David Hoerl [ctb, cph] (Author of included libxls code),\n  Evan Miller [ctb, cph] (Author of included libxls code)",
+        "Packaged": "2026-05-16 14:11:44 UTC; jenny",
+        "Author": "Hadley Wickham [aut] (ORCID: <https://orcid.org/0000-0003-4757-117X>),\n  Jennifer Bryan [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-6983-2759>),\n  Posit, PBC [cph, fnd] (Copyright holder of all R code and all C/C++\n    code without explicit copyright attribution),\n  Marcin Kalicinski [ctb, cph] (Author of included RapidXML code),\n  Komarov Valery [ctb, cph] (Author of included libxls code),\n  Christophe Leitienne [ctb, cph] (Author of included libxls code),\n  Bob Colbert [ctb, cph] (Author of included libxls code),\n  David Hoerl [ctb, cph] (Author of included libxls code),\n  Evan Miller [ctb, cph] (Author of included libxls code)",
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-03-07 17:10:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-04-01 23:29:54 UTC; unix",
+        "Date/Publication": "2026-05-16 21:50:23 UTC",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-17 02:16:09 UTC; unix",
         "Archs": "readxl.so.dSYM"
       }
     },
@@ -3544,7 +3079,7 @@
         "Packaged": "2023-08-30 12:10:51 UTC; gaborcsardi",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-30 16:50:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:54:34 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:51:36 UTC; unix"
       }
     },
     "reticulate": {
@@ -3575,14 +3110,8 @@
         "Maintainer": "Tomasz Kalinowski <tomasz@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-09 11:50:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 04:58:23 UTC; unix",
-        "Archs": "reticulate.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "reticulate",
-        "RemoteRef": "reticulate",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.46.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:18:57 UTC; unix",
+        "Archs": "reticulate.so.dSYM"
       }
     },
     "rlang": {
@@ -3614,14 +3143,8 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-06 10:40:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-08 22:25:16 UTC; unix",
-        "Archs": "rlang.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rlang",
-        "RemoteRef": "rlang",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:30 UTC; unix",
+        "Archs": "rlang.so.dSYM"
       }
     },
     "rmarkdown": {
@@ -3652,13 +3175,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-26 16:30:02 UTC",
-        "Built": "R 4.5.2; ; 2026-03-26 17:17:50 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rmarkdown",
-        "RemoteRef": "rmarkdown",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.31"
+        "Built": "R 4.6.0; ; 2026-04-26 11:07:48 UTC; unix"
       }
     },
     "rprojroot": {
@@ -3688,13 +3205,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-26 16:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-08-26 16:42:40 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rprojroot",
-        "RemoteRef": "rprojroot",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.1.1"
+        "Built": "R 4.6.0; ; 2026-04-25 15:48:39 UTC; unix"
       }
     },
     "rstudioapi": {
@@ -3719,12 +3230,7 @@
         "Author": "Kevin Ushey [aut, cre],\n  JJ Allaire [aut],\n  Hadley Wickham [aut],\n  Gary Ritchie [aut],\n  RStudio [cph]",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-16 09:10:02 UTC",
-        "Built": "R 4.5.2; ; 2026-01-16 11:59:41 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rstudioapi",
-        "RemoteRef": "rstudioapi",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.18.0"
+        "Built": "R 4.6.0; ; 2026-04-25 15:45:31 UTC; unix"
       }
     },
     "rvest": {
@@ -3755,13 +3261,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-29 14:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-09-01 01:53:28 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "rvest",
-        "RemoteRef": "rvest",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.0.5"
+        "Built": "R 4.6.0; ; 2026-04-26 05:22:36 UTC; unix"
       }
     },
     "sass": {
@@ -3790,14 +3290,8 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-04-11 19:50:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-04-11 21:17:02 UTC; unix",
-        "Archs": "sass.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "sass",
-        "RemoteRef": "sass",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.4.10"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 02:19:08 UTC; unix",
+        "Archs": "sass.so.dSYM"
       }
     },
     "scales": {
@@ -3827,13 +3321,7 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-04-24 11:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-24 11:54:38 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "scales",
-        "RemoteRef": "scales",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.4.0"
+        "Built": "R 4.6.0; ; 2026-04-25 23:14:37 UTC; unix"
       }
     },
     "selectr": {
@@ -3858,13 +3346,7 @@
         "Maintainer": "Simon Potter <simon@sjp.co.nz>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-17 09:00:02 UTC",
-        "Built": "R 4.5.2; ; 2025-12-19 08:56:24 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "selectr",
-        "RemoteRef": "selectr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.5-1"
+        "Built": "R 4.6.0; ; 2026-04-26 02:27:14 UTC; unix"
       }
     },
     "shiny": {
@@ -3894,12 +3376,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-20 09:00:03 UTC",
-        "Built": "R 4.5.2; ; 2026-02-20 12:12:49 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "shiny",
-        "RemoteRef": "shiny",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.13.0"
+        "Built": "R 4.6.0; ; 2026-04-26 11:08:04 UTC; unix"
       }
     },
     "shinyjs": {
@@ -3926,12 +3403,7 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-15 06:10:08 UTC",
-        "Built": "R 4.5.2; ; 2026-01-15 07:48:12 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "shinyjs",
-        "RemoteRef": "shinyjs",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "2.1.1"
+        "Built": "R 4.6.0; ; 2026-04-26 11:10:41 UTC; unix"
       }
     },
     "shinylogs": {
@@ -3957,7 +3429,7 @@
         "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
         "Repository": "CRAN",
         "Date/Publication": "2022-04-18 16:20:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 22:59:01 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-26 15:09:14 UTC; unix"
       }
     },
     "sourcetools": {
@@ -3982,13 +3454,8 @@
         "Author": "Kevin Ushey [aut, cre]",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:35 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-29 10:04:03 UTC; unix",
-        "Archs": "sourcetools.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "sourcetools",
-        "RemoteRef": "sourcetools",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "0.1.7-2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:30 UTC; unix",
+        "Archs": "sourcetools.so.dSYM"
       }
     },
     "stringi": {
@@ -4018,13 +3485,7 @@
         "License_is_FOSS": "yes",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 13:10:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:46:23 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "stringi",
-        "RemoteRef": "stringi",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.8.7"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:41:40 UTC; unix"
       }
     },
     "stringr": {
@@ -4055,13 +3516,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-04 14:00:02 UTC",
-        "Built": "R 4.5.0; ; 2025-11-04 17:37:12 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "stringr",
-        "RemoteRef": "stringr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.6.0"
+        "Built": "R 4.6.0; ; 2026-04-25 11:14:29 UTC; unix"
       }
     },
     "svglite": {
@@ -4094,14 +3549,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-21 16:10:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-10-21 18:14:11 UTC; unix",
-        "Archs": "svglite.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "svglite",
-        "RemoteRef": "svglite",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.2.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 02:23:12 UTC; unix",
+        "Archs": "svglite.so.dSYM"
       }
     },
     "sys": {
@@ -4127,14 +3576,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-04 09:40:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-03-31 21:48:25 UTC; unix",
-        "Archs": "sys.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "sys",
-        "RemoteRef": "sys",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "3.4.3"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:55 UTC; unix",
+        "Archs": "sys.so.dSYM"
       }
     },
     "systemfonts": {
@@ -4167,14 +3610,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-05 13:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-05 13:44:23 UTC; unix",
-        "Archs": "systemfonts.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "systemfonts",
-        "RemoteRef": "systemfonts",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.3.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:16:44 UTC; unix",
+        "Archs": "systemfonts.so.dSYM"
       }
     },
     "textshaping": {
@@ -4206,14 +3643,8 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-06 10:40:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-06 14:22:34 UTC; unix",
-        "Archs": "textshaping.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "textshaping",
-        "RemoteRef": "textshaping",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.0.5"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:19:28 UTC; unix",
+        "Archs": "textshaping.so.dSYM"
       }
     },
     "tibble": {
@@ -4248,14 +3679,8 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-11 10:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-11 11:35:41 UTC; unix",
-        "Archs": "tibble.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "tibble",
-        "RemoteRef": "tibble",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "3.3.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 05:14:40 UTC; unix",
+        "Archs": "tibble.so.dSYM"
       }
     },
     "tidyr": {
@@ -4287,14 +3712,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-19 09:20:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-12-21 22:56:43 UTC; unix",
-        "Archs": "tidyr.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "tidyr",
-        "RemoteRef": "tidyr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.3.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 15:50:18 UTC; unix",
+        "Archs": "tidyr.so.dSYM"
       }
     },
     "tidyselect": {
@@ -4324,13 +3743,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.5.0; ; 2025-04-01 15:54:40 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "tidyselect",
-        "RemoteRef": "tidyselect",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.1"
+        "Built": "R 4.6.0; ; 2026-04-26 02:19:10 UTC; unix"
       }
     },
     "timechange": {
@@ -4357,14 +3770,8 @@
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-29 22:20:08 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-29 23:29:04 UTC; unix",
-        "Archs": "timechange.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "timechange",
-        "RemoteRef": "timechange",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.4.0"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:44:04 UTC; unix",
+        "Archs": "timechange.so.dSYM"
       }
     },
     "tinytex": {
@@ -4390,13 +3797,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:10 UTC",
-        "Built": "R 4.5.2; ; 2026-03-29 10:05:51 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "tinytex",
-        "RemoteRef": "tinytex",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.59"
+        "Built": "R 4.6.0; ; 2026-04-25 23:14:13 UTC; unix"
       }
     },
     "tzdb": {
@@ -4425,7 +3826,7 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-15 22:50:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-04-01 06:32:38 UTC; unix",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:44:31 UTC; unix",
         "Archs": "tzdb.so.dSYM"
       }
     },
@@ -4453,14 +3854,8 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-06-08 19:00:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-06-08 20:24:56 UTC; unix",
-        "Archs": "utf8.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "utf8",
-        "RemoteRef": "utf8",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.2.6"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:41:06 UTC; unix",
+        "Archs": "utf8.so.dSYM"
       }
     },
     "vctrs": {
@@ -4493,14 +3888,8 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-11 06:20:03 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-04-15 04:58:47 UTC; unix",
-        "Archs": "vctrs.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "vctrs",
-        "RemoteRef": "vctrs",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.7.3"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:15:23 UTC; unix",
+        "Archs": "vctrs.so.dSYM"
       }
     },
     "viridisLite": {
@@ -4527,13 +3916,7 @@
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Antônio Pedro Camargo [ctb, cph],\n  Cédric Scherer [ctb, cph]",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-04 06:40:10 UTC",
-        "Built": "R 4.5.2; ; 2026-02-07 09:05:34 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "viridisLite",
-        "RemoteRef": "viridisLite",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.4.3"
+        "Built": "R 4.6.0; ; 2026-04-25 15:40:19 UTC; unix"
       }
     },
     "vroom": {
@@ -4568,13 +3951,8 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-31 05:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-31 08:24:20 UTC; unix",
-        "Archs": "vroom.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "vroom",
-        "RemoteRef": "vroom",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.7.1"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:09:05 UTC; unix",
+        "Archs": "vroom.so.dSYM"
       }
     },
     "whisker": {
@@ -4597,7 +3975,7 @@
         "Packaged": "2022-12-05 15:15:55 UTC; hornik",
         "Repository": "CRAN",
         "Date/Publication": "2022-12-05 15:33:50 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:55:43 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-25 15:49:54 UTC; unix"
       }
     },
     "withr": {
@@ -4627,13 +4005,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.5.0; ; 2025-03-31 21:42:13 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "withr",
-        "RemoteRef": "withr",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "3.0.2"
+        "Built": "R 4.6.0; ; 2026-04-25 09:28:00 UTC; unix"
       }
     },
     "xfun": {
@@ -4661,14 +4033,8 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-20 16:50:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-03-22 20:50:32 UTC; unix",
-        "Archs": "xfun.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "xfun",
-        "RemoteRef": "xfun",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "0.57"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:40:14 UTC; unix",
+        "Archs": "xfun.so.dSYM"
       }
     },
     "xml2": {
@@ -4699,14 +4065,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-17 16:10:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2026-01-17 16:23:11 UTC; unix",
-        "Archs": "xml2.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "xml2",
-        "RemoteRef": "xml2",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "1.5.2"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:48 UTC; unix",
+        "Archs": "xml2.so.dSYM"
       }
     },
     "xtable": {
@@ -4731,12 +4091,7 @@
         "Packaged": "2026-02-20 02:51:53 UTC; dsco0",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2026-02-22 11:20:02 UTC",
-        "Built": "R 4.5.2; ; 2026-02-22 13:16:04 UTC; unix",
-        "RemoteType": "standard",
-        "RemotePkgRef": "xtable",
-        "RemoteRef": "xtable",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.8-8"
+        "Built": "R 4.6.0; ; 2026-04-25 15:39:58 UTC; unix"
       }
     },
     "yaml": {
@@ -4764,14 +4119,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-10 07:00:01 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-12-10 09:31:17 UTC; unix",
-        "Archs": "yaml.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "yaml",
-        "RemoteRef": "yaml",
-        "RemoteRepos": "https://cran.rstudio.com/",
-        "RemotePkgPlatform": "aarch64-apple-darwin20",
-        "RemoteSha": "2.3.12"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:54 UTC; unix",
+        "Archs": "yaml.so.dSYM"
       }
     },
     "zip": {
@@ -4798,7 +4147,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-13 14:10:02 UTC",
-        "Built": "R 4.5.0; aarch64-apple-darwin20; 2025-05-13 15:17:31 UTC; unix"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:49:42 UTC; unix"
       }
     },
     "zoo": {
@@ -4822,13 +4171,8 @@
         "Maintainer": "Achim Zeileis <Achim.Zeileis@R-project.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-15 14:30:02 UTC",
-        "Built": "R 4.5.2; aarch64-apple-darwin20; 2025-12-15 18:03:39 UTC; unix",
-        "Archs": "zoo.so.dSYM",
-        "RemoteType": "standard",
-        "RemotePkgRef": "zoo",
-        "RemoteRef": "zoo",
-        "RemoteRepos": "https://cran.rstudio.com",
-        "RemoteSha": "1.8-15"
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:28:22 UTC; unix",
+        "Archs": "zoo.so.dSYM"
       }
     }
   },
@@ -4840,7 +4184,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "18c9f0ffce42a2e728543fd5b3fe53a9"
+      "checksum": "2432de5587d2042ee334d424c6f1f21f"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4912,7 +4256,7 @@
       "checksum": "e5af14aa12d4679f71ba54443c346be3"
     },
     "inst/app/www/wizard-nav.js": {
-      "checksum": "1e12159eba5f19987a989880a351602e"
+      "checksum": "3be30466bdbb018a2ae71101b0fe191d"
     },
     "inst/config/brand.yml": {
       "checksum": "8097b52693ae309bf2bd587bb6a487b9"
@@ -4979,9 +4323,6 @@
     },
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
-    },
-    "manifest.json": {
-      "checksum": "9e65c84b4b558e9897e5b84d7724b490"
     },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
@@ -5107,7 +4448,7 @@
       "checksum": "d8a1f060147ffd0df5a6ff8490bce3ad"
     },
     "R/fct_spc_execute.R": {
-      "checksum": "8952dc02659b932024ef5bd5845d483e"
+      "checksum": "a3576e599770818484a2463e76835360"
     },
     "R/fct_spc_file_save_load.R": {
       "checksum": "ce1e71cec2afe3f34144e8febef607dd"
@@ -5377,7 +4718,7 @@
       "checksum": "2a89e70626500a1b8267ecb603047ff5"
     },
     "R/utils_ui_app_layout.R": {
-      "checksum": "da12c58ef7963b33b0883ba01e249572"
+      "checksum": "83e12e86341a1a2a0bc8577c4a59fae3"
     },
     "R/utils_ui_column_sync.R": {
       "checksum": "cfb8a0e40df0094e786ba865c1caef30"

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -60,13 +60,14 @@ mock_bfh_qic <- function(data, x, y, n = NULL, chart_type = "run",
                          y_axis_unit = NULL, chart_title = NULL,
                          target_value = NULL, target_text = NULL,
                          notes = NULL, part = NULL, freeze = NULL,
-                         exclude = NULL, cl = NULL, multiply = NULL,
+                         exclude = NULL, cl = NULL, ylim = NULL,
+                         multiply = NULL,
                          agg.fun = "mean", base_size = 12,
                          width = NULL, height = NULL, units = "in",
                          dpi = 96, plot_margin = NULL,
                          ylab = NULL, xlab = NULL,
                          subtitle = NULL, caption = NULL,
-                         return.data = FALSE, print.summary = FALSE,
+                         return.data = FALSE,
                          language = "da") {
   n_rows <- nrow(data)
   cl_value <- if (!is.null(cl)) {


### PR DESCRIPTION
## Summary

- Regenerér `manifest.json` for Connect Cloud-deploy
- Bump siblings: BFHcharts 0.22.1 → 0.23.0 (Imports), BFHtheme 0.5.1 → 0.5.2 (Suggests)
- Synk `mock_bfh_qic` med BFHcharts 0.23.0 (tilføjet `ylim`, fjernet `print.summary`) — kontrakt-test grøn
- BFHtheme 0.5.2 var et fejl-navngivet tag (Version 0.5.1); fixet upstream via version-only release (BFHtheme PR #76/#77 + force-retag) før denne publish
- Genereret via `dev/publish_prepare.R` (install + manifest), valideret med `dev/validate_connect_manifest.R`

## Test plan

- [x] `dev/publish_prepare.R install` — siblings installeret fra tags
- [x] `dev/publish_prepare.R manifest` — testthat-suite bestået
- [x] `dev/validate_connect_manifest.R manifest.json` — manifest OK (alle 4 BFH-siblings)
- [x] Pre-push hooks bestået
- [ ] Merge PR → develop
- [ ] Senere release-PR develop → master triggerer Connect Cloud-deploy