### PR TITLE
feat(i-prime): auto-vælg procent y-akse ved nævner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,13 @@
   valgbare diagramtyper. Alle typer beregnes af qicharts2 — ingen ny
   afhængighed.
 
+* **I′-kort vælger automatisk procent-y-akse ved nævner.** Når I′-kort vælges
+  og der allerede er angivet både tæller og nævner, sættes y-akse-enheden
+  automatisk til procent (y/n er en andel) som første automatiserede valg. Er
+  der kun en tæller, forbliver enheden "tal". Skifter brugeren selv til rate
+  eller tal, respekteres det (auto-valget sker kun ved skift af diagramtype,
+  ikke ved manuelt y-akse-valg).
+
 # biSPCharts 0.7.0
 
 ## Nye features

--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -223,10 +223,19 @@ update_ui_for_chart_type <- function(transition, ct, input, session, app_state,
   )
 
   if (!identical(qic_ct, "run")) {
-    # Brug ct (original) ikke qic_ct, saa "t" matches direkte i
-    # chart_type_to_ui_type() -- get_qic_chart_type("t") fallbacker
-    # til "run" fordi "t" ikke er i CHART_TYPES_EN endnu.
-    desired_ui <- chart_type_to_ui_type(ct)
+    if (identical(qic_ct, "i'")) {
+      # I-prime: naevner-bevidst default via den pure decide_default_y_axis_ui_type
+      # (med naevner -> procent, ellers tal). Bruger-override respekteres, da
+      # denne observer kun fyrer ved chart_type-skift, ikke ved manuelt
+      # y_axis_unit-valg.
+      n_present <- has_input_value(get_n_column(app_state))
+      desired_ui <- decide_default_y_axis_ui_type(qic_ct, n_present)
+    } else {
+      # Brug ct (original) ikke qic_ct, saa "t" matches direkte i
+      # chart_type_to_ui_type() -- get_qic_chart_type("t") fallbacker
+      # til "run" fordi "t" ikke er i CHART_TYPES_EN endnu.
+      desired_ui <- chart_type_to_ui_type(ct)
+    }
     current_ui <- input_scalar(input$y_axis_unit, default = "count")
     if (!identical(current_ui, desired_ui)) {
       safe_programmatic_ui_update(session, app_state, function() {

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -106,7 +106,9 @@ suggest_chart_type <- function(internal_class, n_present = FALSE, n_points = NA_
 #' @keywords internal
 decide_default_y_axis_ui_type <- function(chart_type, n_present) {
   ct <- get_qic_chart_type(chart_type)
-  if (identical(ct, "run") && isTRUE(n_present)) {
+  # Run og I-prime: med naevner plottes en andel (y/n) -> default procent.
+  # Uden naevner -> tal. Brugeren kan altid overskrive.
+  if (ct %in% c("run", "i'") && isTRUE(n_present)) {
     return("percent")
   }
   return("count")

--- a/tests/testthat/test-y-axis-scaling-overhaul.R
+++ b/tests/testthat/test-y-axis-scaling-overhaul.R
@@ -387,6 +387,18 @@ test_that("run chart denominator toggle semantics (unit-only)", {
   expect_equal(decide_default_y_axis_ui_type("run", n_present = FALSE), "count")
 })
 
+test_that("i-prime default y-axis with denominator presence", {
+  # I' + med naevner -> procent (y/n er en andel); standard foerste auto-valg
+  expect_equal(decide_default_y_axis_ui_type("i'", n_present = TRUE), "percent")
+
+  # I' + uden naevner -> tal (degenererer til standard i-kort)
+  expect_equal(decide_default_y_axis_ui_type("i'", n_present = FALSE), "count")
+
+  # Oevrige korttyper paavirkes ikke af naevner-tilstedevaerelse
+  expect_equal(decide_default_y_axis_ui_type("i", n_present = TRUE), "count")
+  expect_equal(decide_default_y_axis_ui_type("c", n_present = TRUE), "count")
+})
+
 # =============================================================================
 # SEKTION 3: Y-AXIS MODEL (fra test-y-axis-model.R)
 # Tests for determine_internal_class() og suggest_chart_type()


### PR DESCRIPTION
## Summary
Når **I′-kort** vælges og der allerede er angivet **både tæller (y) og nævner (n)**, sættes y-akse-enheden automatisk til **procent** (y/n er en andel) som første automatiserede valg. Er der kun en tæller → enheden forbliver **tal**. Brugerens egne skift til rate/tal **respekteres**.

## Adfærd (kravspec)
| Situation | Y-akse auto |
|---|---|
| i′ + tæller + nævner | **procent** (default) |
| i′ + kun tæller | tal |
| Bruger skifter selv til rate/tal (m. nævner) | respekteres |

## Hvordan
- `decide_default_y_axis_ui_type()` (pure, allerede tested for run): udvidet med i′ → `(run|i') + n → percent`, ellers count.
- `update_ui_for_chart_type()`: i′-grenen kalder den pure funktion (DRY) i stedet for `chart_type_to_ui_type()` (som gav "count" for i′).
- **Override-respekt er gratis:** auto-set-observeren fyrer kun ved `chart_type`-skift, ikke ved manuelt `y_axis_unit`-valg → brugervalg overskrives ikke.

## Test plan
- [x] 171 y-axis-tests grønne; nye: `decide_default_y_axis_ui_type("i'", n=TRUE)=="percent"`, `n=FALSE=="count"`, øvrige typer upåvirkede
- [ ] Manuel UI-test: vælg i′ med nævner → procent; uden → tal; manuelt skift respekteres
- [ ] **Ingen version-bump** (afventer test; NEWS under `(development)`)

## Noter
- Separat fra #842 (pp/up/mr-eksponering). Bygger på i′ fra #840 (allerede i develop).
- Data-load-auto-set (`utils_server_events_ui.R`) er run-only by design; i′ håndteres ved diagramtype-valg (path 1).