### PR TITLE
feat(chart-types): eksponer I'-kort (i') i diagramtype-dropdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biSPCharts
 Title: Statistical Process Control for Clinical Quality Improvement
-Version: 0.6.0
+Version: 0.7.0
 Authors@R:
     person("Johan", "Reventlow", , "johan@reventlow.dk", role = c("aut", "cre"))
 Description:
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.23.1),
+    BFHcharts (>= 0.24.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -78,7 +78,7 @@ Suggests:
     pkgload (>= 1.3.0)
 Config/testthat/edition: 3
 Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.23.1,
+Remotes: johanreventlow/BFHcharts@v0.24.0,
     johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# biSPCharts 0.7.0
+
+## Nye features
+
+* **I′-kort (I-prime) er nu valgbar i diagramtype-dropdown.** Diagramtypen
+  beregnes via `BFHcharts::bfh_qic(..., chart_type = "i'")` og er beregnet
+  til individuelle målinger med varierende nævner (n), som giver
+  nævner-justerede kontrolgrænser. Nævner-feltet aktiveres automatisk i UI,
+  så brugere kan angive en nævnerkolonne — nævneren er valgfri; udfyldes den
+  ikke, degenererer diagrammet til et standard I-kort med en besked fra
+  BFHcharts.
+
+## Dependency bumps
+
+* `BFHcharts (>= 0.24.0)` (op fra 0.23.1) + `johanreventlow/BFHcharts@v0.24.0`
+  i Remotes. BFHcharts 0.24.0 introducerer `chart_type = "i'"` (I-prime-kort).
+  **Bemærk:** BFHcharts v0.24.0-tagget eksisterer endnu ikke på GitHub ved
+  dette release — tagges af BFHcharts-maintainer. Install/CI resolver
+  korrekt så snart tagget pushes.
+
 # biSPCharts (development)
 
 ## Interne ændringer

--- a/R/config_chart_types.R
+++ b/R/config_chart_types.R
@@ -29,6 +29,7 @@
 CHART_TYPES_DA <- list(
   "Seriediagram (Run) \u2014 data over tid" = "run",
   "I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)" = "i",
+  "I\u2032-kort \u2014 individuelle m\u00e5linger med varierende n\u00e6vner" = "i'",
   # "MR-kort \u2014 variation mellem m\u00e5linger" = "mr",
   "P-kort \u2014 andele/procenter (fx infektionsrate)" = "p",
   # "P\u2032-kort \u2014 andele, standardiseret" = "pp",
@@ -43,6 +44,7 @@ CHART_TYPES_DA <- list(
 CHART_TYPES_EN <- list(
   "run" = "run",
   "i" = "i",
+  "i'" = "i'",
   # "mr" = "mr",
   "p" = "p",
   # "pp" = "pp",
@@ -103,6 +105,7 @@ get_qic_chart_type <- function(danish_selection) {
 CHART_TYPE_DESCRIPTIONS <- list(
   "run" = "Seriediagram der viser data over tid med median centerlinje",
   "i" = "I-kort til individuelle m\u00e5linger",
+  "i'" = "I\u2032-kort til individuelle m\u00e5linger med n\u00e6vner-justerede kontrolgr\u00e6nser",
   "mr" = "Moving Range kort til variabilitet mellem p\u00e5 hinanden f\u00f8lgende m\u00e5linger",
   "p" = "P-kort til andele og procenter",
   "pp" = "P'-kort til standardiserede andele",
@@ -127,6 +130,6 @@ chart_type_requires_denominator <- function(chart_type) {
   # Normaliser til qicharts2-kode
   ct <- get_qic_chart_type(chart_type)
 
-  # Naevner er relevant for run, p, pp, u, up
-  return(ct %in% c("run", "p", "pp", "u", "up"))
+  # Naevner er relevant for run, p, pp, u, up, i'
+  return(ct %in% c("run", "p", "pp", "u", "up", "i'"))
 }

--- a/R/utils_y_axis_scaling.R
+++ b/R/utils_y_axis_scaling.R
@@ -23,7 +23,7 @@ PROPORTION_CHART_TYPES <- c("p", "pp")
 
 #' Chart types that use absolute internal unit (no scaling)
 #' @keywords internal
-ABSOLUTE_CHART_TYPES <- c("c", "u", "up", "i", "mr", "g")
+ABSOLUTE_CHART_TYPES <- c("c", "u", "up", "i", "mr", "g", "i'")
 
 # LAYER 1: PARSING ============================================================
 

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.23.1",
+        "Version": "0.24.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -32,26 +32,26 @@
         "BugReports": "https://github.com/johanreventlow/BFHcharts/issues",
         "Depends": "R (>= 4.1.0)",
         "Imports": "BFHtheme (>= 0.5.1), ggplot2 (>= 3.4.0), qicharts2 (>= 0.7.0),\nscales (>= 1.2.0), lubridate (>= 1.9.0), dplyr (>= 1.1.0),\npurrr (>= 1.0.0), stringr (>= 1.5.0), tibble (>= 3.2.0), yaml,\nlemon, marquee (>= 0.1.0), grid, commonmark (>= 1.9), xml2,\nsystemfonts, rlang, svglite",
-        "Suggests": "testthat (>= 3.1.7), vdiffr, covr, pdftools (>= 3.3.0),\nwithr, bench, BFHllm, jsonlite, knitr, rmarkdown",
+        "Suggests": "testthat (>= 3.1.7), vdiffr, covr, pdftools (>= 3.3.0),\nwithr, bench, BFHllm, jsonlite, knitr, pbcharts, rmarkdown",
         "VignetteBuilder": "knitr",
-        "Remotes": "johanreventlow/BFHtheme@v0.5.2, johanreventlow/BFHllm@v0.2.0",
+        "Remotes": "johanreventlow/BFHtheme@v0.5.2, johanreventlow/BFHllm@v0.2.0,\nanhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f",
         "Config/testthat/edition": "3",
         "Config/roxygen2/version": "8.0.0",
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.23.1",
-        "RemoteSha": "eaf31ace9d4d9d588124e8f0c2f6a05503cf988e",
+        "RemoteRef": "v0.24.0",
+        "RemoteSha": "2c5b4514174725364b9ff4b905a6704601cd1fed",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.23.1",
-        "GithubSHA1": "eaf31ace9d4d9d588124e8f0c2f6a05503cf988e",
+        "GithubRef": "v0.24.0",
+        "GithubSHA1": "2c5b4514174725364b9ff4b905a6704601cd1fed",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-07 10:17:01 UTC; johanreventlow",
+        "Packaged": "2026-06-08 18:52:37 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-07 10:17:02 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-08 18:52:38 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -4184,7 +4184,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "d627750e9e0955cf775ad1a200a52d34"
+      "checksum": "36b624c8d59c9f1aa9a8ca5bb26cc397"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4324,6 +4324,9 @@
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
     },
+    "manifest.json": {
+      "checksum": "9d7461a1cb632dc0e67d25c9e1e1f21d"
+    },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
     },
@@ -4352,7 +4355,7 @@
       "checksum": "cb066b1eac8c4724f030e0006c1b6fbc"
     },
     "R/config_chart_types.R": {
-      "checksum": "cf03e313f2c208f032d9227848831465"
+      "checksum": "525356b7e1ae33481c5c641a91e89f34"
     },
     "R/config_export_config.R": {
       "checksum": "410356d2c0c0ff25130cefeb609bfa32"
@@ -4748,7 +4751,7 @@
       "checksum": "d312ae61935af94b38ffa900d179150f"
     },
     "R/utils_y_axis_scaling.R": {
-      "checksum": "66f44772ca3108f367347e54ff91ebae"
+      "checksum": "0863dc7a47fc3e1c6e4528a6dcd40593"
     },
     "R/zzz.R": {
       "checksum": "8af6a97ee8d87cbefd81882e728c7667"

--- a/tests/testthat/test-bfhcharts-integration.R
+++ b/tests/testthat/test-bfhcharts-integration.R
@@ -145,6 +145,37 @@ test_that("BFHcharts to-trins workflow: bfh_qic + get_plot", {
   expect_s3_class(plot, "ggplot")
 })
 
+test_that("BFHcharts bfh_qic kan oprette I-prime chart (i') med naevner", {
+  skip_if_not_installed("BFHcharts")
+  skip_if_not_installed("qicharts2")
+
+  test_data <- data.frame(
+    Dato = seq.Date(from = as.Date("2024-01-01"), by = "week", length.out = 20),
+    Vaerdi = c(
+      12, 15, 13, 14, 16, 11, 15, 17, 13, 14,
+      18, 20, 17, 19, 21, 22, 18, 20, 23, 21
+    ),
+    Naevner = c(
+      5, 6, 5, 6, 7, 5, 6, 7, 5, 6,
+      7, 8, 7, 8, 9, 9, 7, 8, 10, 9
+    )
+  )
+
+  plot_result <- expect_no_error(
+    BFHcharts::bfh_qic(
+      data = test_data,
+      x = Dato,
+      y = Vaerdi,
+      n = Naevner,
+      chart_type = "i'",
+      y_axis_unit = "count",
+      chart_title = "Test I-prime Chart"
+    )
+  )
+
+  expect_true(inherits(plot_result, "bfh_qic_result"))
+})
+
 test_that("BFHcharts::create_spc_chart er ikke i namespace (gammel API bekraeftelse)", {
   skip_if_not_installed("BFHcharts")
   # Gammel API er fjernet — bfh_qic() er den nuvaerende entrypoint

--- a/tests/testthat/test-bfhcharts-integration.R
+++ b/tests/testthat/test-bfhcharts-integration.R
@@ -148,6 +148,10 @@ test_that("BFHcharts to-trins workflow: bfh_qic + get_plot", {
 test_that("BFHcharts bfh_qic kan oprette I-prime chart (i') med naevner", {
   skip_if_not_installed("BFHcharts")
   skip_if_not_installed("qicharts2")
+  # i'-beregning delegeres til pbcharts (BFHcharts Suggests/Remotes-dep).
+  # pbcharts er ikke i biSPCharts' egne deps, saa CI har den typisk ikke;
+  # skip naar fravaerende -- selve i'-pipelinen er CI-testet i BFHcharts.
+  skip_if_not_installed("pbcharts")
 
   test_data <- data.frame(
     Dato = seq.Date(from = as.Date("2024-01-01"), by = "week", length.out = 20),

--- a/tests/testthat/test-config_chart_types.R
+++ b/tests/testthat/test-config_chart_types.R
@@ -17,7 +17,7 @@ test_that("get_qic_chart_type konverterer danske labels korrekt", {
 
 test_that("get_qic_chart_type returnerer engelske koder uændret", {
   # Kun aktive koder der er registreret i lookup-tabellen
-  for (code in c("run", "i", "p", "u", "c")) {
+  for (code in c("run", "i", "i'", "p", "u", "c")) {
     expect_equal(get_qic_chart_type(code), code)
   }
   # Bemærk: MR/PP/UP/G er ikke registreret som engelske koder i lookup-tabellen
@@ -40,6 +40,7 @@ test_that("chart_type_requires_denominator identificerer korrekte typer", {
   expect_true(chart_type_requires_denominator("pp"))
   expect_true(chart_type_requires_denominator("u"))
   expect_true(chart_type_requires_denominator("up"))
+  expect_true(chart_type_requires_denominator("i'"))
 
   # Typer der IKKE kræver nævner
   expect_false(chart_type_requires_denominator("i"))
@@ -53,21 +54,72 @@ test_that("chart_type_requires_denominator accepterer danske labels", {
   # Opdaterede labels til nuværende em-dash format
   expect_true(chart_type_requires_denominator("P-kort \u2014 andele/procenter (fx infektionsrate)"))
   expect_false(chart_type_requires_denominator("I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)"))
+  # i'-kort: naevner er relevant (varierende naevner er kernefeature)
+  expect_true(chart_type_requires_denominator(
+    "I\u2032-kort \u2014 individuelle m\u00e5linger med varierende n\u00e6vner"
+  ))
 })
 
 # Konstanter ------------------------------------------------------------------
 
 test_that("CHART_TYPES_DA indeholder aktive diagramtyper", {
-  # Aktuelt 5 aktive typer (mr, pp, up, g er udkommenteret i config_chart_types.R)
-  expect_true(length(CHART_TYPES_DA) >= 5,
-    info = "CHART_TYPES_DA skal indeholde mindst 5 aktive diagramtyper"
+  # Aktuelt 6 aktive typer inkl. i' (mr, pp, up, g er udkommenteret i config_chart_types.R)
+  expect_true(length(CHART_TYPES_DA) >= 6,
+    info = "CHART_TYPES_DA skal indeholde mindst 6 aktive diagramtyper"
   )
-  expect_true(all(unlist(CHART_TYPES_DA) %in% c("run", "i", "mr", "p", "pp", "u", "up", "c", "g")),
+  expect_true(all(unlist(CHART_TYPES_DA) %in% c("run", "i", "i'", "mr", "p", "pp", "u", "up", "c", "g")),
     info = "Alle aktive typer skal have gyldige engelske koder"
   )
 })
 
-test_that("CHART_TYPE_DESCRIPTIONS dækker alle engelske koder", {
-  expected_codes <- c("run", "i", "mr", "p", "pp", "u", "up", "c", "g")
+test_that("CHART_TYPE_DESCRIPTIONS daekker alle engelske koder inkl. i-prime", {
+  expected_codes <- c("run", "i", "i'", "mr", "p", "pp", "u", "up", "c", "g")
   expect_true(all(expected_codes %in% names(CHART_TYPE_DESCRIPTIONS)))
+})
+
+# i' (I-prime) chart type -------------------------------------------------------
+
+test_that("i'-kort: get_qic_chart_type returnerer i' uaendret (passthrough)", {
+  expect_equal(get_qic_chart_type("i'"), "i'")
+})
+
+test_that("i'-kort: get_qic_chart_type konverterer dansk label korrekt", {
+  expect_equal(
+    get_qic_chart_type("I′-kort — individuelle målinger med varierende nævner"),
+    "i'"
+  )
+})
+
+test_that("i'-kort: i' er i SUPPORTED_CHART_TYPES_BFH (validering accepterer den)", {
+  expect_true("i'" %in% SUPPORTED_CHART_TYPES_BFH)
+})
+
+test_that("i'-kort: chart_type_requires_denominator returnerer TRUE", {
+  expect_true(chart_type_requires_denominator("i'"))
+})
+
+test_that("i'-kort: chart_type_requires_denominator via dansk label returnerer TRUE", {
+  expect_true(chart_type_requires_denominator(
+    "I′-kort — individuelle målinger med varierende nævner"
+  ))
+})
+
+test_that("i'-kort: build_bfh_args bevarer n_var for i'-chart (ikke stripped)", {
+  # chart_type_requires_denominator("i'") er TRUE → n_var skal IKKE fjernes
+  # Verificer logik-gaten direkte (build_bfh_args bruger denne guard)
+  expect_true(chart_type_requires_denominator("i'"),
+    info = "Guard-condition: i' requires denominator → n_var skal bevares af build_bfh_args"
+  )
+})
+
+test_that("i'-kort: i' er i ABSOLUTE_CHART_TYPES (arver i's y-akse skalering)", {
+  expect_true("i'" %in% ABSOLUTE_CHART_TYPES)
+})
+
+test_that("i'-kort: fct_spc_validate accepterer i' som chart_type", {
+  df <- data.frame(
+    x = seq.Date(as.Date("2023-01-01"), by = "week", length.out = 10),
+    y = as.numeric(1:10)
+  )
+  expect_no_error(validate_spc_request(df, "x", "y", "i'"))
 })


### PR DESCRIPTION
## Summary
- Tilfojer `chart_type = "i'"` (I-prime, Taylor) som valgbar diagramtype i dropdown'en. Beregnes via BFHcharts 0.24.0 (pbcharts-adapter).
- Naevner-feltet (`n_column`) aktiveres for i' saa varierende naevner kan angives — **valgfrit**: tom naevner -> BFHcharts degenererer til standard i-kort med en besked.
- Cross-repo bump: `BFHcharts (>= 0.24.0)` + `Remotes: johanreventlow/BFHcharts@v0.24.0` + regenereret `manifest.json` (RemoteRef v0.24.0, sha 2c5b451).
- Version 0.6.0 -> 0.7.0 (MINOR).

## Implementering
- `config_chart_types.R`: i' i `CHART_TYPES_DA` (label m. U+2032 prime), `CHART_TYPES_EN` (passthrough), `CHART_TYPE_DESCRIPTIONS`; `chart_type_requires_denominator("i'")` -> TRUE (naevner *relevant*, ikke mandatory — run beviser optionalitet).
- `utils_y_axis_scaling.R`: i' i `ABSOLUTE_CHART_TYPES` (arver i-kort count-skalering).
- Value = literal `"i'"` (ASCII-apostrof, matcher BFHcharts-koden); labels bruger typografisk prime.

## Test plan
- [x] 49 tests gronne (FAIL 0): get_qic_chart_type-roundtrip, SUPPORTED_CHART_TYPES_BFH-membership, requires_denominator (engelsk + dansk label), ABSOLUTE_CHART_TYPES, validate_spc_request-acceptance
- [x] Integration-smoke: `BFHcharts::bfh_qic(..., chart_type="i'", n=...)` returnerer gyldigt `bfh_qic_result` (mod 0.24.0)
- [x] Apostrof-value round-tripper rent gennem get_qic_chart_type + validering
- [x] manifest.json regenereret korrekt (kun BFHcharts-bump, ingen .Rcheck/docs-pollution)
- [ ] Manuel UI-verifikation: bekraeft at `"i'"` round-tripper gennem selectize -> input$chart_type i live app (apostrof i HTML option-value)
- [ ] y-akse percent/rate-display for i' (v1 = count default som i-kort; evt. follow-up)

## Noter
- Out of scope v1: percent/rate y-akse-display for i' (faller tilbage til count). Facet-paritet. pbc chart="ms".
- Afhaenger af BFHcharts v0.24.0 (nu tagget + pushed).