### PR TITLE
chore(deps): bump BFHcharts to v0.26.0 + fix mock contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 **Project-type rules (Tier 2 — Shiny):**
 
+@~/.claude/rules-profiles/r/R_STANDARDS.md
 @~/.claude/rules-profiles/shiny/SHINY_STANDARDS.md
 @~/.claude/rules-profiles/shiny/SHINY_ADVANCED_PATTERNS.md
 @~/.claude/rules-profiles/shiny/ARCHITECTURE_PATTERNS.md
@@ -10,7 +11,6 @@
 
 <!-- @~/.claude/rules-ondemand/OBSERVABILITY_STANDARDS.md -->
 <!-- @~/.claude/rules-ondemand/DEPLOYMENT_GUIDE.md -->
-<!-- @~/.claude/rules-ondemand/TROUBLESHOOTING_GUIDE.md -->
 <!-- @~/.claude/rules-ondemand/CI_CD_WORKFLOW.md -->
 
 ---

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.25.0),
+    BFHcharts (>= 0.26.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -79,7 +79,7 @@ Suggests:
     pbcharts (>= 0.1.0)
 Config/testthat/edition: 3
 Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.25.0,
+Remotes: johanreventlow/BFHcharts@v0.26.0,
     johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2,

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.25.0",
+        "Version": "0.26.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3 + file LICENSE",
@@ -41,18 +41,18 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemotePkgRef": "johanreventlow/BFHcharts@v0.25.0",
-        "RemoteRef": "v0.25.0",
-        "RemoteSha": "670ad7803d0e680efa2c5587e476cbac6bbb3d8d",
+        "RemotePkgRef": "johanreventlow/BFHcharts@v0.26.0",
+        "RemoteRef": "v0.26.0",
+        "RemoteSha": "2616f890f7c9bf845d3e24dabc69d375ba8cc1c0",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.25.0",
-        "GithubSHA1": "670ad7803d0e680efa2c5587e476cbac6bbb3d8d",
+        "GithubRef": "v0.26.0",
+        "GithubSHA1": "2616f890f7c9bf845d3e24dabc69d375ba8cc1c0",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-10 19:23:45 UTC; johanreventlow",
+        "Packaged": "2026-06-13 13:34:38 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-10 19:23:47 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-13 13:34:39 UTC; unix"
       }
     },
     "BFHchartsAssets": {
@@ -82,10 +82,10 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-07 10:15:35 UTC; johanreventlow",
+        "Packaged": "2026-06-11 10:40:06 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-07 10:15:36 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-11 10:40:07 UTC; unix"
       }
     },
     "BFHllm": {
@@ -111,6 +111,7 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHllm",
         "RemoteUsername": "johanreventlow",
+        "RemotePkgRef": "johanreventlow/BFHllm@v0.2.0",
         "RemoteRef": "v0.2.0",
         "RemoteSha": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "GithubRepo": "BFHllm",
@@ -118,10 +119,10 @@
         "GithubRef": "v0.2.0",
         "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-07 10:16:54 UTC; johanreventlow",
+        "Packaged": "2026-05-10 10:33:45 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-07 10:16:55 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-29 15:05:20 UTC; unix"
       }
     },
     "BFHtheme": {
@@ -146,6 +147,7 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHtheme",
         "RemoteUsername": "johanreventlow",
+        "RemotePkgRef": "johanreventlow/BFHtheme@v0.5.2",
         "RemoteRef": "v0.5.2",
         "RemoteSha": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
         "GithubRepo": "BFHtheme",
@@ -153,10 +155,10 @@
         "GithubRef": "v0.5.2",
         "GithubSHA1": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-07 10:16:45 UTC; johanreventlow",
+        "Packaged": "2026-06-13 13:34:32 UTC; johanreventlow",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-07 10:16:46 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-13 13:34:33 UTC; unix"
       }
     },
     "BH": {
@@ -2411,7 +2413,7 @@
         "Package": "openssl",
         "Type": "Package",
         "Title": "Toolkit for Encryption, Signatures and Certificates Based on\nOpenSSL",
-        "Version": "2.4.1",
+        "Version": "2.4.2",
         "Authors@R": "c(person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroenooms@gmail.com\",\n    comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Oliver\", \"Keyes\", role = \"ctb\"))",
         "Description": "Bindings to OpenSSL libssl and libcrypto, plus custom SSH key parsers.\n    Supports RSA, DSA and EC curves P-256, P-384, P-521, and curve25519. Cryptographic\n    signatures can either be created and verified manually or via x509 certificates. \n    AES can be used in cbc, ctr or gcm mode for symmetric encryption; RSA for asymmetric\n    (public key) encryption or EC for Diffie Hellman. High-level envelope functions \n    combine RSA and AES for encrypting arbitrary sized data. Other utilities include key\n    generators, hash functions (md5, sha1, sha256, etc), base64 encoder, a secure random\n    number generator, and 'bignum' math methods for manually performing crypto \n    calculations on large multibyte integers.",
         "License": "MIT + file LICENSE",
@@ -2421,16 +2423,22 @@
         "VignetteBuilder": "knitr",
         "Imports": "askpass",
         "Suggests": "curl, testthat (>= 2.1.0), digest, knitr, rmarkdown,\njsonlite, jose, sodium",
-        "RoxygenNote": "7.3.2",
         "Encoding": "UTF-8",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-05-14 13:48:16 UTC; jeroen",
+        "Packaged": "2026-06-09 10:51:42 UTC; jeroen",
         "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Oliver Keyes [ctb]",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-05-14 14:50:14 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-14 19:24:59 UTC; unix",
-        "Archs": "openssl.so.dSYM"
+        "Date/Publication": "2026-06-09 13:30:02 UTC",
+        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-06-09 16:28:40 UTC; unix",
+        "Archs": "openssl.so.dSYM",
+        "RemoteType": "standard",
+        "RemotePkgRef": "openssl",
+        "RemoteRef": "openssl",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemotePkgPlatform": "aarch64-apple-darwin23",
+        "RemoteSha": "2.4.2"
       }
     },
     "openxlsx": {
@@ -4220,7 +4228,7 @@
       "checksum": "3229dcd4aabe33a327543f3081c6a86b"
     },
     "DESCRIPTION": {
-      "checksum": "dde40b4ec126775809577b5259acb79f"
+      "checksum": "23dd34389dd9214b8082d4e8306bc90b"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "2ed67aade811d126e30272f5e6e0d035"
@@ -4361,7 +4369,7 @@
       "checksum": "5f4913fc0a1e497e314621369145b916"
     },
     "manifest.json": {
-      "checksum": "04af46bde9d78ce6d13bdce49f90a65a"
+      "checksum": "35cf38bf0cb7098cb5a95526410a8cd7"
     },
     "NAMESPACE": {
       "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
@@ -4487,7 +4495,7 @@
       "checksum": "026c3d389d6197dd72e166ddcb87e4d3"
     },
     "R/fct_spc_excel_analysis.R": {
-      "checksum": "d8a1f060147ffd0df5a6ff8490bce3ad"
+      "checksum": "acafefe585a7c3c8b4935da7e717f76b"
     },
     "R/fct_spc_execute.R": {
       "checksum": "aec7a62736731e9fcefdd295899891fc"

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -62,12 +62,13 @@ mock_bfh_qic <- function(data, x, y, n = NULL, chart_type = "run",
                          notes = NULL, part = NULL, freeze = NULL,
                          exclude = NULL, cl = NULL, ylim = NULL,
                          multiply = NULL,
-                         agg.fun = "mean", base_size = 12,
+                         agg.fun = "mean", agg_fun = NULL,
+                         base_size = 12,
                          width = NULL, height = NULL, units = "in",
                          dpi = 96, plot_margin = NULL,
                          ylab = NULL, xlab = NULL,
                          subtitle = NULL, caption = NULL,
-                         return.data = FALSE,
+                         return.data = FALSE, return_data = NULL,
                          language = "da") {
   n_rows <- nrow(data)
   cl_value <- if (!is.null(cl)) {


### PR DESCRIPTION
## Summary
- `BFHcharts (>= 0.26.0)` og `Remotes: johanreventlow/BFHcharts@v0.26.0`
- `manifest.json` regenereret via `dev/_regen_manifest.R` (valideret OK)
- `mock_bfh_qic` opdateret med `agg_fun`/`return_data` aliases (#490-kontrakttest)

## BFHcharts 0.26.0 highlights
- Aritmetisk panel-højedmåling (30ms/kald, eliminerer 3x PDF-rendering)
- `agg_fun`/`return_data` snake_case aliases
- I-prime migrationshint + analysis-fil refactor

## Test plan
- [ ] CI grøn (contract-test bekræfter mock matcher ny signatur)
- [ ] Connect manifest valideret lokalt: `Connect manifest OK`