### PR TITLE
fix(check): ret 2 release-gate-WARNINGs (non-ASCII string + stale Rd)

### DIFF
--- a/R/utils_export_helpers.R
+++ b/R/utils_export_helpers.R
@@ -208,7 +208,7 @@ build_export_plot <- function(app_state, title_input, dept_input,
   )
 
   # Pre-flight: kolonner med kun NA-vaerdier => BFHcharts fejler nedenfor.
-  # Returnér NULL; mod_export_server.R:211 viser "Ingen graf tilgaengeligt".
+  # Returner NULL; mod_export_server.R:211 viser "Ingen graf tilgaengeligt".
   current_data <- app_state$data$current_data
   if (y_col %in% names(current_data) && all(is.na(current_data[[y_col]]))) {
     log_warn(
@@ -240,7 +240,7 @@ build_export_plot <- function(app_state, title_input, dept_input,
     NULL
   } else {
     # PDF: instruktiv default-titel
-    "Skriv en kort titel, eller tilføj en konklusion,\n**der tydeligt opsummerer, hvad grafen fortæller**"
+    "Skriv en kort titel, eller tilf\u00f8j en konklusion,\n**der tydeligt opsummerer, hvad grafen fort\u00e6ller**"
   }
 
   # Regenerate plot with context-specific dimensions

--- a/man/decide_default_y_axis_ui_type.Rd
+++ b/man/decide_default_y_axis_ui_type.Rd
@@ -4,15 +4,20 @@
 \alias{decide_default_y_axis_ui_type}
 \title{Vælg default Y-akse UI-type ud fra kontekst}
 \usage{
-decide_default_y_axis_ui_type(chart_type, n_present)
+decide_default_y_axis_ui_type(chart_type, n_present, y = NULL, n = NULL)
 }
 \arguments{
 \item{chart_type}{qicharts2-kode for korttype (fx "run")}
 
 \item{n_present}{Logical – om N-kolonne er valgt}
+
+\item{y}{Numeric/character vektor – tæller-kolonne (valgfri). Bruges kun til
+centerline-tjek for run/i'-kort med nævner.}
+
+\item{n}{Numeric/character vektor – nævner-kolonne (valgfri).}
 }
 \value{
-"percent" eller "count"
+"percent", "rate" eller "count"
 }
 \description{
 Særligt for run chart ønsker vi:
@@ -21,5 +26,11 @@ Særligt for run chart ønsker vi:
 \item Hvis kun tæller: default = count
 Brugeren kan altid overskrive.
 }
+}
+\details{
+For I'- og run-kort med nævner gælder desuden: hvis den pooled centerline
+(\code{sum(tæller)/sum(nævner)}) overstiger 100\%, er serien reelt en rate, ikke
+en andel → default = rate i stedet for percent. Kræver at \code{y} og \code{n} gives;
+uden dem bevares den hidtidige procent-default (bagudkompatibelt).
 }
 \keyword{internal}


### PR DESCRIPTION
## Summary

develop→master release-gaten (#851, `rcmdcheck error_on="warning"`) fejlede på to WARNINGs som normal develop-push-CI ikke fanger:

1. **non-ASCII i R-kode** (`utils_export_helpers.R`): PDF-default-titlen havde direkte `ø`/`æ` i en string-literal (introduceret i #847). R CMD check kræver ASCII i kode (kommentarer tolereres). Escaped til `ø`/`æ` — runtime-teksten er uændret (verificeret: `tilføj`/`fortæller` renderer korrekt).
2. **Codoc-mismatch** (`decide_default_y_axis_ui_type.Rd`): #852 tilføjede `y`/`n`-args uden `devtools::document()`. Regenereret kun den relevante Rd (develop's øvrige `man/` er kronisk usynket — urelaterede ændringer holdt ude for minimal impact).

Begge er regressioner fra nyligt mergede PRs (#847, #852).

## Hvorfor kun disse 2

Release-gaten gav præcis 2 WARNINGs + 2 NOTEs. NOTEs (NEWS `(development)`-version, svglite Imports-not-used, `BFHtheme:::`-kald) fejler ikke under `error_on="warning"` og røres ikke. Comment-non-ASCII (udbredt i kodebasen) tolereres af R CMD check — kun string-literal-non-ASCII flagges.

## Test plan

- [x] `tools::showNonASCIIfile("R/utils_export_helpers.R")` → tom
- [x] String-literal evaluerer til korrekt dansk tekst (`tilføj`/`fortæller`)
- [x] `.Rd` usage matcher funktionssignatur (`chart_type, n_present, y = NULL, n = NULL`)
- [ ] Release-gate (#851) grøn efter merge til develop