### PR TITLE
chore(deps): adapt to BFHcharts 0.25.0 i-prime rename (i' -> ip)

### DIFF
--- a/.github/workflows/skip-inventory.yaml
+++ b/.github/workflows/skip-inventory.yaml
@@ -137,6 +137,10 @@ jobs:
 
       - name: Upload skip inventory artifact
         uses: actions/upload-artifact@v4
+        # Artifact-upload er bekvemmelighed (inspektion), ikke en gate. En
+        # account-bred artifact-storage-quota maa ikke faelde audit-jobbet --
+        # den reelle gate er "Fail if TODO-skips increased" nedenfor.
+        continue-on-error: true
         with:
           name: skip-inventory
           retention-days: 7

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.24.0),
+    BFHcharts (>= 0.25.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -78,8 +78,8 @@ Suggests:
     pkgload (>= 1.3.0),
     pbcharts (>= 0.1.0)
 Config/testthat/edition: 3
-Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for i'/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.24.0,
+Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
+Remotes: johanreventlow/BFHcharts@v0.25.0,
     johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # biSPCharts (development)
 
+## Interne ændringer
+
+* **Tilpasset BFHcharts 0.25.0: I-prime-kortets `chart_type`-værdi omdøbt
+  fra `"i'"` til `"ip"`.** Følger BFHcharts' breaking change der harmoniserer
+  prime-kortenes navngivning (`pp`, `up`, `ip`). De danske UI-labels
+  (I′-kort) er uændrede; kun den interne kode-værdi der sendes til
+  `bfh_qic()` er ændret. Kræver BFHcharts (>= 0.25.0).
+
 ## Nye features
 
 * **Grupperet diagramtype-dropdown.** Diagramtype-vælgeren er nu inddelt i

--- a/R/config_chart_type_groups.R
+++ b/R/config_chart_type_groups.R
@@ -3,11 +3,11 @@
 # ==============================================================================
 # Grupperet diagramtype-dropdown med progressiv disclosure i tre kategorier.
 # Samme korttype kan optraede i flere grupper, saa hver option har en UNIK
-# alias-value (fx "i'__dt") for at undgaa at selectize.js deduperer paa value.
+# alias-value (fx "ip__dt") for at undgaa at selectize.js deduperer paa value.
 # get_qic_chart_type() stripper aliaset tilbage til den rene qicharts2-kode
 # (se config_chart_types.R: sub("__.*$", "", ...)).
 #
-#   Standardvalg              -> simple valg (run + anbefalet kontrolkort = i')
+#   Standardvalg              -> simple valg (run + anbefalet kontrolkort = ip)
 #   Udvidede kontrolkortvalg  -> datatype-drevne labels (skjuler kort-navnet)
 #   Avanceret kontrolkortvalg -> alle korttyper ved navn
 # ==============================================================================
@@ -22,17 +22,17 @@
 CHART_TYPE_GROUPS <- list(
   "Standardvalg" = list(
     "Seriediagram \u2013 udvikling over tid" = "run",
-    "Kontrolkort \u2013 vurdering af variation" = "i'__ctrl"
+    "Kontrolkort \u2013 vurdering af variation" = "ip__ctrl"
   ),
   "Udvidede kontrolkortvalg" = list(
-    "Enkeltm\u00e5linger/v\u00e6rdier \u2013 fx ventetid, blodtryk, score" = "i'__dt",
+    "Enkeltm\u00e5linger/v\u00e6rdier \u2013 fx ventetid, blodtryk, score" = "ip__dt",
     "Procent/andele \u2013 fx andel med komplikation" = "pp__dt",
     "Rater \u2013 fx h\u00e6ndelser pr. 1000 patientdage" = "up__dt",
     "Antal/t\u00e6llinger \u2013 fx antal fald pr. m\u00e5ned" = "c__dt"
   ),
   "Avanceret kontrolkortvalg" = list(
     "I-kort \u2013 enkeltm\u00e5linger" = "i",
-    "I'-kort \u2013 enkeltm\u00e5linger, varierende n\u00e6vner" = "i'",
+    "I'-kort \u2013 enkeltm\u00e5linger, varierende n\u00e6vner" = "ip",
     "P-kort \u2013 andele" = "p",
     "P'-kort \u2013 andele, standardiseret" = "pp",
     "U-kort \u2013 rater" = "u",

--- a/R/config_chart_types.R
+++ b/R/config_chart_types.R
@@ -29,7 +29,7 @@
 CHART_TYPES_DA <- list(
   "Seriediagram (Run) \u2014 data over tid" = "run",
   "I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)" = "i",
-  "I\u2032-kort \u2014 individuelle m\u00e5linger med varierende n\u00e6vner" = "i'",
+  "I\u2032-kort \u2014 individuelle m\u00e5linger med varierende n\u00e6vner" = "ip",
   "MR-kort \u2014 variation mellem m\u00e5linger" = "mr",
   "P-kort \u2014 andele/procenter (fx infektionsrate)" = "p",
   "P\u2032-kort \u2014 andele/procenter, standardiseret" = "pp",
@@ -44,7 +44,7 @@ CHART_TYPES_DA <- list(
 CHART_TYPES_EN <- list(
   "run" = "run",
   "i" = "i",
-  "i'" = "i'",
+  "ip" = "ip",
   "mr" = "mr",
   "p" = "p",
   "pp" = "pp",
@@ -78,7 +78,7 @@ get_qic_chart_type <- function(danish_selection) {
     return("run") # standard
   }
 
-  # MVP grouped-dropdown: strip alias-suffix (fx "i'__dt"/"pp__dt" -> "i'"/"pp").
+  # MVP grouped-dropdown: strip alias-suffix (fx "ip__dt"/"pp__dt" -> "ip"/"pp").
   # Ingen rigtig kode/label indeholder "__", saa dette er en no-op for dem.
   danish_selection <- sub("__.*$", "", danish_selection)
 
@@ -109,7 +109,7 @@ get_qic_chart_type <- function(danish_selection) {
 CHART_TYPE_DESCRIPTIONS <- list(
   "run" = "Seriediagram der viser data over tid med median centerlinje",
   "i" = "I-kort til individuelle m\u00e5linger",
-  "i'" = "I\u2032-kort til individuelle m\u00e5linger med n\u00e6vner-justerede kontrolgr\u00e6nser",
+  "ip" = "I\u2032-kort til individuelle m\u00e5linger med n\u00e6vner-justerede kontrolgr\u00e6nser",
   "mr" = "Moving Range kort til variabilitet mellem p\u00e5 hinanden f\u00f8lgende m\u00e5linger",
   "p" = "P-kort til andele og procenter",
   "pp" = "P'-kort til standardiserede andele",
@@ -134,6 +134,6 @@ chart_type_requires_denominator <- function(chart_type) {
   # Normaliser til qicharts2-kode
   ct <- get_qic_chart_type(chart_type)
 
-  # Naevner er relevant for run, p, pp, u, up, i'
-  return(ct %in% c("run", "p", "pp", "u", "up", "i'"))
+  # Naevner er relevant for run, p, pp, u, up, ip
+  return(ct %in% c("run", "p", "pp", "u", "up", "ip"))
 }

--- a/R/utils_server_events_chart.R
+++ b/R/utils_server_events_chart.R
@@ -223,7 +223,7 @@ update_ui_for_chart_type <- function(transition, ct, input, session, app_state,
   )
 
   if (!identical(qic_ct, "run")) {
-    if (identical(qic_ct, "i'")) {
+    if (identical(qic_ct, "ip")) {
       # I-prime: naevner-bevidst default via den pure decide_default_y_axis_ui_type
       # (med naevner -> procent, ellers tal). Bruger-override respekteres, da
       # denne observer kun fyrer ved chart_type-skift, ikke ved manuelt

--- a/R/utils_y_axis_model.R
+++ b/R/utils_y_axis_model.R
@@ -141,7 +141,7 @@ proportion_centerline_exceeds_unity <- function(y, n) {
 #' @param chart_type qicharts2-kode for korttype (fx "run")
 #' @param n_present Logical – om N-kolonne er valgt
 #' @param y Numeric/character vektor – tæller-kolonne (valgfri). Bruges kun til
-#'   centerline-tjek for run/i'-kort med nævner.
+#'   centerline-tjek for run/ip-kort med nævner.
 #' @param n Numeric/character vektor – nævner-kolonne (valgfri).
 #' @return "percent", "rate" eller "count"
 #' @keywords internal
@@ -149,7 +149,7 @@ decide_default_y_axis_ui_type <- function(chart_type, n_present, y = NULL, n = N
   ct <- get_qic_chart_type(chart_type)
   # Run og I-prime: med naevner plottes en andel (y/n) -> default procent.
   # Uden naevner -> tal. Brugeren kan altid overskrive.
-  if (ct %in% c("run", "i'") && isTRUE(n_present)) {
+  if (ct %in% c("run", "ip") && isTRUE(n_present)) {
     # Andel > 100% i centerlinjen => det er en rate, ikke en procent.
     if (proportion_centerline_exceeds_unity(y, n)) {
       return("rate")

--- a/R/utils_y_axis_scaling.R
+++ b/R/utils_y_axis_scaling.R
@@ -23,7 +23,7 @@ PROPORTION_CHART_TYPES <- c("p", "pp")
 
 #' Chart types that use absolute internal unit (no scaling)
 #' @keywords internal
-ABSOLUTE_CHART_TYPES <- c("c", "u", "up", "i", "mr", "g", "i'")
+ABSOLUTE_CHART_TYPES <- c("c", "u", "up", "i", "mr", "g", "ip")
 
 # LAYER 1: PARSING ============================================================
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -275,7 +275,7 @@ reset_qic_performance_counters <- function() {
 .onAttach <- function(libname, pkgname) {
   bfhllm_status <- if (requireNamespace("BFHllm", quietly = TRUE)) "tilg\u00e6ngelig" else "ikke installeret"
   qic_status <- if (requireNamespace("qicharts2", quietly = TRUE)) "tilg\u00e6ngelig" else "ikke installeret"
-  # pbcharts kraeves af BFHcharts for i'/i-prime + Laney P'/U'-charts, som er
+  # pbcharts kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts, som er
   # eksponeret som foersteklasses chart-typer i dropdownen. Den eksplicitte
   # requireNamespace-reference goer desuden pakken synlig for rsconnect's
   # dependency-scanner, saa den medtages i Connect-manifestet (uden en

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.24.0",
+        "Version": "0.25.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -41,17 +41,18 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.24.0",
-        "RemoteSha": "2c5b4514174725364b9ff4b905a6704601cd1fed",
+        "RemotePkgRef": "johanreventlow/BFHcharts@v0.25.0",
+        "RemoteRef": "v0.25.0",
+        "RemoteSha": "670ad7803d0e680efa2c5587e476cbac6bbb3d8d",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.24.0",
-        "GithubSHA1": "2c5b4514174725364b9ff4b905a6704601cd1fed",
+        "GithubRef": "v0.25.0",
+        "GithubSHA1": "670ad7803d0e680efa2c5587e476cbac6bbb3d8d",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-08 18:52:37 UTC; johanreventlow",
+        "Packaged": "2026-06-10 19:23:45 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-08 18:52:38 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-10 19:23:47 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -4219,7 +4220,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "d81029d9c0653dcb0562969d5c6759ea"
+      "checksum": "dde40b4ec126775809577b5259acb79f"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4359,6 +4360,9 @@
     "inst/templates/typst/README.md": {
       "checksum": "5f4913fc0a1e497e314621369145b916"
     },
+    "manifest.json": {
+      "checksum": "04af46bde9d78ce6d13bdce49f90a65a"
+    },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
     },
@@ -4387,10 +4391,10 @@
       "checksum": "cb066b1eac8c4724f030e0006c1b6fbc"
     },
     "R/config_chart_type_groups.R": {
-      "checksum": "b9dfc8fd47fad1e19046cbdb9d788677"
+      "checksum": "08e6842003c325ade7fd8001b64eb9a5"
     },
     "R/config_chart_types.R": {
-      "checksum": "9eaf85cc7f871387436ab09a0013b035"
+      "checksum": "a2df867a75348d9e5974be2fb7c53065"
     },
     "R/config_export_config.R": {
       "checksum": "410356d2c0c0ff25130cefeb609bfa32"
@@ -4450,7 +4454,7 @@
       "checksum": "d4d7e0569dc318ba62f75738d391238b"
     },
     "R/fct_file_operations.R": {
-      "checksum": "ed62fada50ce28c1e2452fc45bc1a962"
+      "checksum": "34f1fda5219513fcf2ec14b45ce74c7b"
     },
     "R/fct_file_parse_pure.R": {
       "checksum": "7e3744188e2cd07ec98a7c6a489f3550"
@@ -4624,7 +4628,7 @@
       "checksum": "6239f32d74045acbca25463fd89d8132"
     },
     "R/utils_export_helpers.R": {
-      "checksum": "47354f33f1aaa2789c2e9048bc22d26a"
+      "checksum": "7f3f4c4de2fcef6e94d3c7d7a271e360"
     },
     "R/utils_export_validation.R": {
       "checksum": "f1901f35087860ff18513fa7950eaaaf"
@@ -4681,7 +4685,7 @@
       "checksum": "60614a7b4afebc57ccbe80442e63cf9a"
     },
     "R/utils_server_events_chart.R": {
-      "checksum": "2d2901ae7356d934b05a783ce526e81c"
+      "checksum": "f980bd04d476812ee5d9f9c975238495"
     },
     "R/utils_server_events_data.R": {
       "checksum": "ddbbb46f800c8e25322ee6f4dc3e13c9"
@@ -4783,13 +4787,13 @@
       "checksum": "a43315bd81b9b8e9c4c8d7eb9e5e853c"
     },
     "R/utils_y_axis_model.R": {
-      "checksum": "36682c0122cbf6a9863c01e2dd96e3bb"
+      "checksum": "62c5fe0b350a2997174b38d141fee69b"
     },
     "R/utils_y_axis_scaling.R": {
-      "checksum": "0863dc7a47fc3e1c6e4528a6dcd40593"
+      "checksum": "f894af4a40bcf6f45db307687e3cef20"
     },
     "R/zzz.R": {
-      "checksum": "73a9c7bdd9db7cc421b1890f057675d2"
+      "checksum": "179e6232b79a8e3613f42bb7a97d0272"
     }
   },
   "users": null

--- a/tests/testthat/test-bfhcharts-integration.R
+++ b/tests/testthat/test-bfhcharts-integration.R
@@ -145,12 +145,12 @@ test_that("BFHcharts to-trins workflow: bfh_qic + get_plot", {
   expect_s3_class(plot, "ggplot")
 })
 
-test_that("BFHcharts bfh_qic kan oprette I-prime chart (i') med naevner", {
+test_that("BFHcharts bfh_qic kan oprette I-prime chart (ip) med naevner", {
   skip_if_not_installed("BFHcharts")
   skip_if_not_installed("qicharts2")
-  # i'-beregning delegeres til pbcharts (BFHcharts Suggests/Remotes-dep).
+  # ip-beregning delegeres til pbcharts (BFHcharts Suggests/Remotes-dep).
   # pbcharts er ikke i biSPCharts' egne deps, saa CI har den typisk ikke;
-  # skip naar fravaerende -- selve i'-pipelinen er CI-testet i BFHcharts.
+  # skip naar fravaerende -- selve ip-pipelinen er CI-testet i BFHcharts.
   skip_if_not_installed("pbcharts")
 
   test_data <- data.frame(
@@ -171,7 +171,7 @@ test_that("BFHcharts bfh_qic kan oprette I-prime chart (i') med naevner", {
       x = Dato,
       y = Vaerdi,
       n = Naevner,
-      chart_type = "i'",
+      chart_type = "ip",
       y_axis_unit = "count",
       chart_title = "Test I-prime Chart"
     )

--- a/tests/testthat/test-config_chart_type_groups.R
+++ b/tests/testthat/test-config_chart_type_groups.R
@@ -23,22 +23,22 @@ test_that("alle option-values resolver til gyldige qic-koder", {
 # Alias-resolution -------------------------------------------------------------
 
 test_that("alias-values stripper korrekt til ren qic-kode", {
-  expect_equal(get_qic_chart_type("i'__ctrl"), "i'")
-  expect_equal(get_qic_chart_type("i'__dt"), "i'")
+  expect_equal(get_qic_chart_type("ip__ctrl"), "ip")
+  expect_equal(get_qic_chart_type("ip__dt"), "ip")
   expect_equal(get_qic_chart_type("pp__dt"), "pp")
   expect_equal(get_qic_chart_type("up__dt"), "up")
   expect_equal(get_qic_chart_type("c__dt"), "c")
 })
 
 test_that("rene koder uden alias er upaavirkede af strip", {
-  for (code in c("run", "i", "i'", "p", "pp", "u", "up", "c", "mr", "g", "t")) {
+  for (code in c("run", "i", "ip", "p", "pp", "u", "up", "c", "mr", "g", "t")) {
     expect_equal(get_qic_chart_type(code), code)
   }
 })
 
 test_that("requires_denominator er korrekt gennem alias", {
-  expect_true(chart_type_requires_denominator("i'__ctrl")) # i'
-  expect_true(chart_type_requires_denominator("i'__dt")) # i'
+  expect_true(chart_type_requires_denominator("ip__ctrl")) # ip
+  expect_true(chart_type_requires_denominator("ip__dt")) # ip
   expect_true(chart_type_requires_denominator("pp__dt")) # pp
   expect_true(chart_type_requires_denominator("up__dt")) # up
   expect_false(chart_type_requires_denominator("c__dt")) # c bruger ingen naevner
@@ -46,16 +46,16 @@ test_that("requires_denominator er korrekt gennem alias", {
 
 # Gruppe-indhold ---------------------------------------------------------------
 
-test_that("Standardvalg indeholder run + i' (via alias)", {
+test_that("Standardvalg indeholder run + ip (via alias)", {
   std <- build_grouped_chart_choices()[["Standardvalg"]]
   resolved <- vapply(unlist(std, use.names = FALSE), get_qic_chart_type, character(1))
-  expect_setequal(unname(resolved), c("run", "i'"))
+  expect_setequal(unname(resolved), c("run", "ip"))
 })
 
 test_that("Avanceret-gruppen daekker alle eksponerede korttyper inkl. g/t", {
   adv <- build_grouped_chart_choices()[["Avanceret kontrolkortvalg"]]
   expect_setequal(
     unlist(adv, use.names = FALSE),
-    c("i", "i'", "p", "pp", "u", "up", "c", "mr", "g", "t")
+    c("i", "ip", "p", "pp", "u", "up", "c", "mr", "g", "t")
   )
 })

--- a/tests/testthat/test-config_chart_types.R
+++ b/tests/testthat/test-config_chart_types.R
@@ -17,7 +17,7 @@ test_that("get_qic_chart_type konverterer danske labels korrekt", {
 
 test_that("get_qic_chart_type returnerer engelske koder uændret", {
   # Aktive koder registreret i lookup-tabellen (mr/pp/up nu eksponeret)
-  for (code in c("run", "i", "i'", "mr", "p", "pp", "u", "up", "c")) {
+  for (code in c("run", "i", "ip", "mr", "p", "pp", "u", "up", "c")) {
     expect_equal(get_qic_chart_type(code), code)
   }
   # Bemærk: G/T er stadig ikke registreret og returnerer "run" (fallback).
@@ -38,7 +38,7 @@ test_that("chart_type_requires_denominator identificerer korrekte typer", {
   expect_true(chart_type_requires_denominator("pp"))
   expect_true(chart_type_requires_denominator("u"))
   expect_true(chart_type_requires_denominator("up"))
-  expect_true(chart_type_requires_denominator("i'"))
+  expect_true(chart_type_requires_denominator("ip"))
 
   # Typer der IKKE kræver nævner
   expect_false(chart_type_requires_denominator("i"))
@@ -52,7 +52,7 @@ test_that("chart_type_requires_denominator accepterer danske labels", {
   # Opdaterede labels til nuværende em-dash format
   expect_true(chart_type_requires_denominator("P-kort \u2014 andele/procenter (fx infektionsrate)"))
   expect_false(chart_type_requires_denominator("I-kort \u2014 enkelte m\u00e5linger (fx ventetid, temperatur)"))
-  # i'-kort: naevner er relevant (varierende naevner er kernefeature)
+  # ip-kort: naevner er relevant (varierende naevner er kernefeature)
   expect_true(chart_type_requires_denominator(
     "I\u2032-kort \u2014 individuelle m\u00e5linger med varierende n\u00e6vner"
   ))
@@ -61,65 +61,65 @@ test_that("chart_type_requires_denominator accepterer danske labels", {
 # Konstanter ------------------------------------------------------------------
 
 test_that("CHART_TYPES_DA indeholder aktive diagramtyper", {
-  # Aktuelt 6 aktive typer inkl. i' (mr, pp, up, g er udkommenteret i config_chart_types.R)
+  # Aktuelt 6 aktive typer inkl. ip (mr, pp, up, g er udkommenteret i config_chart_types.R)
   expect_true(length(CHART_TYPES_DA) >= 6,
     info = "CHART_TYPES_DA skal indeholde mindst 6 aktive diagramtyper"
   )
-  expect_true(all(unlist(CHART_TYPES_DA) %in% c("run", "i", "i'", "mr", "p", "pp", "u", "up", "c", "g")),
+  expect_true(all(unlist(CHART_TYPES_DA) %in% c("run", "i", "ip", "mr", "p", "pp", "u", "up", "c", "g")),
     info = "Alle aktive typer skal have gyldige engelske koder"
   )
 })
 
 test_that("CHART_TYPE_DESCRIPTIONS daekker alle engelske koder inkl. i-prime", {
-  expected_codes <- c("run", "i", "i'", "mr", "p", "pp", "u", "up", "c", "g")
+  expected_codes <- c("run", "i", "ip", "mr", "p", "pp", "u", "up", "c", "g")
   expect_true(all(expected_codes %in% names(CHART_TYPE_DESCRIPTIONS)))
 })
 
-# i' (I-prime) chart type -------------------------------------------------------
+# ip (I-prime) chart type -------------------------------------------------------
 
-test_that("i'-kort: get_qic_chart_type returnerer i' uaendret (passthrough)", {
-  expect_equal(get_qic_chart_type("i'"), "i'")
+test_that("ip-kort: get_qic_chart_type returnerer ip uaendret (passthrough)", {
+  expect_equal(get_qic_chart_type("ip"), "ip")
 })
 
-test_that("i'-kort: get_qic_chart_type konverterer dansk label korrekt", {
+test_that("ip-kort: get_qic_chart_type konverterer dansk label korrekt", {
   expect_equal(
     get_qic_chart_type("I′-kort — individuelle målinger med varierende nævner"),
-    "i'"
+    "ip"
   )
 })
 
-test_that("i'-kort: i' er i SUPPORTED_CHART_TYPES_BFH (validering accepterer den)", {
-  expect_true("i'" %in% SUPPORTED_CHART_TYPES_BFH)
+test_that("ip-kort: ip er i SUPPORTED_CHART_TYPES_BFH (validering accepterer den)", {
+  expect_true("ip" %in% SUPPORTED_CHART_TYPES_BFH)
 })
 
-test_that("i'-kort: chart_type_requires_denominator returnerer TRUE", {
-  expect_true(chart_type_requires_denominator("i'"))
+test_that("ip-kort: chart_type_requires_denominator returnerer TRUE", {
+  expect_true(chart_type_requires_denominator("ip"))
 })
 
-test_that("i'-kort: chart_type_requires_denominator via dansk label returnerer TRUE", {
+test_that("ip-kort: chart_type_requires_denominator via dansk label returnerer TRUE", {
   expect_true(chart_type_requires_denominator(
     "I′-kort — individuelle målinger med varierende nævner"
   ))
 })
 
-test_that("i'-kort: build_bfh_args bevarer n_var for i'-chart (ikke stripped)", {
-  # chart_type_requires_denominator("i'") er TRUE → n_var skal IKKE fjernes
+test_that("ip-kort: build_bfh_args bevarer n_var for ip-chart (ikke stripped)", {
+  # chart_type_requires_denominator("ip") er TRUE → n_var skal IKKE fjernes
   # Verificer logik-gaten direkte (build_bfh_args bruger denne guard)
-  expect_true(chart_type_requires_denominator("i'"),
-    info = "Guard-condition: i' requires denominator → n_var skal bevares af build_bfh_args"
+  expect_true(chart_type_requires_denominator("ip"),
+    info = "Guard-condition: ip requires denominator → n_var skal bevares af build_bfh_args"
   )
 })
 
-test_that("i'-kort: i' er i ABSOLUTE_CHART_TYPES (arver i's y-akse skalering)", {
-  expect_true("i'" %in% ABSOLUTE_CHART_TYPES)
+test_that("ip-kort: ip er i ABSOLUTE_CHART_TYPES (arver ips y-akse skalering)", {
+  expect_true("ip" %in% ABSOLUTE_CHART_TYPES)
 })
 
-test_that("i'-kort: fct_spc_validate accepterer i' som chart_type", {
+test_that("ip-kort: fct_spc_validate accepterer ip som chart_type", {
   df <- data.frame(
     x = seq.Date(as.Date("2023-01-01"), by = "week", length.out = 10),
     y = as.numeric(1:10)
   )
-  expect_no_error(validate_spc_request(df, "x", "y", "i'"))
+  expect_no_error(validate_spc_request(df, "x", "y", "ip"))
 })
 
 # Laney P'/U' + MR eksponering -------------------------------------------------

--- a/tests/testthat/test-y-axis-scaling-overhaul.R
+++ b/tests/testthat/test-y-axis-scaling-overhaul.R
@@ -389,10 +389,10 @@ test_that("run chart denominator toggle semantics (unit-only)", {
 
 test_that("i-prime default y-axis with denominator presence", {
   # I' + med naevner -> procent (y/n er en andel); standard foerste auto-valg
-  expect_equal(decide_default_y_axis_ui_type("i'", n_present = TRUE), "percent")
+  expect_equal(decide_default_y_axis_ui_type("ip", n_present = TRUE), "percent")
 
   # I' + uden naevner -> tal (degenererer til standard i-kort)
-  expect_equal(decide_default_y_axis_ui_type("i'", n_present = FALSE), "count")
+  expect_equal(decide_default_y_axis_ui_type("ip", n_present = FALSE), "count")
 
   # Oevrige korttyper paavirkes ikke af naevner-tilstedevaerelse
   expect_equal(decide_default_y_axis_ui_type("i", n_present = TRUE), "count")
@@ -404,7 +404,7 @@ test_that("i-prime/run skifter default til rate naar pooled centerline > 100%", 
   y_andel <- c(40, 50, 45)
   n_andel <- c(100, 100, 100)
   expect_equal(
-    decide_default_y_axis_ui_type("i'", n_present = TRUE, y = y_andel, n = n_andel),
+    decide_default_y_axis_ui_type("ip", n_present = TRUE, y = y_andel, n = n_andel),
     "percent"
   )
 
@@ -412,7 +412,7 @@ test_that("i-prime/run skifter default til rate naar pooled centerline > 100%", 
   y_rate <- c(150, 200, 175)
   n_rate <- c(100, 100, 100)
   expect_equal(
-    decide_default_y_axis_ui_type("i'", n_present = TRUE, y = y_rate, n = n_rate),
+    decide_default_y_axis_ui_type("ip", n_present = TRUE, y = y_rate, n = n_rate),
     "rate"
   )
 
@@ -423,7 +423,7 @@ test_that("i-prime/run skifter default til rate naar pooled centerline > 100%", 
   )
 
   # Uden y/n-data -> bagudkompatibel procent-default (intet centerline-tjek)
-  expect_equal(decide_default_y_axis_ui_type("i'", n_present = TRUE), "percent")
+  expect_equal(decide_default_y_axis_ui_type("ip", n_present = TRUE), "percent")
 })
 
 test_that("proportion_centerline_exceeds_unity haandterer edge cases robust", {


### PR DESCRIPTION
## Summary

- BFHcharts 0.25.0 renamed the I-prime `chart_type` value `"i'"` → `"ip"` (consistency with `pp`/`up`). Updates all biSPCharts call-sites that pass the value to `bfh_qic()` plus the internal chart-type config/lookup tables.
- Danish UI labels (`I'-kort` / `I′-kort`) unchanged — value-only rename.
- Regular `i`-chart (`'i'`) untouched; regression tests pass.
- `DESCRIPTION`: `BFHcharts (>= 0.25.0)` + `Remotes` pin `@v0.25.0`; `manifest.json` regenerated (validated).

## Depends on

BFHcharts v0.25.0 (released, tagged).

## Test plan

- [x] Affected suites green vs locally-installed BFHcharts 0.25.0 (config_chart_types, config_chart_type_groups, y-axis-scaling, bfhcharts-integration)
- [x] Regression: regular i-chart suites (sync-chart-type-to-state, chart-type-observer-integration) green
- [x] `dev/validate_connect_manifest.R` OK
- [ ] CI green