### PR TITLE
fix(excel): Danish label for i-prime (ip) chart type

### DIFF
--- a/R/fct_spc_excel_analysis.R
+++ b/R/fct_spc_excel_analysis.R
@@ -66,6 +66,7 @@ NULL
     pp = "P'-kort",
     u = "U-kort",
     up = "U'-kort",
+    ip = "I'-kort",
     c = "C-kort",
     g = "G-kort",
     t = "T-kort",

--- a/tests/testthat/test-fct_spc_excel_analysis.R
+++ b/tests/testthat/test-fct_spc_excel_analysis.R
@@ -37,6 +37,10 @@ test_that("build_overview_section angiver charttype på dansk", {
   expect_equal(ct, "P-kort")
 })
 
+test_that(".excel_chart_type_da oversaetter ip til I'-kort (ikke raa kode)", {
+  expect_equal(.excel_chart_type_da("ip"), "I'-kort")
+})
+
 test_that("build_overview_section samler ooc-rækker som komma-separeret tekst", {
   qic <- fixture_qic_data_3_parts()
   # Forvent ooc-rækker i part 3: y[11] = 0.15 > ucl[11] = 0.10 -> række 11


### PR DESCRIPTION
## Summary

`.excel_chart_type_da()` had no case for the i-prime chart, so Excel exports showed the raw code (`ip`) instead of a Danish name. Adds `ip = "I'-kort"` (matching `pp`/`up`). Pre-existing gap surfaced by the i'->ip rename.

## Test plan

- [x] New unit test: `.excel_chart_type_da("ip")` == `"I'-kort"`
- [x] test-fct_spc_excel_analysis.R green