### PR TITLE
chore(ci): cap artifact retention to reduce Actions storage

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -201,9 +201,10 @@ jobs:
         shell: bash
 
       - name: Upload tarball check output
-        if: always()
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: release-gate-check-output
           path: biSPCharts.Rcheck/
           if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -80,6 +80,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: shinytest2-snapshots
+          retention-days: 7
           path: |
             tests/testthat/**/_snaps/
             tests/testthat/**/*-new.png

--- a/.github/workflows/skip-inventory.yaml
+++ b/.github/workflows/skip-inventory.yaml
@@ -139,6 +139,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: skip-inventory
+          retention-days: 7
           path: |
             dev/audit-output/skip-inventory.json
             dev/audit-output/skip-inventory.md


### PR DESCRIPTION
## Summary
- Actions-storage ramte 90% af kontoens included quota (0,46/0,5GB). biSPCharts er eneste reelle forbruger: ~8,7GB ukomprimeret artifacts.
- `release-gate-check-output` (4,7GB / 172 stk) uploadede hele `biSPCharts.Rcheck/` på **hver** run (`if: always()`, ingen retention) → nu kun `if: failure()` + `retention-days: 7`.
- `shinytest2-snapshots` + `skip-inventory`: tilføjet `retention-days: 7`.

## Ikke dækket af denne PR
- `Linux-X64-*-results` (3,6GB) kommer fra `r-lib/actions/check-r-package` og kan ikke få `retention-days` inline. Cappes via **repo-default artifact retention** (Settings → Actions → General → Artifact and log retention). Ingen REST-API → manuelt trin.
- Sletning af eksisterende ~8,7GB gamle artifacts sker separat (afventer brugerbekræftelse).

## Test plan
- [ ] Næste grønne R-CMD-check-run uploader IKKE release-gate-check-output
- [ ] Et failure-run uploader stadig output (debugging bevaret)
- [ ] Verificér storage-fald efter retention + cleanup