### PR TITLE
chore(ci): reducer artifact-storage (failure-only + lavere retention)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -207,4 +207,4 @@ jobs:
           name: release-gate-check-output
           path: biSPCharts.Rcheck/
           if-no-files-found: ignore
-          retention-days: 7
+          retention-days: 5

--- a/.github/workflows/shinytest2.yaml
+++ b/.github/workflows/shinytest2.yaml
@@ -76,11 +76,14 @@ jobs:
         shell: Rscript {0}
 
       - name: Upload screenshots and snapshot diffs
-        if: always()
+        # Kun ved failure: snapshot-diffs er kun relevante naar visual-regression
+        # fejler. Tidligere always() uploadede snapshots paa hvert groent run
+        # -> unoedig Actions-storage.
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: shinytest2-snapshots
-          retention-days: 7
+          retention-days: 5
           path: |
             tests/testthat/**/_snaps/
             tests/testthat/**/*-new.png

--- a/.github/workflows/skip-inventory.yaml
+++ b/.github/workflows/skip-inventory.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: skip-inventory
-          retention-days: 7
+          retention-days: 5
           path: |
             dev/audit-output/skip-inventory.json
             dev/audit-output/skip-inventory.md


### PR DESCRIPTION
## Baggrund

GitHub-kontoen nåede 100% af inkluderet Actions-storage. Engangs-oprydning af eksisterende artifacts (~247 MB på tværs af biSPCharts/BFHtheme/BFHcharts/BFHllm) er allerede udført. Denne PR forhindrer gentagelse.

## Ændringer

- **shinytest2:** `if: always()` → `if: failure()` — snapshot-diffs uploades nu kun når visual-regression fejler (før: også på hvert grønt nightly-run).
- **retention-days 7 → 5** på de eksplicitte uploads (R-CMD-check release-gate, shinytest2, skip-inventory).

## ⚠️ [MANUELT TRIN] — primær recurrence-fix

De største artifacts (`Linux-X64-r-0-results`, ~38 MB) uploades af `r-lib/actions/check-r-package` ved failure og bruger **repo-default-retention (90 dage)**, som ikke kan cappes i workflow-kaldet.

**Sæt repo-default ned manuelt** (per repo: biSPCharts, BFHtheme, BFHcharts, BFHllm):
`Settings → Actions → General → "Artifact and log retention" → 5 dage`

Dette er den eneste lever for de 38 MB check-dumps og har størst effekt.

## Test plan

- [x] Workflow-syntaks uændret bortset fra `if:`/`retention-days`
- [ ] Næste nightly shinytest2-run uploader IKKE snapshots ved success
- [ ] [MANUELT] repo-default-retention sat til 5 dage på alle 4 repos