### PR TITLE
fix(deploy): inkluder pbcharts i Connect-manifest for i'/Laney-charts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -75,11 +75,13 @@ Suggests:
     ggrepel,
     hms,
     lintr (>= 3.0.0),
-    pkgload (>= 1.3.0)
+    pkgload (>= 1.3.0),
+    pbcharts (>= 0.1.0)
 Config/testthat/edition: 3
-Config/Notes: qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
+Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for i'/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
 Remotes: johanreventlow/BFHcharts@v0.24.0,
     johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
-    johanreventlow/BFHchartsAssets@v0.1.2
+    johanreventlow/BFHchartsAssets@v0.1.2,
+    anhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f
 Config/roxygen2/version: 8.0.0

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -275,6 +275,12 @@ reset_qic_performance_counters <- function() {
 .onAttach <- function(libname, pkgname) {
   bfhllm_status <- if (requireNamespace("BFHllm", quietly = TRUE)) "tilg\u00e6ngelig" else "ikke installeret"
   qic_status <- if (requireNamespace("qicharts2", quietly = TRUE)) "tilg\u00e6ngelig" else "ikke installeret"
+  # pbcharts kraeves af BFHcharts for i'/i-prime + Laney P'/U'-charts, som er
+  # eksponeret som foersteklasses chart-typer i dropdownen. Den eksplicitte
+  # requireNamespace-reference goer desuden pakken synlig for rsconnect's
+  # dependency-scanner, saa den medtages i Connect-manifestet (uden en
+  # kode-reference scanner rsconnect den ikke, selvom den staar i Suggests).
+  pbcharts_status <- if (requireNamespace("pbcharts", quietly = TRUE)) "tilg\u00e6ngelig" else "ikke installeret"
   quarto_status <- if (nzchar(Sys.which("quarto"))) "tilg\u00e6ngelig" else "ikke fundet i PATH"
 
   analytics_cfg <- resolve_analytics_config()
@@ -282,6 +288,7 @@ reset_qic_performance_counters <- function() {
     "biSPCharts optional features: ",
     "BFHllm=", bfhllm_status, ", ",
     "qicharts2=", qic_status, ", ",
+    "pbcharts=", pbcharts_status, ", ",
     "Quarto=", quarto_status, "\n",
     "Analytics: shinylogs=", if (analytics_cfg$enabled) "aktiv" else "inaktiv",
     " (kilde: ", analytics_cfg$source, ")"

--- a/dev/validate_connect_manifest.R
+++ b/dev/validate_connect_manifest.R
@@ -84,6 +84,11 @@ main <- function() {
   failures <- character(0)
   checked <- character(0)
   semver_tag_pattern <- "^v[0-9]+\\.[0-9]+\\.[0-9]+$"
+  # Fuld 40-char commit-SHA. Immutable -> deploy-stabil for tredjeparts-repos
+  # vi ikke kan tagge (jf. exemption nedenfor + issue #445).
+  full_sha_pattern <- "^[0-9a-f]{40}$"
+  # Vores egne sibling-pakker: vi kontrollerer tags -> kraev vX.Y.Z.
+  sibling_org_prefix <- "johanreventlow/"
 
   # Cycle 9 (maturity-audit Codex 2026-05-10): Forbidden file-pattern denylist.
   # release-tarball-audit forbyder allerede .DS_Store i tarball, men dette gate
@@ -115,11 +120,28 @@ main <- function() {
     dep_row <- deps[deps$package == remote$package, ]
     is_required_import <- remote$package %in% imports$package
 
-    if (!is.na(remote$ref) && !grepl(semver_tag_pattern, remote$ref)) {
-      failures <- c(failures, sprintf(
-        "%s ref er ikke vX.Y.Z-tag: DESCRIPTION Remotes=%s (feature-branches og SHA er ikke deploy-stabile, jf. issue #445)",
-        remote$package, remote$ref
-      ))
+    # Ref-stabilitetskrav afhaenger af repo-ejerskab (issue #445 ramte en
+    # MUTABEL feature-branch-ref, ikke immutable SHA'er):
+    #   - Egne siblings (johanreventlow/*): kraev vX.Y.Z-tag. Vi kontrollerer
+    #     deres tags, og tag-pinning er VERSIONING_POLICY-konventionen.
+    #   - Tredjeparts (fx anhoej/pbcharts): utagget upstream vi ikke kan tagge.
+    #     En fuld 40-char SHA er immutable og dermed lige saa deploy-stabil som
+    #     et tag. Branch-navne afvises stadig (de er mutable, kernen i #445).
+    is_sibling <- startsWith(remote$repo, sibling_org_prefix)
+    if (!is.na(remote$ref)) {
+      if (is_sibling && !grepl(semver_tag_pattern, remote$ref)) {
+        failures <- c(failures, sprintf(
+          "%s ref er ikke vX.Y.Z-tag: DESCRIPTION Remotes=%s (feature-branches er ikke deploy-stabile for egne siblings, jf. issue #445)",
+          remote$package, remote$ref
+        ))
+      } else if (!is_sibling &&
+                 !grepl(semver_tag_pattern, remote$ref) &&
+                 !grepl(full_sha_pattern, remote$ref)) {
+        failures <- c(failures, sprintf(
+          "%s ref er hverken vX.Y.Z-tag eller fuld 40-char SHA: DESCRIPTION Remotes=%s (branch-refs er ikke deploy-stabile for tredjeparts-pakker, jf. issue #445)",
+          remote$package, remote$ref
+        ))
+      }
     }
 
     if (is.null(pkg_desc)) {
@@ -144,12 +166,26 @@ main <- function() {
       ))
     }
 
+    # Ref-match: ved SHA-pin (tredjeparts) registrerer remotes-install ofte
+    # RemoteRef=HEAD mens den immutable SHA staar i RemoteSha/GithubSHA1.
+    # Sammenlign derfor DESCRIPTION-SHA mod manifest-SHA, ikke mod RemoteRef.
     manifest_ref <- pkg_desc$GithubRef %||% pkg_desc$RemoteRef
-    if (!is.na(remote$ref) && !identical(manifest_ref, remote$ref)) {
-      failures <- c(failures, sprintf(
-        "%s ref mismatch: DESCRIPTION Remotes=%s, manifest=%s",
-        remote$package, remote$ref, manifest_ref
-      ))
+    manifest_sha <- pkg_desc$GithubSHA1 %||% pkg_desc$RemoteSha
+    ref_is_sha <- !is.na(remote$ref) && grepl(full_sha_pattern, remote$ref)
+    if (!is.na(remote$ref)) {
+      if (ref_is_sha) {
+        if (!identical(manifest_sha, remote$ref)) {
+          failures <- c(failures, sprintf(
+            "%s SHA mismatch: DESCRIPTION Remotes=%s, manifest RemoteSha=%s",
+            remote$package, remote$ref, manifest_sha %||% "(mangler)"
+          ))
+        }
+      } else if (!identical(manifest_ref, remote$ref)) {
+        failures <- c(failures, sprintf(
+          "%s ref mismatch: DESCRIPTION Remotes=%s, manifest=%s",
+          remote$package, remote$ref, manifest_ref
+        ))
+      }
     }
 
     if (nrow(dep_row) > 0) {

--- a/manifest.json
+++ b/manifest.json
@@ -2494,6 +2494,41 @@
         "Built": "R 4.6.0; ; 2026-04-25 15:39:31 UTC; unix"
       }
     },
+    "pbcharts": {
+      "Source": "github",
+      "Repository": null,
+      "description": {
+        "Package": "pbcharts",
+        "Title": "Process Behaviour Charts",
+        "Version": "0.1.0",
+        "Authors@R": "\n    person(\"Jacob\", \"Anhøj\", , \"jacob@anhoej.net\", role = c(\"aut\", \"cre\"))",
+        "Description": "Run charts and individuals control charts for statistical quality\n    control and improvement. Control limits accommodate varying subgroup sizes\n    as suggested by Taylor (2017)\n    <https://variation.com/normalized-individuals-control-chart/> making \n    `pbcharts` useful for a wide range of measurement and count data and a\n    convenient replacement for classic Shewhart control charts.",
+        "URL": "https://github.com/anhoej/pbcharts",
+        "License": "MIT + file LICENSE",
+        "Encoding": "UTF-8",
+        "Roxygen": "list(markdown = TRUE)",
+        "RoxygenNote": "7.3.3",
+        "Depends": "R (>= 3.5)",
+        "LazyData": "true",
+        "Suggests": "testthat (>= 3.0.0)",
+        "Config/testthat/edition": "3",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "pbcharts",
+        "RemoteUsername": "anhoej",
+        "RemoteRef": "HEAD",
+        "RemoteSha": "d37a8ec1864528ece1f5cd60ac152d06c013515f",
+        "GithubRepo": "pbcharts",
+        "GithubUsername": "anhoej",
+        "GithubRef": "HEAD",
+        "GithubSHA1": "d37a8ec1864528ece1f5cd60ac152d06c013515f",
+        "NeedsCompilation": "no",
+        "Packaged": "2026-06-08 14:12:12 UTC; johanreventlow",
+        "Author": "Jacob Anhøj [aut, cre]",
+        "Maintainer": "Jacob Anhøj <jacob@anhoej.net>",
+        "Built": "R 4.6.0; ; 2026-06-08 14:12:13 UTC; unix"
+      }
+    },
     "pillar": {
       "Source": "CRAN",
       "Repository": "https://cloud.r-project.org",
@@ -4184,7 +4219,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "36b624c8d59c9f1aa9a8ca5bb26cc397"
+      "checksum": "d81029d9c0653dcb0562969d5c6759ea"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4754,7 +4789,7 @@
       "checksum": "0863dc7a47fc3e1c6e4528a6dcd40593"
     },
     "R/zzz.R": {
-      "checksum": "8af6a97ee8d87cbefd81882e728c7667"
+      "checksum": "73a9c7bdd9db7cc421b1890f057675d2"
     }
   },
   "users": null


### PR DESCRIPTION
## Summary

Connect Cloud-deploy installerede ikke `pbcharts` → i'/i-prime + Laney P'/U'-charts fejlede runtime med `pbcharts is required for the i-prime (i') chart type`. pbcharts er kun i BFHcharts' Suggests (GitHub-only `anhoej/pbcharts`), så Connect trak den ikke med.

**Root cause:** rsconnect's dependency-scanner medtager kun pakker der refereres i kode eller står i app'ens egen DESCRIPTION. pbcharts stod ingen af stederne → manglede i manifest `packages` → ikke installeret på Connect. (BFHllm m.fl. kommer med fordi koden kalder `BFHllm::` direkte.)

## Changes

- **DESCRIPTION:** `pbcharts` i Suggests + Remotes (`anhoej/pbcharts@<sha>`), mirror af BFHllm-mønstret. biSPCharts ejer sin deploy-dep da i'/Laney er førsteklasses chart-typer.
- **R/zzz.R:** `requireNamespace("pbcharts")` i `.onAttach`-statuslinjen, så rsconnect-scanneren ser pakken (uden kode-reference medtages den ikke — verificeret empirisk).
- **manifest.json:** regenereret, pbcharts nu github-source med pinnet SHA.
- **dev/validate_connect_manifest.R:** tillad fuld 40-char SHA for tredjeparts-repos (ikke `johanreventlow/*`). Issue #445 ramte en *mutabel* feature-branch-ref; en immutable SHA er lige så deploy-stabil som et tag. Egne siblings skal fortsat bruge vX.Y.Z-tags. Branch-navne + korte SHA'er afvises stadig.

## Test plan

- [x] `validate_connect_manifest.R` passerer med pbcharts inkluderet
- [x] Negative-test: branch-refs + sibling-SHA + korte SHA'er afvises stadig (7 cases korrekte)
- [x] i-prime render OK lokalt (`compute_spc_results_bfh(chart_type="i'")` → has_plot=TRUE)
- [x] pbcharts lander i manifest `packages` (github-source, SHA d37a8ec)
- [ ] Verificér på Connect Cloud-deploy at i'/Laney-charts renderer