### PR TITLE
fix(check): escape em-dash i export-message-strenge (unblock develop→master)

### DIFF
--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -213,7 +213,7 @@ build_export_plot <- function(app_state, title_input, dept_input,
   if (y_col %in% names(current_data) && all(is.na(current_data[[y_col]]))) {
     log_warn(
       .context = "EXPORT_MODULE",
-      message = "build_export_plot: y_col all-NA — venter paa gyldig kolonnemapping",
+      message = "build_export_plot: y_col all-NA \u2014 venter paa gyldig kolonnemapping",
       details = list(chart_type = chart_type, y_col = y_col)
     )
     return(NULL)
@@ -224,7 +224,7 @@ build_export_plot <- function(app_state, title_input, dept_input,
     all(is.na(current_data[[mappings_n_column]]))) {
     log_warn(
       .context = "EXPORT_MODULE",
-      message = "build_export_plot: n_col all-NA — venter paa gyldig kolonnemapping",
+      message = "build_export_plot: n_col all-NA \u2014 venter paa gyldig kolonnemapping",
       details = list(chart_type = chart_type, n_col = mappings_n_column)
     )
     return(NULL)


### PR DESCRIPTION
## Problem
"Promote develop to master" (#844) fejler på R-CMD-check: **non-ASCII WARNING** (gate behandler warnings som fejl). `utils_export_helpers.R` har rå em-dash (U+2014) i to `message`-strenge (linje 216, 227).

Med `Encoding: UTF-8` tillader R CMD check non-ASCII i **kommentarer**, men ikke i kode/strenge. Det var eneste fil med streng-non-ASCII → eneste flag.

## Fix
Em-dash → `—` i de to strenge (renderer identisk). Kommentar-linje 211 (e-acute) uændret — tilladt i kommentarer.

## Verifikation
- [x] `parse()` OK; streng renderer identisk
- [x] Ingen non-ASCII i strenge tilbage
- [ ] CI R-CMD-check grøn → #844 kan passere

Pre-existing tech-debt der blokerede promoten — ikke fra de seneste feature-merges.