### PR TITLE
feat(i-prime): default til rate naar pooled centerline overstiger 100%

### DIFF
--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -228,8 +228,25 @@ update_ui_for_chart_type <- function(transition, ct, input, session, app_state,
       # (med naevner -> procent, ellers tal). Bruger-override respekteres, da
       # denne observer kun fyrer ved chart_type-skift, ikke ved manuelt
       # y_axis_unit-valg.
-      n_present <- has_input_value(get_n_column(app_state))
-      desired_ui <- decide_default_y_axis_ui_type(qic_ct, n_present)
+      n_col <- get_n_column(app_state)
+      n_present <- has_input_value(n_col)
+      # Hent tæller/nævner-data saa default kan skifte til rate naar den pooled
+      # centerline overstiger 100% (da er serien en rate, ikke en andel).
+      y_vec <- NULL
+      n_vec <- NULL
+      if (isTRUE(n_present)) {
+        current_data <- shiny::isolate(app_state$data$current_data)
+        y_col <- get_y_column(app_state)
+        cols_available <- !is.null(current_data) &&
+          has_input_value(y_col) &&
+          y_col %in% names(current_data) &&
+          n_col %in% names(current_data)
+        if (cols_available) {
+          y_vec <- current_data[[y_col]]
+          n_vec <- current_data[[n_col]]
+        }
+      }
+      desired_ui <- decide_default_y_axis_ui_type(qic_ct, n_present, y = y_vec, n = n_vec)
     } else {
       # Brug ct (original) ikke qic_ct, saa "t" matches direkte i
       # chart_type_to_ui_type() -- get_qic_chart_type("t") fallbacker

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -93,6 +93,39 @@ suggest_chart_type <- function(internal_class, n_present = FALSE, n_points = NA_
   return("run")
 }
 
+#' Afgør om en proportions-centerline overstiger 100%
+#'
+#' For I'- og run-kort med naevner plottes per-punkt-andelen y/n. Centerlinjen
+#' er den pooled andel `sum(tæller)/sum(nævner)` (samme som pbcharts beregner
+#' via `weighted.mean(y, den)` i `pbc.i`). Naar denne overstiger 1.0 (100%) er
+#' serien ikke en andel men en rate (haendelser pr. enhed, kan overstige 1),
+#' og "procent" giver et misvisende default.
+#'
+#' @param y Numeric/character vektor – tæller-kolonne (parses defensivt).
+#' @param n Numeric/character vektor – nævner-kolonne.
+#' @return Logical(1). TRUE hvis pooled centerline > 1. FALSE ved manglende
+#'   data, nul/negativ samlet nævner eller NULL-input (saa default forbliver
+#'   procent — konservativt).
+#' @keywords internal
+#' @noRd
+proportion_centerline_exceeds_unity <- function(y, n) {
+  if (is.null(y) || is.null(n) || length(y) == 0L || length(n) == 0L) {
+    return(FALSE)
+  }
+  y_num <- suppressWarnings(as.numeric(y))
+  n_num <- suppressWarnings(as.numeric(n))
+  ok <- !is.na(y_num) & !is.na(n_num) & n_num > 0
+  if (!any(ok)) {
+    return(FALSE)
+  }
+  den_sum <- sum(n_num[ok])
+  if (!is.finite(den_sum) || den_sum <= 0) {
+    return(FALSE)
+  }
+  cl <- sum(y_num[ok]) / den_sum
+  is.finite(cl) && cl > 1
+}
+
 #' Vælg default Y-akse UI-type ud fra kontekst
 #'
 #' Særligt for run chart ønsker vi:
@@ -100,15 +133,27 @@ suggest_chart_type <- function(internal_class, n_present = FALSE, n_points = NA_
 #' - Hvis kun tæller: default = count
 #' Brugeren kan altid overskrive.
 #'
+#' For I'- og run-kort med nævner gælder desuden: hvis den pooled centerline
+#' (`sum(tæller)/sum(nævner)`) overstiger 100%, er serien reelt en rate, ikke
+#' en andel → default = rate i stedet for percent. Kræver at `y` og `n` gives;
+#' uden dem bevares den hidtidige procent-default (bagudkompatibelt).
+#'
 #' @param chart_type qicharts2-kode for korttype (fx "run")
 #' @param n_present Logical – om N-kolonne er valgt
-#' @return "percent" eller "count"
+#' @param y Numeric/character vektor – tæller-kolonne (valgfri). Bruges kun til
+#'   centerline-tjek for run/i'-kort med nævner.
+#' @param n Numeric/character vektor – nævner-kolonne (valgfri).
+#' @return "percent", "rate" eller "count"
 #' @keywords internal
-decide_default_y_axis_ui_type <- function(chart_type, n_present) {
+decide_default_y_axis_ui_type <- function(chart_type, n_present, y = NULL, n = NULL) {
   ct <- get_qic_chart_type(chart_type)
   # Run og I-prime: med naevner plottes en andel (y/n) -> default procent.
   # Uden naevner -> tal. Brugeren kan altid overskrive.
   if (ct %in% c("run", "i'") && isTRUE(n_present)) {
+    # Andel > 100% i centerlinjen => det er en rate, ikke en procent.
+    if (proportion_centerline_exceeds_unity(y, n)) {
+      return("rate")
+    }
     return("percent")
   }
   return("count")

--- a/tests/testthat/test-y-axis-scaling-overhaul.R
+++ b/tests/testthat/test-y-axis-scaling-overhaul.R
@@ -399,6 +399,58 @@ test_that("i-prime default y-axis with denominator presence", {
   expect_equal(decide_default_y_axis_ui_type("c", n_present = TRUE), "count")
 })
 
+test_that("i-prime/run skifter default til rate naar pooled centerline > 100%", {
+  # Centerline = sum(taeller)/sum(naevner). cl = 135/300 = 0.45 <= 1 -> procent.
+  y_andel <- c(40, 50, 45)
+  n_andel <- c(100, 100, 100)
+  expect_equal(
+    decide_default_y_axis_ui_type("i'", n_present = TRUE, y = y_andel, n = n_andel),
+    "percent"
+  )
+
+  # cl = 525/300 = 1.75 > 1 -> rate (taeller overstiger naevner i gennemsnit)
+  y_rate <- c(150, 200, 175)
+  n_rate <- c(100, 100, 100)
+  expect_equal(
+    decide_default_y_axis_ui_type("i'", n_present = TRUE, y = y_rate, n = n_rate),
+    "rate"
+  )
+
+  # Samme regel gaelder run-kort med naevner
+  expect_equal(
+    decide_default_y_axis_ui_type("run", n_present = TRUE, y = y_rate, n = n_rate),
+    "rate"
+  )
+
+  # Uden y/n-data -> bagudkompatibel procent-default (intet centerline-tjek)
+  expect_equal(decide_default_y_axis_ui_type("i'", n_present = TRUE), "percent")
+})
+
+test_that("proportion_centerline_exceeds_unity haandterer edge cases robust", {
+  # Pooled (ikke mean-of-ratios): vaegtning efter naevner som pbcharts
+  # weighted.mean(y, den). cl = sum(y)/sum(n).
+  expect_false(proportion_centerline_exceeds_unity(c(100, 100), c(100, 100)))
+  expect_true(proportion_centerline_exceeds_unity(c(120, 100), c(100, 100)))
+
+  # Pooled vs mean-of-ratios divergerer ved varierende naevner: store naevnere
+  # vejer tungere. y=c(10,300) n=c(10,100): pooled=310/110=2.82>1 (rate),
+  # mean-of-ratios=(1.0+3.0)/2=2.0. Begge > 1 her, men pooled er det korrekte
+  # (matcher pbcharts).
+  expect_true(proportion_centerline_exceeds_unity(c(10, 300), c(10, 100)))
+
+  # NULL / tomme / NA / nul-naevner -> FALSE (konservativt: behold procent)
+  expect_false(proportion_centerline_exceeds_unity(NULL, NULL))
+  expect_false(proportion_centerline_exceeds_unity(numeric(0), numeric(0)))
+  expect_false(proportion_centerline_exceeds_unity(c(NA, NA), c(NA, NA)))
+  expect_false(proportion_centerline_exceeds_unity(c(150, 200), c(0, 0)))
+
+  # Character-input parses defensivt
+  expect_true(proportion_centerline_exceeds_unity(c("150", "200"), c("100", "100")))
+
+  # Delvis NA: kun gyldige raekker taeller (n>0, ikke-NA)
+  expect_true(proportion_centerline_exceeds_unity(c(150, NA, 200), c(100, 50, 100)))
+})
+
 # =============================================================================
 # SEKTION 3: Y-AXIS MODEL (fra test-y-axis-model.R)
 # Tests for determine_internal_class() og suggest_chart_type()


### PR DESCRIPTION
## Summary

I'-kort med nævner defaultede altid til **procent** når tæller+nævner var valgt. Men hvis den pooled centerline (`sum(tæller)/sum(nævner)`) overstiger 100%, er serien ikke en andel men en **rate** (hændelser pr. enhed, kan overstige 1) — procent giver da et misvisende default.

## Hvorfor pooled centerline

Centerline-beregningen matcher pbcharts' egen i'-centerline: `pbc.i` bruger `weighted.mean(y, den)` = `sum(num)/sum(den)` (pooled proportion). Ny regel: `cl > 1.0` → rate, ellers procent.

## Changes

- `decide_default_y_axis_ui_type()` får valgfri `y`/`n`-args; uden dem bevares hidtidig procent-default (bagudkompatibelt). Reglen gælder både `i'` og `run`.
- Ny pure helper `proportion_centerline_exceeds_unity()` — defensiv mod NA, nul-nævner, character-input; konservativ `FALSE` ved manglende data (behold procent).
- i'-observeren i `utils_server_events_chart.R` henter tæller/nævner fra `app_state` og videregiver til default-beslutningen.

Brugeren kan altid overskrive — observeren fyrer kun ved chart-type-skift.

## Afhængighed

i'-charts kræver `pbcharts` på deploy → afhænger af #849 (pbcharts i Connect-manifest) for at virke i produktion. Logikken her er uafhængig og testbar uden #849 (pbcharts er installeret lokalt).

## Test plan

- [x] `cl <= 100%` → percent; `cl > 100%` → rate (i' + run)
- [x] Pooled vægtning verificeret (ikke mean-of-ratios)
- [x] Edge cases: NULL/tom/NA/nul-nævner/character-input → konservativ FALSE
- [x] i' + rate renderer end-to-end (`has_plot=TRUE`)
- [x] 255 PASS i y-axis + chart-events + integration-suiter, 0 FAIL
- [ ] Manuel UI-verifikation: skift til i' med tæller>nævner → rate forvælges