### PR TITLE
chore(deps): bump BFHcharts to 0.27.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.26.0),
+    BFHcharts (>= 0.27.0),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -79,7 +79,7 @@ Suggests:
     pbcharts (>= 0.1.0)
 Config/testthat/edition: 3
 Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.26.0,
+Remotes: johanreventlow/BFHcharts@v0.27.0,
     johanreventlow/BFHtheme@v0.5.2,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,7 +65,7 @@ Suggests:
     curl (>= 4.3.0),
     BFHllm (>= 0.2.0),
     BFHchartsAssets (>= 0.1.2),
-    BFHtheme (>= 0.5.2),
+    BFHtheme (>= 0.5.5),
     pins (>= 1.2.0),
     gert (>= 1.9.0),
     shinylogs (>= 0.2.0),
@@ -80,7 +80,7 @@ Suggests:
 Config/testthat/edition: 3
 Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
 Remotes: johanreventlow/BFHcharts@v0.27.0,
-    johanreventlow/BFHtheme@v0.5.2,
+    johanreventlow/BFHtheme@v0.5.5,
     johanreventlow/BFHllm@v0.2.0,
     johanreventlow/BFHchartsAssets@v0.1.2,
     anhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 ## Interne ændringer
 
+* **BFHcharts bumpet til 0.27.0** (fra 0.26.0, inkl. 0.26.1's bugfixes).
+  0.27.0 gør periodelinjen granularitets-bevidst (uge-, dags-, kvartals- og
+  årsdata vises nu med matchende periodeformat i stedet for altid måned+år,
+  med ISO-år for ugenumre) og forankrer x-akse-labels til kalenderen for
+  dags- og ugedata, så lange serier får læsbare, regelmæssige breaks.
+  Se BFHcharts NEWS 0.27.0 for detaljer.
+
 * **Tilpasset BFHcharts 0.25.0: I-prime-kortets `chart_type`-værdi omdøbt
   fra `"i'"` til `"ip"`.** Følger BFHcharts' breaking change der harmoniserer
   prime-kortenes navngivning (`pp`, `up`, `ip`). De danske UI-labels

--- a/manifest.json
+++ b/manifest.json
@@ -21,38 +21,37 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.26.0",
+        "Version": "0.27.0",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
-        "License": "GPL-3 + file LICENSE",
+        "License": "GPL-3",
         "Encoding": "UTF-8",
         "Roxygen": "list(markdown = TRUE)",
         "SystemRequirements": "Quarto CLI (>= 1.4.0) for PDF export via Typst\ntemplates",
         "URL": "https://github.com/johanreventlow/BFHcharts",
         "BugReports": "https://github.com/johanreventlow/BFHcharts/issues",
         "Depends": "R (>= 4.1.0)",
-        "Imports": "BFHtheme (>= 0.5.1), ggplot2 (>= 3.4.0), qicharts2 (>= 0.7.0),\nscales (>= 1.2.0), lubridate (>= 1.9.0), dplyr (>= 1.1.0),\npurrr (>= 1.0.0), stringr (>= 1.5.0), tibble (>= 3.2.0), yaml,\nlemon, marquee (>= 0.1.0), grid, commonmark (>= 1.9), xml2,\nsystemfonts, rlang, svglite",
-        "Suggests": "testthat (>= 3.1.7), vdiffr, covr, pdftools (>= 3.3.0),\nwithr, bench, BFHllm, jsonlite, knitr, pbcharts, rmarkdown",
+        "Imports": "BFHtheme (>= 0.5.5), ggplot2 (>= 3.5.0), qicharts2 (>= 0.7.0),\nscales (>= 1.2.0), lubridate (>= 1.9.0), dplyr (>= 1.1.0),\npurrr (>= 1.0.0), stringr (>= 1.5.0), tibble (>= 3.2.0), yaml,\nlemon, marquee (>= 0.1.0), grid, systemfonts, rlang, svglite",
+        "Suggests": "commonmark (>= 1.9), xml2, testthat (>= 3.1.7), vdiffr, covr,\npdftools (>= 3.3.0), withr, bench, BFHllm, jsonlite, knitr,\npbcharts, rmarkdown",
         "VignetteBuilder": "knitr",
-        "Remotes": "johanreventlow/BFHtheme@v0.5.2, johanreventlow/BFHllm@v0.2.0,\nanhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f",
+        "Remotes": "johanreventlow/BFHtheme@v0.5.5, johanreventlow/BFHllm@v0.2.0,\nanhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f",
         "Config/testthat/edition": "3",
         "Config/roxygen2/version": "8.0.0",
         "RemoteType": "github",
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemotePkgRef": "johanreventlow/BFHcharts@v0.26.0",
-        "RemoteRef": "v0.26.0",
-        "RemoteSha": "2616f890f7c9bf845d3e24dabc69d375ba8cc1c0",
+        "RemoteRef": "v0.27.0",
+        "RemoteSha": "e5cc1ef8844f7c3c4b547f43dc091c573254704e",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.26.0",
-        "GithubSHA1": "2616f890f7c9bf845d3e24dabc69d375ba8cc1c0",
+        "GithubRef": "v0.27.0",
+        "GithubSHA1": "e5cc1ef8844f7c3c4b547f43dc091c573254704e",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-13 13:34:38 UTC; johanreventlow",
+        "Packaged": "2026-08-11 15:37:21 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-13 13:34:39 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-08-11 15:37:32 UTC; windows"
       }
     },
     "BFHchartsAssets": {
@@ -82,21 +81,21 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-11 10:40:06 UTC; johanreventlow",
+        "Packaged": "2026-08-11 15:40:49 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-11 10:40:07 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-08-11 15:40:56 UTC; windows"
       }
     },
     "BFHllm": {
-      "Source": "github",
+      "Source": "https://johanreventlow.r-universe.dev",
       "Repository": null,
       "description": {
         "Package": "BFHllm",
         "Title": "LLM Integration Framework for BFH Packages",
         "Version": "0.2.0",
         "Authors@R": "\n    person(\"Johan\", \"Reventlow\", , \"johan.reventlow@regionh.dk\", role = c(\"aut\", \"cre\"))",
-        "Description": "AI-driven insights and text generation for healthcare quality\n    improvement. Provides LLM chat interface, RAG (Retrieval Augmented\n    Generation) integration with knowledge stores, and SPC-specific\n    improvement suggestions. Designed for standalone use with BFHcharts\n    or integration in Shiny applications.",
+        "Description": "AI-driven insights and text generation for healthcare\n        quality improvement. Provides LLM chat interface, RAG\n        (Retrieval Augmented Generation) integration with knowledge\n        stores, and SPC-specific improvement suggestions. Designed for\n        standalone use with BFHcharts or integration in Shiny\n        applications.",
         "License": "MIT + file LICENSE",
         "URL": "https://github.com/johanreventlow/BFHllm",
         "BugReports": "https://github.com/johanreventlow/BFHllm/issues",
@@ -107,22 +106,17 @@
         "Suggests": "testthat (>= 3.0.0), shiny (>= 1.7.0), mockery, withr,\nBFHcharts (>= 0.4.0)",
         "Remotes": "johanreventlow/BFHcharts",
         "Config/testthat/edition": "3",
-        "RemoteType": "github",
-        "RemoteHost": "api.github.com",
-        "RemoteRepo": "BFHllm",
-        "RemoteUsername": "johanreventlow",
-        "RemotePkgRef": "johanreventlow/BFHllm@v0.2.0",
-        "RemoteRef": "v0.2.0",
+        "Config/pak/sysreqs": "cmake libicu-dev libpng-dev libxml2-dev libssl-dev\npython3 xz-utils",
+        "Repository": "https://johanreventlow.r-universe.dev",
+        "Date/Publication": "2026-05-09 08:27:54 UTC",
+        "RemoteUrl": "https://github.com/johanreventlow/BFHllm",
+        "RemoteRef": "HEAD",
         "RemoteSha": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
-        "GithubRepo": "BFHllm",
-        "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.2.0",
-        "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-10 10:33:45 UTC; johanreventlow",
+        "Packaged": "2026-05-09 09:19:40 UTC; root",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-05-29 15:05:20 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-09 09:21:10 UTC; windows"
       }
     },
     "BFHtheme": {
@@ -132,7 +126,7 @@
         "Package": "BFHtheme",
         "Type": "Package",
         "Title": "BFH Theme and Color Palettes for ggplot2",
-        "Version": "0.5.2",
+        "Version": "0.5.5",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "Provides comprehensive theming support for ggplot2 graphics\n    following Bispebjerg og Frederiksberg Hospital and Region Hovedstaden\n    visual identity guidelines. Includes color palettes for both Hospital\n    and Region H branding, themes, scale functions, and helper utilities\n    for creating consistent and professional visualizations. Uses modern\n    'systemfonts' package for robust font detection with graceful fallback.\n    Recommends 'ragg', 'svglite', and Cairo devices for high-quality output.",
         "License": "MIT + file LICENSE",
@@ -147,18 +141,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHtheme",
         "RemoteUsername": "johanreventlow",
-        "RemotePkgRef": "johanreventlow/BFHtheme@v0.5.2",
-        "RemoteRef": "v0.5.2",
-        "RemoteSha": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
+        "RemoteRef": "v0.5.5",
+        "RemoteSha": "8fc1eb9809de13af00aeaafcc5a791fe3bfb4330",
         "GithubRepo": "BFHtheme",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.5.2",
-        "GithubSHA1": "a71a64a643b3785dbeb39a5e466dcd897a4204ee",
+        "GithubRef": "v0.5.5",
+        "GithubSHA1": "8fc1eb9809de13af00aeaafcc5a791fe3bfb4330",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-13 13:34:32 UTC; johanreventlow",
+        "Packaged": "2026-08-11 16:34:06 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-06-13 13:34:33 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-08-11 16:34:09 UTC; windows"
       }
     },
     "BH": {
@@ -181,7 +174,12 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-14 10:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:48:04 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-21 00:41:53 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "BH",
+        "RemoteRef": "BH",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.90.0-1"
       }
     },
     "DBI": {
@@ -213,7 +211,14 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-25 06:31:27 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:47:33 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-22 08:59:08 UTC; windows",
+        "RemoteType": "standard",
+        "RemoteRef": "DBI",
+        "RemotePkgRef": "DBI",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.3.0"
       }
     },
     "Matrix": {
@@ -221,15 +226,15 @@
       "Repository": "https://cloud.r-project.org",
       "description": {
         "Package": "Matrix",
-        "Version": "1.7-5",
+        "Version": "1.7-6",
         "VersionNote": "do also bump src/version.h, inst/include/Matrix/version.h",
-        "Date": "2026-03-20",
+        "Date": "2026-07-24",
         "Priority": "recommended",
         "Title": "Sparse and Dense Matrix Classes and Methods",
         "Description": "A rich hierarchy of sparse and dense matrix classes,\n\tincluding general, symmetric, triangular, and diagonal matrices\n\twith numeric, logical, or pattern entries.  Efficient methods for\n\toperating on such matrices, often wrapping the 'BLAS', 'LAPACK',\n\tand 'SuiteSparse' libraries.",
         "License": "GPL (>= 2) | file LICENCE",
-        "URL": "https://Matrix.R-forge.R-project.org",
-        "BugReports": "https://R-forge.R-project.org/tracker/?atid=294&group_id=61",
+        "URL": "https://codeberg.org/jaganmn/Matrix",
+        "BugReports": "https://codeberg.org/jaganmn/Matrix/issues",
         "Contact": "Matrix-authors@R-project.org",
         "Authors@R": "\n\tc(person(\"Douglas\", \"Bates\", role = \"aut\",\n\t         comment = c(ORCID = \"0000-0001-8316-9503\")),\n\t  person(\"Martin\", \"Maechler\", role = c(\"aut\", \"cre\"),\n\t         email = \"mmaechler+Matrix@gmail.com\",\n\t         comment = c(ORCID = \"0000-0002-8685-9910\")),\n\t  person(\"Mikael\", \"Jagan\", role = \"aut\",\n\t         comment = c(ORCID = \"0000-0002-3542-2938\")),\n\t  person(\"Timothy A.\", \"Davis\", role = \"ctb\",\n\t         comment = c(ORCID = \"0000-0001-7614-6899\",\n\t                     \"SuiteSparse libraries\",\n\t                     \"collaborators listed in dir(system.file(\\\"doc\\\", \\\"SuiteSparse\\\", package=\\\"Matrix\\\"), pattern=\\\"License\\\", full.names=TRUE, recursive=TRUE)\")),\n\t  person(\"George\", \"Karypis\", role = \"ctb\",\n\t         comment = c(ORCID = \"0000-0003-2753-1437\",\n\t                     \"METIS library\",\n\t                     \"Copyright: Regents of the University of Minnesota\")),\n\t  person(\"Jason\", \"Riedy\", role = \"ctb\",\n\t         comment = c(ORCID = \"0000-0002-4345-4200\",\n\t                     \"GNU Octave's condest() and onenormest()\",\n\t                     \"Copyright: Regents of the University of California\")),\n\t  person(\"Jens\", \"Oehlschlägel\", role = \"ctb\",\n\t         comment = \"initial nearPD()\"),\n\t  person(\"R Core Team\", role = \"ctb\",\n\t         comment = c(ROR = \"02zz1nj61\", \"base R's matrix implementation\")))",
         "Depends": "R (>= 4.4), methods",
@@ -241,12 +246,18 @@
         "BuildResaveData": "no",
         "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-03-20 19:40:14 UTC; maechler",
+        "Packaged": "2026-07-24 11:40:35 UTC; maechler",
         "Author": "Douglas Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>),\n  Martin Maechler [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-8685-9910>),\n  Mikael Jagan [aut] (ORCID: <https://orcid.org/0000-0002-3542-2938>),\n  Timothy A. Davis [ctb] (ORCID: <https://orcid.org/0000-0001-7614-6899>,\n    SuiteSparse libraries, collaborators listed in\n    dir(system.file(\"doc\", \"SuiteSparse\", package=\"Matrix\"),\n    pattern=\"License\", full.names=TRUE, recursive=TRUE)),\n  George Karypis [ctb] (ORCID: <https://orcid.org/0000-0003-2753-1437>,\n    METIS library, Copyright: Regents of the University of Minnesota),\n  Jason Riedy [ctb] (ORCID: <https://orcid.org/0000-0002-4345-4200>, GNU\n    Octave's condest() and onenormest(), Copyright: Regents of the\n    University of California),\n  Jens Oehlschlägel [ctb] (initial nearPD()),\n  R Core Team [ctb] (ROR: <https://ror.org/02zz1nj61>, base R's matrix\n    implementation)",
         "Maintainer": "Martin Maechler <mmaechler+Matrix@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-03-21 14:40:03 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 08:58:56 UTC; unix"
+        "Date/Publication": "2026-07-25 02:50:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-30 01:48:54 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "Matrix",
+        "RemoteRef": "Matrix",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.7-6"
       }
     },
     "R6": {
@@ -273,7 +284,7 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-02-15 00:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:39:09 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 00:46:26 UTC; windows"
       }
     },
     "RColorBrewer": {
@@ -294,7 +305,12 @@
         "NeedsCompilation": "no",
         "Repository": "CRAN",
         "Date/Publication": "2022-04-03 19:20:13 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:40:08 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-21 00:40:53 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "RColorBrewer",
+        "RemoteRef": "RColorBrewer",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1-3"
       }
     },
     "Rcpp": {
@@ -303,8 +319,8 @@
       "description": {
         "Package": "Rcpp",
         "Title": "Seamless R and C++ Integration",
-        "Version": "1.1.1-1.1",
-        "Date": "2026-04-19",
+        "Version": "1.1.2",
+        "Date": "2026-07-01",
         "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\",\n                    comment = c(ORCID = \"0000-0001-6419-907X\")),\n             person(\"Romain\", \"Francois\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0002-2444-4226\")),\n             person(\"JJ\", \"Allaire\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0003-0174-9868\")),\n             person(\"Kevin\", \"Ushey\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0003-2880-7407\")),\n             person(\"Qiang\", \"Kou\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-6786-5453\")),\n             person(\"Nathan\", \"Russell\", role = \"aut\"),\n             person(\"Iñaki\", \"Ucar\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-6403-5550\")),\n             person(\"Doug\", \"Bates\", role = \"aut\",\n                    comment = c(ORCID = \"0000-0001-8316-9503\")),\n             person(\"John\", \"Chambers\", role = \"aut\"))",
         "Description": "The 'Rcpp' package provides R functions as well as C++ classes which\n offer a seamless integration of R and C++. Many R data types and objects can be\n mapped back and forth to C++ equivalents which facilitates both writing of new\n code as well as easier integration of third-party libraries. Documentation\n about 'Rcpp' is provided by several vignettes included in this package, via the\n 'Rcpp Gallery' site at <https://gallery.rcpp.org>, the paper by Eddelbuettel and\n Francois (2011, <doi:10.18637/jss.v040.i08>), the book by Eddelbuettel (2013,\n <doi:10.1007/978-1-4614-6868-4>) and the paper by Eddelbuettel and Balamuta (2018,\n <doi:10.1080/00031305.2017.1375990>); see 'citation(\"Rcpp\")' for details.",
         "Depends": "R (>= 3.5.0)",
@@ -313,18 +329,22 @@
         "URL": "https://www.rcpp.org,\nhttps://dirk.eddelbuettel.com/code/rcpp.html,\nhttps://github.com/RcppCore/Rcpp",
         "License": "GPL (>= 2)",
         "BugReports": "https://github.com/RcppCore/Rcpp/issues",
-        "MailingList": "rcpp-devel@lists.r-forge.r-project.org",
         "RoxygenNote": "6.1.1",
         "Encoding": "UTF-8",
         "VignetteBuilder": "Rcpp",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-23 14:12:31 UTC; edd",
+        "Packaged": "2026-07-01 11:00:56 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Romain Francois [aut] (ORCID: <https://orcid.org/0000-0002-2444-4226>),\n  JJ Allaire [aut] (ORCID: <https://orcid.org/0000-0003-0174-9868>),\n  Kevin Ushey [aut] (ORCID: <https://orcid.org/0000-0003-2880-7407>),\n  Qiang Kou [aut] (ORCID: <https://orcid.org/0000-0001-6786-5453>),\n  Nathan Russell [aut],\n  Iñaki Ucar [aut] (ORCID: <https://orcid.org/0000-0001-6403-5550>),\n  Doug Bates [aut] (ORCID: <https://orcid.org/0000-0001-8316-9503>),\n  John Chambers [aut]",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-24 05:30:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:45 UTC; unix",
-        "Archs": "Rcpp.so.dSYM"
+        "Date/Publication": "2026-07-05 08:30:08 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:02:08 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "Rcpp",
+        "RemoteRef": "Rcpp",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.2"
       }
     },
     "RcppCCTZ": {
@@ -352,8 +372,13 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-08 16:20:21 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:37:01 UTC; unix",
-        "Archs": "RcppCCTZ.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:21:42 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "RcppCCTZ",
+        "RemoteRef": "RcppCCTZ",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.2.14"
       }
     },
     "RcppDate": {
@@ -363,8 +388,8 @@
         "Package": "RcppDate",
         "Type": "Package",
         "Title": "'date' C++ Header Library for Date and Time Functionality",
-        "Version": "0.0.6",
-        "Date": "2025-05-29",
+        "Version": "0.0.7",
+        "Date": "2026-07-27",
         "Authors@R": "c(person(\"Dirk\", \"Eddelbuettel\", role = c(\"aut\", \"cre\"), email = \"edd@debian.org\",\n                    comment = c(ORCID = \"0000-0001-6419-907X\")),\n             person(\"Howard\", \"Hinnant\", role = \"aut\", comment = \"author of 'date' library\"))",
         "Description": "A header-only C++ library is provided with support\n for dates, time zones, ISO weeks, Julian dates, and Islamic dates.\n 'date' offers extensive date and time functionality for the C++11,\n C++14 and C++17 standards and was written by Howard Hinnant and released \n under the MIT license. A slightly modified version has been accepted\n (along with 'tz.h') as part of C++20. This package regroups all\n header files from the upstream repository by Howard Hinnant so that\n other R packages can use them in their C++ code. At present, few of\n the types have explicit 'Rcpp' wrappers though these may be added as\n needed. ",
         "License": "GPL (>= 2)",
@@ -372,12 +397,17 @@
         "URL": "https://github.com/eddelbuettel/rcppdate,\nhttps://dirk.eddelbuettel.com/code/rcpp.date.html",
         "BugReports": "https://github.com/eddelbuettel/rcppdate/issues",
         "NeedsCompilation": "no",
-        "Packaged": "2025-05-29 10:46:52 UTC; edd",
+        "Packaged": "2026-07-28 01:15:40 UTC; edd",
         "Author": "Dirk Eddelbuettel [aut, cre] (ORCID:\n    <https://orcid.org/0000-0001-6419-907X>),\n  Howard Hinnant [aut] (author of 'date' library)",
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-05-29 14:50:09 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 16:37:02 UTC; unix"
+        "Date/Publication": "2026-07-28 09:10:15 UTC",
+        "Built": "R 4.6.1; ; 2026-07-29 23:51:17 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "RcppDate",
+        "RemoteRef": "RcppDate",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.0.7"
       }
     },
     "RcppTOML": {
@@ -405,8 +435,13 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-08 14:30:06 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:50:47 UTC; unix",
-        "Archs": "RcppTOML.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:04:02 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "RcppTOML",
+        "RemoteRef": "RcppTOML",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.2.3"
       }
     },
     "S7": {
@@ -438,8 +473,13 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 11:00:10 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:28:03 UTC; unix",
-        "Archs": "S7.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:15 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "S7",
+        "RemoteRef": "S7",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.2.2"
       }
     },
     "anytime": {
@@ -469,8 +509,13 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-14 12:30:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:05:26 UTC; unix",
-        "Archs": "anytime.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:12:19 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "anytime",
+        "RemoteRef": "anytime",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.13"
       }
     },
     "askpass": {
@@ -497,8 +542,13 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-04 07:20:03 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:17:34 UTC; unix",
-        "Archs": "askpass.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "askpass",
+        "RemoteRef": "askpass",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.1"
       }
     },
     "attempt": {
@@ -524,7 +574,12 @@
         "Maintainer": "Colin Fay <contact@colinfay.me>",
         "Repository": "CRAN",
         "Date/Publication": "2020-05-03 20:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:49:28 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:12:30 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "attempt",
+        "RemoteRef": "attempt",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.1"
       }
     },
     "base64enc": {
@@ -547,8 +602,8 @@
         "Packaged": "2026-02-02 01:51:07 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-02 06:31:10 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:42 UTC; unix",
-        "Archs": "base64enc.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-21 00:40:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "bit": {
@@ -576,8 +631,13 @@
         "Maintainer": "Michael Chirico <MichaelChirico4@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-06 10:50:01 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:45:18 UTC; unix",
-        "Archs": "bit.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:22 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "bit",
+        "RemoteRef": "bit",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "4.6.0"
       }
     },
     "bit64": {
@@ -607,8 +667,13 @@
         "Maintainer": "Michael Chirico <michaelchirico4@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-19 09:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-19 11:15:45 UTC; unix",
-        "Archs": "bit64.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:49 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "bit64",
+        "RemoteRef": "bit64",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "4.8.2"
       }
     },
     "blob": {
@@ -637,7 +702,12 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-14 09:10:14 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:18:16 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:35 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "blob",
+        "RemoteRef": "blob",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.0"
       }
     },
     "bslib": {
@@ -670,7 +740,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-16 08:10:07 UTC",
-        "Built": "R 4.6.0; ; 2026-05-16 12:36:52 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:44 UTC; windows"
       }
     },
     "cachem": {
@@ -697,8 +767,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-16 09:50:11 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:13:45 UTC; unix",
-        "Archs": "cachem.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "callr": {
@@ -707,27 +777,33 @@
       "description": {
         "Package": "callr",
         "Title": "Call R from R",
-        "Version": "3.7.6",
-        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"),\n           comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\"))\n  )",
+        "Version": "3.8.0",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\", \"cph\"),\n           comment = c(ORCID = \"0000-0001-7098-9676\")),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(\"Ascent Digital Services\", role = c(\"cph\", \"fnd\"))\n  )",
         "Description": "It is sometimes useful to perform a computation in a separate\n    R process, without affecting the current R process at all.  This\n    packages does exactly that.",
         "License": "MIT + file LICENSE",
         "URL": "https://callr.r-lib.org, https://github.com/r-lib/callr",
         "BugReports": "https://github.com/r-lib/callr/issues",
         "Depends": "R (>= 3.4)",
-        "Imports": "processx (>= 3.6.1), R6, utils",
-        "Suggests": "asciicast (>= 2.3.1), cli (>= 1.1.0), mockery, ps, rprojroot,\nspelling, testthat (>= 3.2.0), withr (>= 2.3.0)",
+        "Imports": "otel (>= 0.2.0), processx (>= 3.6.1), R6, utils",
+        "Suggests": "asciicast (>= 2.3.1), carrier, cli (>= 1.1.0), otelsdk (>=\n0.2.0), ps, rprojroot, spelling, testthat (>= 3.2.0), withr (>=\n2.3.0)",
         "Config/Needs/website": "r-lib/asciicast, glue, htmlwidgets, igraph,\ntibble, tidyverse/tidytemplate",
         "Config/testthat/edition": "3",
+        "Config/usethis/last-upkeep": "2025-04-28",
         "Encoding": "UTF-8",
         "Language": "en-US",
-        "RoxygenNote": "7.3.1.9000",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "no",
-        "Packaged": "2024-03-25 12:10:25 UTC; gaborcsardi",
-        "Author": "Gábor Csárdi [aut, cre, cph] (<https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd],\n  Ascent Digital Services [cph, fnd]",
+        "Packaged": "2026-06-05 08:20:00 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0001-7098-9676>),\n  Winston Chang [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Ascent Digital Services [cph, fnd]",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2024-03-25 13:30:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:21:34 UTC; unix"
+        "Date/Publication": "2026-06-05 11:40:13 UTC",
+        "Built": "R 4.6.0; ; 2026-06-05 23:51:01 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "callr",
+        "RemoteRef": "callr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.8.0"
       }
     },
     "cellranger": {
@@ -754,7 +830,12 @@
         "Maintainer": "Jennifer Bryan <jenny@stat.ubc.ca>",
         "Repository": "CRAN",
         "Date/Publication": "2016-07-27 03:17:48",
-        "Built": "R 4.6.0; ; 2026-04-26 05:17:23 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:20:13 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "cellranger",
+        "RemoteRef": "cellranger",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.0"
       }
     },
     "cli": {
@@ -783,8 +864,13 @@
         "Maintainer": "Gábor Csárdi <gabor@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-09 09:50:18 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:10 UTC; unix",
-        "Archs": "cli.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:15 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "cli",
+        "RemoteRef": "cli",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.6.6"
       }
     },
     "clipr": {
@@ -813,7 +899,33 @@
         "Maintainer": "Matthew Lincoln <matthew.d.lincoln@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-25 05:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-25 08:30:02 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:26 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "clipr",
+        "RemoteRef": "clipr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.8.1"
+      }
+    },
+    "codetools": {
+      "Source": "CRAN",
+      "Repository": "https://cloud.r-project.org",
+      "description": {
+        "Package": "codetools",
+        "Version": "0.2-20",
+        "Priority": "recommended",
+        "Author": "Luke Tierney <luke-tierney@uiowa.edu>",
+        "Description": "Code analysis tools for R.",
+        "Title": "Code Analysis Tools for R",
+        "Depends": "R (>= 2.1)",
+        "Maintainer": "Luke Tierney <luke-tierney@uiowa.edu>",
+        "URL": "https://gitlab.com/luke-tierney/codetools",
+        "License": "GPL",
+        "NeedsCompilation": "no",
+        "Packaged": "2024-03-31 18:18:09 UTC; luke",
+        "Repository": "CRAN",
+        "Date/Publication": "2024-03-31 20:10:06 UTC",
+        "Built": "R 4.6.0; ; 2026-04-24 08:16:28 UTC; windows"
       }
     },
     "commonmark": {
@@ -839,8 +951,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-07-07 13:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:27:57 UTC; unix",
-        "Archs": "commonmark.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-20 00:46:30 UTC; windows",
+        "Archs": "x64"
       }
     },
     "config": {
@@ -869,7 +981,12 @@
         "Maintainer": "Andrie de Vries <apdevries@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-30 16:50:36 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:49:14 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:12:29 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "config",
+        "RemoteRef": "config",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.2"
       }
     },
     "coro": {
@@ -898,7 +1015,12 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-11-05 10:30:09 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 17:06:36 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:03:54 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "coro",
+        "RemoteRef": "coro",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.0"
       }
     },
     "cpp11": {
@@ -927,7 +1049,7 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-06 14:40:12 UTC",
-        "Built": "R 4.6.0; ; 2026-05-06 16:42:29 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 00:46:24 UTC; windows"
       }
     },
     "crayon": {
@@ -954,7 +1076,12 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-06-20 13:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:44:21 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:26 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "crayon",
+        "RemoteRef": "crayon",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.3"
       }
     },
     "credentials": {
@@ -983,7 +1110,12 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-12 09:30:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:16:31 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:51 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "credentials",
+        "RemoteRef": "credentials",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.3"
       }
     },
     "curl": {
@@ -1012,8 +1144,8 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:29:32 UTC; unix",
-        "Archs": "curl.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:37 UTC; windows",
+        "Archs": "x64"
       }
     },
     "data.table": {
@@ -1040,8 +1172,13 @@
         "Maintainer": "Tyson Barrett <t.barrett88@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-06 05:10:20 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-06 07:00:46 UTC; unix",
-        "Archs": "data_table.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:28 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "data.table",
+        "RemoteRef": "data.table",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.18.4"
       }
     },
     "dbplyr": {
@@ -1051,30 +1188,35 @@
         "Type": "Package",
         "Package": "dbplyr",
         "Title": "A 'dplyr' Back End for Databases",
-        "Version": "2.5.2",
+        "Version": "2.6.0",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Maximilian\", \"Girlich\", role = \"aut\"),\n    person(\"Edgar\", \"Ruiz\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"))\n  )",
-        "Description": "A 'dplyr' back end for databases that allows you to work with\n    remote database tables as if they are in-memory data frames.  Basic\n    features works with any database that has a 'DBI' back end; more\n    advanced features require 'SQL' translation to be provided by the\n    package author.",
+        "Description": "A 'dplyr' back end for databases that allows you to work with\n    remote database tables as if they are in-memory data frames.  Basic\n    features work with any database that has a 'DBI' back end; more\n    advanced features require 'SQL' translation to be provided by the\n    package author.",
         "License": "MIT + file LICENSE",
         "URL": "https://dbplyr.tidyverse.org/, https://github.com/tidyverse/dbplyr",
         "BugReports": "https://github.com/tidyverse/dbplyr/issues",
-        "Depends": "R (>= 3.6)",
+        "Depends": "R (>= 4.1)",
         "Imports": "blob (>= 1.2.0), cli (>= 3.6.1), DBI (>= 1.1.3), dplyr (>=\n1.1.2), glue (>= 1.6.2), lifecycle (>= 1.0.3), magrittr,\nmethods, pillar (>= 1.9.0), purrr (>= 1.0.1), R6 (>= 2.2.2),\nrlang (>= 1.1.1), tibble (>= 3.2.1), tidyr (>= 1.3.0),\ntidyselect (>= 1.2.1), utils, vctrs (>= 0.6.3), withr (>=\n2.5.0)",
-        "Suggests": "bit64, covr, knitr, Lahman, nycflights13, odbc (>= 1.4.2),\nRMariaDB (>= 1.2.2), rmarkdown, RPostgres (>= 1.4.5),\nRPostgreSQL, RSQLite (>= 2.3.8), testthat (>= 3.1.10)",
+        "Suggests": "adbcdrivermanager, adbcsqlite, adbi, bit64, covr, knitr,\nLahman, nycflights13, odbc (>= 1.4.2), RJDBC, RMariaDB (>=\n1.2.2), rmarkdown, RPostgres (>= 1.4.5), RPostgreSQL, RSQLite\n(>= 2.3.8), testthat (>= 3.1.10)",
         "VignetteBuilder": "knitr",
         "Config/Needs/website": "tidyverse/tidytemplate",
         "Config/testthat/edition": "3",
         "Config/testthat/parallel": "TRUE",
         "Encoding": "UTF-8",
         "Language": "en-gb",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'db-sql.R' 'utils-check.R' 'import-standalone-types-check.R'\n'import-standalone-obj-type.R' 'utils.R' 'sql.R' 'escape.R'\n'translate-sql-cut.R' 'translate-sql-quantile.R'\n'translate-sql-string.R' 'translate-sql-paste.R'\n'translate-sql-helpers.R' 'translate-sql-window.R'\n'translate-sql-conditional.R' 'backend-.R' 'backend-access.R'\n'backend-hana.R' 'backend-hive.R' 'backend-impala.R'\n'verb-copy-to.R' 'backend-mssql.R' 'backend-mysql.R'\n'backend-odbc.R' 'backend-oracle.R' 'backend-postgres.R'\n'backend-postgres-old.R' 'backend-redshift.R'\n'backend-snowflake.R' 'backend-spark-sql.R' 'backend-sqlite.R'\n'backend-teradata.R' 'build-sql.R' 'data-cache.R'\n'data-lahman.R' 'data-nycflights13.R' 'db-escape.R' 'db-io.R'\n'db.R' 'dbplyr.R' 'explain.R' 'ident.R'\n'import-standalone-s3-register.R' 'join-by-compat.R'\n'join-cols-compat.R' 'lazy-join-query.R' 'lazy-ops.R'\n'lazy-query.R' 'lazy-select-query.R' 'lazy-set-op-query.R'\n'memdb.R' 'optimise-utils.R' 'pillar.R' 'progress.R'\n'sql-build.R' 'query-join.R' 'query-select.R'\n'query-semi-join.R' 'query-set-op.R' 'query.R' 'reexport.R'\n'remote.R' 'rows.R' 'schema.R' 'simulate.R' 'sql-clause.R'\n'sql-expr.R' 'src-sql.R' 'src_dbi.R' 'table-name.R'\n'tbl-lazy.R' 'tbl-sql.R' 'test-frame.R' 'testthat.R'\n'tidyeval-across.R' 'tidyeval.R' 'translate-sql.R'\n'utils-format.R' 'verb-arrange.R' 'verb-compute.R'\n'verb-count.R' 'verb-distinct.R' 'verb-do-query.R' 'verb-do.R'\n'verb-expand.R' 'verb-fill.R' 'verb-filter.R' 'verb-group_by.R'\n'verb-head.R' 'verb-joins.R' 'verb-mutate.R'\n'verb-pivot-longer.R' 'verb-pivot-wider.R' 'verb-pull.R'\n'verb-select.R' 'verb-set-ops.R' 'verb-slice.R'\n'verb-summarise.R' 'verb-uncount.R' 'verb-window.R' 'zzz.R'",
+        "Collate": "'verb-copy-inline.R' 'verb-copy-to.R' 'db-sql.R' 'db.R'\n'utils-check.R' 'import-standalone-types-check.R'\n'import-standalone-obj-type.R' 'utils.R' 'sql.R' 'escape.R'\n'translate-sql-cut.R' 'translate-sql-string.R'\n'translate-sql-aggregate.R' 'translate-sql-scalar.R'\n'translate-sql-helpers.R' 'translate-sql-window.R'\n'translate-sql-conditional.R' 'backend-.R' 'backend-access.R'\n'backend-adbc.R' 'backend-db2.R' 'backend-hana.R'\n'backend-hive.R' 'backend-impala.R' 'backend-jdbc.R'\n'backend-mssql.R' 'backend-mysql.R' 'backend-odbc.R'\n'backend-oracle.R' 'backend-postgres.R'\n'backend-postgres-old.R' 'backend-redshift.R'\n'backend-snowflake.R' 'backend-spark-sql.R' 'backend-sqlite.R'\n'backend-teradata.R' 'backward-compatibility.R'\n'bind-queries.R' 'data-cache.R' 'data-lahman.R'\n'data-nycflights13.R' 'db-io.R' 'dbplyr.R' 'ident.R'\n'import-standalone-s3-register.R' 'join-by-compat.R'\n'join-cols-compat.R' 'lazy-ops.R' 'memdb.R' 'optimise-utils.R'\n'progress.R' 'query-base.R' 'query-join.R' 'query-rf-join.R'\n'query-select.R' 'query-semi-join.R' 'query-set-op.R'\n'query-union.R' 'query.R' 'remote.R' 'rows.R' 'schema.R'\n'sql-build.R' 'sql-clause.R' 'sql-dialect.R' 'sql-glue.R'\n'sql-quote.R' 'sql-superseded.R' 'src-sql.R' 'src_dbi.R'\n'table-name.R' 'tbl-lazy.R' 'tbl-sql.R' 'tidyeval-across.R'\n'tidyeval.R' 'translate-sql.R' 'utils-format.R'\n'verb-arrange.R' 'verb-collapse.R' 'verb-collect.R'\n'verb-compute.R' 'verb-count.R' 'verb-distinct.R'\n'verb-do-query.R' 'verb-do.R' 'verb-expand.R' 'verb-explain.R'\n'verb-fill.R' 'verb-filter.R' 'verb-group_by.R' 'verb-head.R'\n'verb-joins.R' 'verb-mutate.R' 'verb-pivot-longer.R'\n'verb-pivot-wider.R' 'verb-pull.R' 'verb-select.R'\n'verb-set-ops.R' 'verb-slice.R' 'verb-summarise.R'\n'verb-uncount.R' 'verb-window.R' 'with-dialect.R' 'zzz.R'",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "no",
-        "Packaged": "2026-02-12 23:48:38 UTC; hadleywickham",
+        "Packaged": "2026-06-17 12:33:03 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Maximilian Girlich [aut],\n  Edgar Ruiz [aut],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-02-13 07:01:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 15:54:24 UTC; unix"
+        "Date/Publication": "2026-06-17 21:50:07 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 03:50:26 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "dbplyr",
+        "RemoteRef": "dbplyr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.6.0"
       }
     },
     "desc": {
@@ -1104,7 +1246,7 @@
         "Author": "Gábor Csárdi [aut, cre],\n  Kirill Müller [aut],\n  Jim Hester [aut],\n  Maëlle Salmon [ctb] (<https://orcid.org/0000-0002-2815-0399>),\n  Posit Software, PBC [cph, fnd]",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-10 11:40:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:48:08 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 01:36:06 UTC; windows"
       }
     },
     "digest": {
@@ -1131,8 +1273,13 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-19 13:20:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:59 UTC; unix",
-        "Archs": "digest.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:17 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "digest",
+        "RemoteRef": "digest",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.6.39"
       }
     },
     "dplyr": {
@@ -1164,8 +1311,15 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-03 07:30:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:09:07 UTC; unix",
-        "Archs": "dplyr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-06-20 03:41:58 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "dplyr",
+        "RemotePkgRef": "dplyr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.2.1"
       }
     },
     "duckdb": {
@@ -1174,33 +1328,36 @@
       "description": {
         "Package": "duckdb",
         "Title": "DBI Package for the DuckDB Database Management System",
-        "Version": "1.5.2",
+        "Version": "1.5.5",
         "Authors@R": "c(\n    person(\"Hannes\", \"Mühleisen\", , \"hannes@cwi.nl\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-8552-0029\")),\n    person(\"Mark\", \"Raasveldt\", , \"mark.raasveldt@cwi.nl\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-5005-6844\")),\n    person(\"Kirill\", \"Müller\", , \"kirill@cynkra.com\", role = \"cre\",\n           comment = c(ORCID = \"0000-0002-1416-3412\")),\n    person(\"Stichting DuckDB Foundation\", role = \"cph\"),\n    person(\"Apache Software Foundation\", role = \"cph\"),\n    person(\"PostgreSQL Global Development Group\", role = \"cph\"),\n    person(\"The Regents of the University of California\", role = \"cph\"),\n    person(\"Cameron Desrochers\", role = \"cph\"),\n    person(\"Victor Zverovich\", role = \"cph\"),\n    person(\"RAD Game Tools\", role = \"cph\"),\n    person(\"Valve Software\", role = \"cph\"),\n    person(\"Rich Geldreich\", role = \"cph\"),\n    person(\"Tenacious Software LLC\", role = \"cph\"),\n    person(\"The RE2 Authors\", role = \"cph\"),\n    person(\"Google Inc.\", role = \"cph\"),\n    person(\"Facebook Inc.\", role = \"cph\"),\n    person(\"Steven G. Johnson\", role = \"cph\"),\n    person(\"Jiahao Chen\", role = \"cph\"),\n    person(\"Tony Kelman\", role = \"cph\"),\n    person(\"Jonas Fonseca\", role = \"cph\"),\n    person(\"Lukas Fittl\", role = \"cph\"),\n    person(\"Salvatore Sanfilippo\", role = \"cph\"),\n    person(\"Art.sy, Inc.\", role = \"cph\"),\n    person(\"Oran Agra\", role = \"cph\"),\n    person(\"Redis Labs, Inc.\", role = \"cph\"),\n    person(\"Melissa O'Neill\", role = \"cph\"),\n    person(\"PCG Project contributors\", role = \"cph\")\n  )",
         "Description": "The DuckDB project is an embedded analytical data management\n    system with support for the Structured Query Language (SQL). This\n    package includes all of DuckDB and an R Database Interface (DBI)\n    connector.",
         "License": "MIT + file LICENSE",
         "URL": "https://r.duckdb.org/, https://github.com/duckdb/duckdb-r",
         "BugReports": "https://github.com/duckdb/duckdb-r/issues",
-        "Depends": "DBI, R (>= 4.1.0)",
+        "Depends": "DBI, R (>= 4.2.0)",
         "Imports": "methods, utils",
-        "Suggests": "adbcdrivermanager, arrow (>= 13.0.0), bit64, callr, clock,\nDBItest, dbplyr, dplyr, rlang, sf, testthat (>= 3.0.0), tibble,\nvctrs, wk, withr",
+        "Suggests": "adbcdrivermanager, arrow (>= 13.0.0), bit64, callr, clock,\nDBItest, dbplyr, dplyr, nanoarrow, rlang, sf, testthat (>=\n3.0.0), tibble, vctrs, wk, withr",
         "Biarch": "true",
         "Config/build/compilation-database": "false",
         "Config/build/never-clean": "true",
         "Config/comment/compilation-database": "Generate manually with\npkgload:::generate_db() for faster pkgload::load_all()",
-        "Config/gha/extra-packages": "arrow=?ignore-before-r=4.2.0\nadbcdrivermanager=?ignore-before-r=4.2.0",
-        "Config/gha/filter": "os != \"windows-latest\" | r != \"4.1\"",
-        "Config/gha/filter-note": "Inexplicable build failures on Windows GHA with\nR 4.1, works locally",
         "Config/testthat/edition": "3",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3.9000",
         "SystemRequirements": "xz (for building from source)",
+        "Config/roxygen2/version": "8.0.0.9000",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-13 15:04:10 UTC; kirill",
+        "Packaged": "2026-07-24 10:43:59 UTC; kirill",
         "Author": "Hannes Mühleisen [aut] (ORCID: <https://orcid.org/0000-0001-8552-0029>),\n  Mark Raasveldt [aut] (ORCID: <https://orcid.org/0000-0001-5005-6844>),\n  Kirill Müller [cre] (ORCID: <https://orcid.org/0000-0002-1416-3412>),\n  Stichting DuckDB Foundation [cph],\n  Apache Software Foundation [cph],\n  PostgreSQL Global Development Group [cph],\n  The Regents of the University of California [cph],\n  Cameron Desrochers [cph],\n  Victor Zverovich [cph],\n  RAD Game Tools [cph],\n  Valve Software [cph],\n  Rich Geldreich [cph],\n  Tenacious Software LLC [cph],\n  The RE2 Authors [cph],\n  Google Inc. [cph],\n  Facebook Inc. [cph],\n  Steven G. Johnson [cph],\n  Jiahao Chen [cph],\n  Tony Kelman [cph],\n  Jonas Fonseca [cph],\n  Lukas Fittl [cph],\n  Salvatore Sanfilippo [cph],\n  Art.sy, Inc. [cph],\n  Oran Agra [cph],\n  Redis Labs, Inc. [cph],\n  Melissa O'Neill [cph],\n  PCG Project contributors [cph]",
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-13 19:20:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 16:26:08 UTC; unix"
+        "Date/Publication": "2026-07-25 04:40:07 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-30 00:53:49 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "duckdb",
+        "RemoteRef": "duckdb",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.5"
       }
     },
     "ellmer": {
@@ -1209,30 +1366,36 @@
       "description": {
         "Package": "ellmer",
         "Title": "Chat with Large Language Models",
-        "Version": "0.4.1",
+        "Version": "0.4.2",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0003-4757-117X\")),\n    person(\"Joe\", \"Cheng\", role = \"aut\"),\n    person(\"Aaron\", \"Jacobs\", role = \"aut\"),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-9986-114X\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\"))\n  )",
         "Description": "Chat with large language models from a range of providers\n    including 'Claude' <https://claude.ai>, 'OpenAI'\n    <https://chatgpt.com>, and more. Supports streaming, asynchronous\n    calls, tool calling, and structured data extraction.",
         "License": "MIT + file LICENSE",
         "URL": "https://ellmer.tidyverse.org, https://github.com/tidyverse/ellmer",
         "BugReports": "https://github.com/tidyverse/ellmer/issues",
         "Depends": "R (>= 4.1)",
-        "Imports": "cli, coro (>= 1.1.0), glue, httr2 (>= 1.2.1), jsonlite, later\n(>= 1.4.0), lifecycle, promises (>= 1.5.0), R6, rlang (>=\n1.1.0), S7 (>= 0.2.0), tibble, vctrs",
+        "Imports": "cli, coro (>= 1.1.0), glue, httr2 (>= 1.2.3), jsonlite, later\n(>= 1.4.0), lifecycle, promises (>= 1.5.0), R6, rlang (>=\n1.3.0), S7 (>= 0.2.0), tibble, vctrs",
         "Suggests": "connectcreds, curl (>= 6.0.1), gargle, gitcreds, jose, knitr,\nmagick, openssl, otel (>= 0.2.0), otelsdk (>= 0.2.0),\npaws.common, png, rmarkdown, shiny, shinychat (>= 0.3.0),\ntestthat (>= 3.0.0), vcr (>= 2.0.0), withr",
         "VignetteBuilder": "knitr",
+        "Config/Needs/prices": "cli, dplyr, jsonlite, jsonvalidate, stringr,\ntidyr, usethis",
         "Config/Needs/website": "tidyverse/tidytemplate, rmarkdown",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Config/testthat/parallel": "true",
         "Config/testthat/start-first": "chat, provider*",
         "Encoding": "UTF-8",
-        "Collate": "'utils-S7.R' 'types.R' 'ellmer-package.R' 'tools-def.R'\n'content.R' 'provider.R' 'as-json.R' 'batch-chat.R'\n'chat-structured.R' 'chat-tools-content.R' 'turns.R'\n'chat-tools.R' 'chat-utils.R' 'utils-coro.R' 'chat.R'\n'content-image.R' 'content-pdf.R' 'content-replay.R' 'httr2.R'\n'import-standalone-defer.R' 'import-standalone-obj-type.R'\n'import-standalone-purrr.R' 'import-standalone-types-check.R'\n'interpolate.R' 'live.R' 'otel.R' 'parallel-chat.R' 'params.R'\n'provider-any.R' 'provider-aws.R'\n'provider-openai-compatible.R' 'provider-azure.R'\n'provider-claude-files.R' 'provider-claude-tools.R'\n'provider-claude.R' 'provider-google.R' 'provider-cloudflare.R'\n'provider-databricks.R' 'provider-deepseek.R'\n'provider-github.R' 'provider-google-tools.R'\n'provider-google-upload.R' 'provider-groq.R'\n'provider-huggingface.R' 'provider-lmstudio.R'\n'provider-mistral.R' 'provider-ollama.R'\n'provider-openai-tools.R' 'provider-openai.R'\n'provider-openrouter.R' 'provider-perplexity.R'\n'provider-portkey.R' 'provider-snowflake.R' 'provider-vllm.R'\n'schema.R' 'stream-controller.R' 'tokens.R' 'tools-built-in.R'\n'tools-def-auto.R' 'utils-auth.R' 'utils-callbacks.R'\n'utils-cat.R' 'utils-merge.R' 'utils-prettytime.R' 'utils.R'\n'zzz.R'",
-        "Config/roxygen2/version": "8.0.0",
+        "Collate": "'utils-S7.R' 'types.R' 'ellmer-package.R' 'tools-def.R'\n'content.R' 'provider.R' 'as-json.R' 'batch-chat.R'\n'chat-structured.R' 'chat-tools-content.R' 'turns.R'\n'chat-tools.R' 'chat-utils.R' 'utils-coro.R' 'chat.R'\n'content-image.R' 'content-pdf.R' 'content-replay.R' 'httr2.R'\n'import-standalone-defer.R' 'import-standalone-obj-type.R'\n'import-standalone-purrr.R' 'import-standalone-types-check.R'\n'interpolate.R' 'live.R' 'otel.R' 'parallel-chat.R' 'params.R'\n'provider-any.R' 'provider-aws.R'\n'provider-openai-compatible.R' 'provider-azure.R'\n'provider-claude-files.R' 'provider-claude-tools.R'\n'provider-claude.R' 'provider-google.R' 'provider-cloudflare.R'\n'provider-databricks.R' 'provider-deepseek.R'\n'provider-github.R' 'provider-google-tools.R'\n'provider-google-upload.R' 'provider-groq.R'\n'provider-huggingface.R' 'provider-lmstudio.R'\n'provider-mistral.R' 'provider-ollama.R'\n'provider-openai-tools.R' 'provider-openai.R'\n'provider-openrouter.R' 'provider-perplexity.R'\n'provider-portkey.R' 'provider-posit.R' 'provider-snowflake.R'\n'provider-vllm.R' 'schema.R' 'stream-controller.R' 'tokens.R'\n'tools-built-in.R' 'tools-def-auto.R' 'utils-auth.R'\n'utils-callbacks.R' 'utils-cat.R' 'utils-merge.R'\n'utils-prettytime.R' 'utils.R' 'zzz.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-06 20:43:52 UTC; hadleywickham",
+        "Packaged": "2026-07-13 13:22:49 UTC; nic",
         "Author": "Hadley Wickham [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-4757-117X>),\n  Joe Cheng [aut],\n  Aaron Jacobs [aut],\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-05-07 10:40:02 UTC",
-        "Built": "R 4.6.0; ; 2026-05-07 11:41:36 UTC; unix"
+        "Date/Publication": "2026-07-13 23:00:09 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 02:51:18 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ellmer",
+        "RemoteRef": "ellmer",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.2"
       }
     },
     "evaluate": {
@@ -1260,7 +1423,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-27 16:40:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:39:47 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 00:46:29 UTC; windows"
       }
     },
     "excelR": {
@@ -1287,7 +1450,12 @@
         "Author": "Swechhya Bista [aut, cre],\n  Kent Russell [ctb],\n  Mārcis Bratka [ctb]",
         "Repository": "CRAN",
         "Date/Publication": "2020-03-09 13:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 18:06:54 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:32:01 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "excelR",
+        "RemoteRef": "excelR",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.0"
       }
     },
     "farver": {
@@ -1313,8 +1481,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-13 09:33:09 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:40:10 UTC; unix",
-        "Archs": "farver.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:16 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "farver",
+        "RemoteRef": "farver",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.1.2"
       }
     },
     "fastmap": {
@@ -1338,8 +1511,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-05-15 09:00:07 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:44 UTC; unix",
-        "Archs": "fastmap.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:27 UTC; windows",
+        "Archs": "x64"
       }
     },
     "fontawesome": {
@@ -1368,7 +1541,7 @@
         "Maintainer": "Richard Iannone <rich@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-11-16 17:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:26 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:47 UTC; windows"
       }
     },
     "fs": {
@@ -1401,8 +1574,15 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-18 15:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:15 UTC; unix",
-        "Archs": "fs.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-11 01:15:47 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "fs",
+        "RemotePkgRef": "fs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "2.1.0"
       }
     },
     "generics": {
@@ -1430,7 +1610,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-09 23:50:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:40:57 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:23 UTC; windows"
       }
     },
     "gert": {
@@ -1440,27 +1620,33 @@
         "Type": "Package",
         "Package": "gert",
         "Title": "Simple Git Client for R",
-        "Version": "2.3.1",
-        "Authors@R": "c(\n    person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroenooms@gmail.com\",\n      comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Jennifer\", \"Bryan\", role = \"ctb\", email = \"jenny@posit.co\",\n      comment = c(ORCID = \"0000-0002-6983-2759\")))",
+        "Version": "2.4.0",
+        "Authors@R": "c(\n    person(\"Jeroen\", \"Ooms\", role = c(\"aut\", \"cre\"), email = \"jeroenooms@gmail.com\",\n      comment = c(ORCID = \"0000-0002-4035-0289\")),\n    person(\"Maëlle\", \"Salmon\", role = \"aut\", comment = c(ORCID = \"0000-0002-2815-0399\")),\n    person(\"Jennifer\", \"Bryan\", role = \"ctb\", email = \"jenny@posit.co\",\n      comment = c(ORCID = \"0000-0002-6983-2759\")))",
         "Description": "Simple git client for R based on 'libgit2' <https://libgit2.org> with\n    support for SSH and HTTPS remotes. All functions in 'gert' use basic R data \n    types (such as vectors and data-frames) for their arguments and return values.\n    User credentials are shared with command line 'git' through the git-credential\n    store and ssh keys stored on disk or ssh-agent.",
         "License": "MIT + file LICENSE",
         "URL": "https://docs.ropensci.org/gert/,\nhttps://ropensci.r-universe.dev/gert",
         "BugReports": "https://github.com/r-lib/gert/issues",
         "Imports": "askpass, credentials (>= 1.2.1), openssl (>= 2.0.3),\nrstudioapi (>= 0.11), sys, zip (>= 2.1.0)",
-        "Suggests": "spelling, knitr, rmarkdown, testthat",
+        "Suggests": "spelling, knitr, rmarkdown, testthat (>= 3.0.0), roxygen2",
         "VignetteBuilder": "knitr",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
         "SystemRequirements": "libgit2 (>= 1.0): libgit2-devel (rpm) or\nlibgit2-dev (deb)",
         "Language": "en-US",
+        "Config/roxygen2/version": "8.0.0",
+        "Config/testthat/edition": "3",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-01-11 11:37:47 UTC; jeroen",
-        "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Jennifer Bryan [ctb] (ORCID: <https://orcid.org/0000-0002-6983-2759>)",
+        "Packaged": "2026-07-22 09:03:39 UTC; jeroen",
+        "Author": "Jeroen Ooms [aut, cre] (ORCID: <https://orcid.org/0000-0002-4035-0289>),\n  Maëlle Salmon [aut] (ORCID: <https://orcid.org/0000-0002-2815-0399>),\n  Jennifer Bryan [ctb] (ORCID: <https://orcid.org/0000-0002-6983-2759>)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-01-11 23:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:10:56 UTC; unix",
-        "Archs": "gert.so.dSYM"
+        "Date/Publication": "2026-07-22 09:40:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-22 23:51:56 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "gert",
+        "RemoteRef": "gert",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.4.0"
       }
     },
     "ggplot2": {
@@ -1493,7 +1679,12 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 09:10:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:16:05 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:37 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ggplot2",
+        "RemoteRef": "ggplot2",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "4.0.3"
       }
     },
     "glue": {
@@ -1524,8 +1715,15 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-17 05:11:01 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:32 UTC; unix",
-        "Archs": "glue.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-11 01:15:44 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemoteRef": "glue",
+        "RemotePkgRef": "glue",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteReposName": "CRAN",
+        "RemotePkgPlatform": "x86_64-w64-mingw32",
+        "RemoteSha": "1.8.1"
       }
     },
     "golem": {
@@ -1534,28 +1732,33 @@
       "description": {
         "Package": "golem",
         "Title": "A Framework for Robust Shiny Applications",
-        "Version": "0.5.1",
+        "Version": "1.0.1",
         "Authors@R": "c(\n    person(\"Colin\", \"Fay\", , \"contact@colinfay.me\", role = c(\"cre\", \"aut\"),\n           comment = c(ORCID = \"0000-0001-7343-1846\")),\n    person(\"Vincent\", \"Guyader\", , \"vincent@thinkr.fr\", role = \"aut\",\n           comment = c(ORCID = \"0000-0003-0671-9270\", \"previous maintainer\")),\n    person(\"Sébastien\", \"Rochette\", , \"sebastien@thinkr.fr\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-1565-9313\")),\n    person(\"Cervan\", \"Girard\", , \"cervan@thinkr.fr\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-4816-4624\")),\n    person(\"Novica\", \"Nakov\", , \"nnovica@gmail.com\", role = \"ctb\"),\n    person(\"David\", \"Granjon\", , \"dgranjon@ymail.com\", role = \"ctb\"),\n    person(\"Arthur\", \"Bréant\", , \"arthur@thinkr.fr\", role = \"ctb\"),\n    person(\"Antoine\", \"Languillaume\", , \"antoine@thinkr.fr\", role = \"ctb\"),\n    person(\"Ilya\", \"Zarubin\", , \"zarubin@wiso.uni-koeln.de\", role = \"ctb\"),\n    person(\"ThinkR\", role = \"cph\")\n  )",
         "Description": "An opinionated framework for building a production-ready\n    'Shiny' application. This package contains a series of tools for\n    building a robust 'Shiny' application from start to finish.",
         "License": "MIT + file LICENSE",
         "URL": "https://thinkr-open.github.io/golem/,\nhttps://github.com/ThinkR-open/golem",
         "BugReports": "https://github.com/ThinkR-open/golem/issues",
         "Depends": "R (>= 3.5.0)",
-        "Imports": "attempt (>= 0.3.0), config, here, htmltools, rlang (>= 1.0.0),\nshiny (>= 1.5.0), utils, yaml",
-        "Suggests": "attachment (>= 0.3.2), callr, cli (>= 2.0.0), covr, crayon,\ndesc, devtools, dockerfiler (>= 0.2.0), fs, httpuv, knitr,\nmockery, pkgbuild, pkgdown, pkgload (>= 1.3.0), processx,\npurrr, rcmdcheck, remotes, renv, rmarkdown, roxygen2,\nrsconnect, rstudioapi, sass, spelling, stringr, testthat (>=\n3.0.0), tools, usethis (>= 1.6.0), withr",
+        "Imports": "attempt (>= 0.3.0), codetools, config, htmltools, rlang (>=\n1.0.0), shiny (>= 1.5.0), utils, yaml",
+        "Suggests": "attachment (>= 0.3.2), callr, cli (>= 2.0.0), covr, desc,\ndevtools, dockerfiler (>= 0.2.5), fs, httpuv, knitr, lifecycle,\nmockery, pkgbuild, pkgdown, pkgload (>= 1.3.0), processx,\npurrr, rcmdcheck, remotes, renv, rmarkdown, roxygen2,\nrsconnect, rstudioapi, sass, spelling, stringr, testthat (>=\n3.0.0), tools, usethis (>= 1.6.0), withr",
         "VignetteBuilder": "knitr",
         "Config/testthat/edition": "3",
-        "Config/testthat/parallel": "true",
         "Encoding": "UTF-8",
         "Language": "en-US",
-        "RoxygenNote": "7.3.2",
+        "Config/roxygen2/version": "8.0.0",
+        "RoxygenNote": "8.0.0",
         "NeedsCompilation": "no",
-        "Packaged": "2024-08-27 10:11:51 UTC; colinfay",
-        "Author": "Colin Fay [cre, aut] (<https://orcid.org/0000-0001-7343-1846>),\n  Vincent Guyader [aut] (<https://orcid.org/0000-0003-0671-9270>,\n    previous maintainer),\n  Sébastien Rochette [aut] (<https://orcid.org/0000-0002-1565-9313>),\n  Cervan Girard [aut] (<https://orcid.org/0000-0002-4816-4624>),\n  Novica Nakov [ctb],\n  David Granjon [ctb],\n  Arthur Bréant [ctb],\n  Antoine Languillaume [ctb],\n  Ilya Zarubin [ctb],\n  ThinkR [cph]",
+        "Packaged": "2026-07-07 15:18:51 UTC; colinfay",
+        "Author": "Colin Fay [cre, aut] (ORCID: <https://orcid.org/0000-0001-7343-1846>),\n  Vincent Guyader [aut] (ORCID: <https://orcid.org/0000-0003-0671-9270>,\n    previous maintainer),\n  Sébastien Rochette [aut] (ORCID:\n    <https://orcid.org/0000-0002-1565-9313>),\n  Cervan Girard [aut] (ORCID: <https://orcid.org/0000-0002-4816-4624>),\n  Novica Nakov [ctb],\n  David Granjon [ctb],\n  Arthur Bréant [ctb],\n  Antoine Languillaume [ctb],\n  Ilya Zarubin [ctb],\n  ThinkR [cph]",
         "Maintainer": "Colin Fay <contact@colinfay.me>",
         "Repository": "CRAN",
-        "Date/Publication": "2024-08-27 10:50:32 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 11:11:17 UTC; unix"
+        "Date/Publication": "2026-07-07 19:30:02 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 03:10:12 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "golem",
+        "RemoteRef": "golem",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.0.1"
       }
     },
     "gridExtra": {
@@ -1563,23 +1766,28 @@
       "Repository": "https://cloud.r-project.org",
       "description": {
         "Package": "gridExtra",
-        "Authors@R": "c(person(\"Baptiste\", \"Auguie\",\n    email = \"baptiste.auguie@gmail.com\",\n    role = c(\"aut\", \"cre\")), person(\"Anton\", \"Antonov\",\n    email = \"tonytonov@gmail.com\",\n    role = c(\"ctb\")))",
+        "Authors@R": "c(person(\"Baptiste\", \"Auguie\",\n    email = \"baptiste.auguie@vuw.ac.nz\",\n    role = c(\"aut\", \"cre\")), person(\"Anton\", \"Antonov\",\n    email = \"tonytonov@gmail.com\",\n    role = c(\"ctb\")))",
         "License": "GPL (>= 2)",
         "Title": "Miscellaneous Functions for \"Grid\" Graphics",
         "Type": "Package",
         "Description": "Provides a number of user-level functions to work with \"grid\"\n    graphics, notably to arrange multiple grid-based plots on a page, and draw\n    tables.",
-        "Version": "2.3",
+        "Version": "2.3.1",
         "VignetteBuilder": "knitr",
         "Imports": "gtable, grid, grDevices, graphics, utils",
         "Suggests": "ggplot2, egg, lattice, knitr, testthat",
         "RoxygenNote": "6.0.1",
         "NeedsCompilation": "no",
-        "Packaged": "2017-09-08 22:52:09 UTC; baptiste",
+        "Packaged": "2026-06-25 06:16:42 UTC; hornik",
         "Author": "Baptiste Auguie [aut, cre],\n  Anton Antonov [ctb]",
-        "Maintainer": "Baptiste Auguie <baptiste.auguie@gmail.com>",
+        "Maintainer": "Baptiste Auguie <baptiste.auguie@vuw.ac.nz>",
         "Repository": "CRAN",
-        "Date/Publication": "2017-09-09 14:12:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 11:14:31 UTC; unix"
+        "Date/Publication": "2026-06-25 08:54:51 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 02:10:56 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "gridExtra",
+        "RemoteRef": "gridExtra",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.3.1"
       }
     },
     "gtable": {
@@ -1609,7 +1817,12 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-25 13:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:41 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:44 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "gtable",
+        "RemoteRef": "gtable",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.6"
       }
     },
     "here": {
@@ -1638,7 +1851,12 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-15 05:10:09 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:50:06 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:04:02 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "here",
+        "RemoteRef": "here",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.0.2"
       }
     },
     "highr": {
@@ -1666,7 +1884,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-06 06:30:47 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:14:12 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 01:36:02 UTC; windows"
       }
     },
     "hms": {
@@ -1694,7 +1912,12 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-17 05:10:11 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:15:47 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:35 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "hms",
+        "RemoteRef": "hms",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.1.4"
       }
     },
     "htmltools": {
@@ -1725,8 +1948,8 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-04 11:50:09 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:13:58 UTC; unix",
-        "Archs": "htmltools.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "htmlwidgets": {
@@ -1754,7 +1977,7 @@
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-06 06:00:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 15:49:50 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:20:11 UTC; windows"
       }
     },
     "httpuv": {
@@ -1787,8 +2010,8 @@
         "Maintainer": "Winston Chang <winston@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-18 06:12:59 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 05:14:15 UTC; unix",
-        "Archs": "httpuv.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:43:40 UTC; windows",
+        "Archs": "x64"
       }
     },
     "httr": {
@@ -1816,7 +2039,12 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-13 16:20:15 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:16:18 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:38 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "httr",
+        "RemoteRef": "httr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.4.8"
       }
     },
     "httr2": {
@@ -1825,29 +2053,34 @@
       "description": {
         "Package": "httr2",
         "Title": "Perform HTTP Requests and Process the Responses",
-        "Version": "1.2.2",
+        "Version": "1.3.0",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(\"Maximilian\", \"Girlich\", role = \"ctb\")\n  )",
         "Description": "Tools for creating and modifying HTTP requests, then\n    performing them and processing the results. 'httr2' is a modern\n    re-imagining of 'httr' that uses a pipe-based interface and solves\n    more of the problems that API wrapping packages face.",
         "License": "MIT + file LICENSE",
         "URL": "https://httr2.r-lib.org, https://github.com/r-lib/httr2",
         "BugReports": "https://github.com/r-lib/httr2/issues",
         "Depends": "R (>= 4.1)",
-        "Imports": "cli (>= 3.0.0), curl (>= 6.4.0), glue, lifecycle, magrittr,\nopenssl, R6, rappdirs, rlang (>= 1.1.0), vctrs (>= 0.6.3),\nwithr",
-        "Suggests": "askpass, bench, clipr, covr, docopt, httpuv, jose, jsonlite,\nknitr, later (>= 1.4.0), nanonext, otel (>= 0.2.0), otelsdk (>=\n0.2.0), paws.common (>= 0.8.0), promises, rmarkdown, testthat\n(>= 3.1.8), tibble, webfakes (>= 1.4.0), xml2",
+        "Imports": "cli (>= 3.0.0), curl (>= 6.4.0), glue, lifecycle, magrittr,\nopenssl, R6, rlang (>= 1.3.0), vctrs (>= 0.6.3), withr",
+        "Suggests": "askpass, bench, clipr, covr, digest, docopt, httpuv, jose,\njsonlite, knitr, later (>= 1.4.0), nanonext, otel (>= 0.2.0),\notelsdk (>= 0.2.0), paws.common (>= 0.8.0), promises, rappdirs,\nrmarkdown, testthat (>= 3.1.8), tibble, webfakes (>= 1.4.0),\nxml2",
         "VignetteBuilder": "knitr",
         "Config/Needs/website": "tidyverse/tidytemplate",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Config/testthat/parallel": "true",
         "Config/testthat/start-first": "resp-stream, req-perform",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
         "NeedsCompilation": "no",
-        "Packaged": "2025-12-05 17:46:06 UTC; hadleywickham",
+        "Packaged": "2026-07-13 19:55:02 UTC; hadleywickham",
         "Author": "Hadley Wickham [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  Maximilian Girlich [ctb]",
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-12-08 09:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:17:04 UTC; unix"
+        "Date/Publication": "2026-07-13 21:50:06 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 02:30:19 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "httr2",
+        "RemoteRef": "httr2",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.0"
       }
     },
     "isoband": {
@@ -1878,8 +2111,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-07 06:10:07 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:14:25 UTC; unix",
-        "Archs": "isoband.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "isoband",
+        "RemoteRef": "isoband",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.0"
       }
     },
     "jpeg": {
@@ -1902,8 +2140,13 @@
         "Packaged": "2025-03-21 03:05:05 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-21 15:37:18 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:57:32 UTC; unix",
-        "Archs": "jpeg.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-21 00:42:23 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "jpeg",
+        "RemoteRef": "jpeg",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.1-11"
       }
     },
     "jquerylib": {
@@ -1927,7 +2170,7 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2021-04-26 17:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:12 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:47 UTC; windows"
       }
     },
     "jsonlite": {
@@ -1953,8 +2196,13 @@
         "Author": "Jeroen Ooms [aut, cre] (<https://orcid.org/0000-0002-4035-0289>),\n  Duncan Temple Lang [ctb],\n  Lloyd Hilaiel [cph] (author of bundled libyajl)",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 06:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:00 UTC; unix",
-        "Archs": "jsonlite.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:18 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "jsonlite",
+        "RemoteRef": "jsonlite",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.0"
       }
     },
     "knitr": {
@@ -1984,7 +2232,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-20 14:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:51 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 01:54:14 UTC; windows"
       }
     },
     "labeling": {
@@ -2006,7 +2254,12 @@
         "Packaged": "2023-08-29 21:01:57 UTC; loki",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-29 22:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:40:07 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-04-21 00:40:53 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "labeling",
+        "RemoteRef": "labeling",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.3"
       }
     },
     "later": {
@@ -2039,8 +2292,8 @@
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-05 07:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:14:28 UTC; unix",
-        "Archs": "later.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "lattice": {
@@ -2069,7 +2322,8 @@
         "Maintainer": "Deepayan Sarkar <deepayan.sarkar@r-project.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-09 06:10:13 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 08:58:51 UTC; unix"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-24 08:10:45 UTC; windows",
+        "Archs": "x64"
       }
     },
     "lemon": {
@@ -2098,7 +2352,12 @@
         "Maintainer": "Stefan McKinnon Edwards <sme@iysik.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-04 11:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 06:54:00 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:44:55 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "lemon",
+        "RemoteRef": "lemon",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.5.2"
       }
     },
     "lifecycle": {
@@ -2127,7 +2386,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-08 08:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 10:32:18 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 01:36:06 UTC; windows"
       }
     },
     "lubridate": {
@@ -2161,8 +2420,13 @@
         "Author": "Vitalie Spinu [aut, cre],\n  Garrett Grolemund [aut],\n  Hadley Wickham [aut],\n  Davis Vaughan [ctb],\n  Ian Lyttle [ctb],\n  Imanuel Costigan [ctb],\n  Jason Law [ctb],\n  Doug Mitarotonda [ctb],\n  Joseph Larmarange [ctb],\n  Jonathan Boiser [ctb],\n  Chel Hee Lee [ctb]",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-04 09:00:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:16:04 UTC; unix",
-        "Archs": "lubridate.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 02:07:37 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "lubridate",
+        "RemoteRef": "lubridate",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.9.5"
       }
     },
     "magrittr": {
@@ -2191,8 +2455,13 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-04 08:00:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:33 UTC; unix",
-        "Archs": "magrittr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 00:58:15 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "magrittr",
+        "RemoteRef": "magrittr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.5"
       }
     },
     "marquee": {
@@ -2224,8 +2493,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-15 13:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 01:09:38 UTC; unix",
-        "Archs": "marquee.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:54:14 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "marquee",
+        "RemoteRef": "marquee",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.1"
       }
     },
     "memoise": {
@@ -2250,7 +2524,7 @@
         "Maintainer": "Winston Chang <winston@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2021-11-26 16:11:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:19 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:46 UTC; windows"
       }
     },
     "microbenchmark": {
@@ -2276,8 +2550,13 @@
         "Maintainer": "Joshua M. Ulrich <josh.m.ulrich@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-09-04 18:30:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:43:17 UTC; unix",
-        "Archs": "microbenchmark.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:31 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "microbenchmark",
+        "RemoteRef": "microbenchmark",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.0"
       }
     },
     "mime": {
@@ -2302,8 +2581,8 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-17 20:20:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:38:55 UTC; unix",
-        "Archs": "mime.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-21 00:40:54 UTC; windows",
+        "Archs": "x64"
       }
     },
     "mirai": {
@@ -2313,30 +2592,35 @@
         "Type": "Package",
         "Package": "mirai",
         "Title": "Minimalist Async Evaluation Framework for R",
-        "Version": "2.7.1",
+        "Version": "2.7.2",
         "Authors@R": "c(\n    person(\"Charlie\", \"Gao\", , \"charlie.gao@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-0750-061X\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"ctb\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(\"Hibiki AI Limited\", role = \"cph\")\n  )",
         "Description": "Evaluates R expressions asynchronously and in parallel,\n    locally or distributed across networks. An official parallel cluster\n    type for R. Built on 'nanonext' and 'NNG', its non-polling,\n    event-driven architecture scales from a laptop to thousands of\n    processes across high-performance computing clusters and cloud\n    platforms. Features FIFO scheduling with task cancellation and bounded\n    queues, promises for reactive programming, 'OpenTelemetry' distributed\n    tracing, and custom serialization for cross-language data types.",
         "License": "MIT + file LICENSE",
         "URL": "https://mirai.r-lib.org, https://github.com/r-lib/mirai",
         "BugReports": "https://github.com/r-lib/mirai/issues",
         "Depends": "R (>= 3.6)",
-        "Imports": "nanonext (>= 1.9.0)",
-        "Suggests": "cli, later, litedown, mori, otel, otelsdk, secretbase",
+        "Imports": "nanonext (>= 1.10.1)",
+        "Suggests": "cli, litedown, mori, otel, otelsdk, secretbase",
         "Enhances": "parallel, promises",
         "VignetteBuilder": "litedown",
         "Config/Needs/coverage": "rlang",
         "Config/Needs/website": "tidyverse/tidytemplate",
         "Config/roxygen2/markdown": "TRUE",
-        "Config/roxygen2/version": "8.0.0",
-        "Config/usethis/last-upkeep": "2025-04-23",
+        "Config/roxygen2/version": "8.0.0.9000",
+        "Config/usethis/last-upkeep": "2026-07-11",
         "Encoding": "UTF-8",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-01 11:11:45 UTC; shikokuchuo",
+        "Packaged": "2026-07-20 07:28:30 UTC; cg334",
         "Author": "Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Joe Cheng [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Hibiki AI Limited [cph]",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-06-01 12:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-06-01 15:24:46 UTC; unix"
+        "Date/Publication": "2026-07-20 08:10:02 UTC",
+        "Built": "R 4.6.1; ; 2026-07-20 23:51:35 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "mirai",
+        "RemoteRef": "mirai",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.7.2"
       }
     },
     "nanonext": {
@@ -2346,7 +2630,7 @@
         "Type": "Package",
         "Package": "nanonext",
         "Title": "Lightweight Toolkit for Messaging, Concurrency and the Web",
-        "Version": "1.9.1",
+        "Version": "1.10.1",
         "Authors@R": "c(\n    person(\"Charlie\", \"Gao\", , \"charlie.gao@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-0750-061X\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(\"Hibiki AI Limited\", role = \"cph\"),\n    person(\"Staysail Systems, Inc.\", role = \"cph\",\n           comment = \"NNG library\"),\n    person(\"Capitar IT Group BV\", role = \"cph\",\n           comment = \"NNG library\"),\n    person(\"The Mbed TLS Contributors\", role = \"cph\",\n           comment = \"Mbed TLS library\"),\n    person(\"Pierre\", \"L'Ecuyer\", role = \"cph\",\n           comment = \"RngStreams library\"),\n    person(\"sakura authors\", role = \"cph\",\n           comment = \"Serialization hooks\"),\n    person(\"R Consortium\", role = \"fnd\",\n           comment = c(ROR = \"01z833950\"))\n  )",
         "Description": "R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ.\n    A toolkit for messaging, concurrency and the web. High-performance\n    socket messaging over in-process, IPC, TCP, WebSocket and secure TLS\n    transports implements 'Scalability Protocols', a standard for common\n    communications patterns including publish/subscribe, request/reply and\n    survey. A threaded concurrency framework with intuitive 'aio' objects\n    that resolve automatically upon completion of asynchronous operations,\n    and synchronisation primitives that allow R to wait on events\n    signalled by concurrent threads. A unified HTTP server hosting REST\n    endpoints, WebSocket connections and streaming on a single port, with\n    a built-in HTTP client.",
         "License": "MIT + file LICENSE",
@@ -2363,15 +2647,20 @@
         "Config/roxygen2/version": "8.0.0",
         "Config/usethis/last-upkeep": "2025-04-23",
         "Encoding": "UTF-8",
-        "SystemRequirements": "'libnng' >= 1.11 and 'libmbedtls' >= 2.5, or\n'cmake' to compile NNG and/or Mbed TLS included in package\nsources",
+        "SystemRequirements": "'libnng' >= 1.12 and 'libmbedtls' >= 3.0 (optional,\nbundled sources compiled otherwise)",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-06-01 02:08:34 UTC; shikokuchuo",
+        "Packaged": "2026-07-09 21:03:53 UTC; shikokuchuo",
         "Author": "Charlie Gao [aut, cre] (ORCID: <https://orcid.org/0000-0002-0750-061X>),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  Hibiki AI Limited [cph],\n  Staysail Systems, Inc. [cph] (NNG library),\n  Capitar IT Group BV [cph] (NNG library),\n  The Mbed TLS Contributors [cph] (Mbed TLS library),\n  Pierre L'Ecuyer [cph] (RngStreams library),\n  sakura authors [cph] (Serialization hooks),\n  R Consortium [fnd] (ROR: <https://ror.org/01z833950>)",
         "Maintainer": "Charlie Gao <charlie.gao@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-06-01 06:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-06-01 10:22:23 UTC; unix",
-        "Archs": "nanonext.so.dSYM"
+        "Date/Publication": "2026-07-09 21:50:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:03:00 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "nanonext",
+        "RemoteRef": "nanonext",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.10.1"
       }
     },
     "nanotime": {
@@ -2402,8 +2691,13 @@
         "Maintainer": "Dirk Eddelbuettel <edd@debian.org>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-21 12:30:12 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-22 00:16:12 UTC; unix",
-        "Archs": "nanotime.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:07:07 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "nanotime",
+        "RemoteRef": "nanotime",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.15"
       }
     },
     "openssl": {
@@ -2431,13 +2725,12 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-06-09 13:30:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-06-09 16:28:40 UTC; unix",
-        "Archs": "openssl.so.dSYM",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 02:10:56 UTC; windows",
+        "Archs": "x64",
         "RemoteType": "standard",
         "RemotePkgRef": "openssl",
         "RemoteRef": "openssl",
         "RemoteRepos": "https://cran.rstudio.com",
-        "RemotePkgPlatform": "aarch64-apple-darwin23",
         "RemoteSha": "2.4.2"
       }
     },
@@ -2471,8 +2764,13 @@
         "Maintainer": "Jan Marvin Garbuszus <jan.garbuszus@ruhr-uni-bochum.de>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-31 06:10:51 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:57:07 UTC; unix",
-        "Archs": "openxlsx.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:55 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "openxlsx",
+        "RemoteRef": "openxlsx",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "4.2.8.1"
       }
     },
     "otel": {
@@ -2500,7 +2798,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-29 13:30:07 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:39:31 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:43 UTC; windows"
       }
     },
     "pbcharts": {
@@ -2532,10 +2830,10 @@
         "GithubRef": "HEAD",
         "GithubSHA1": "d37a8ec1864528ece1f5cd60ac152d06c013515f",
         "NeedsCompilation": "no",
-        "Packaged": "2026-06-08 14:12:12 UTC; johanreventlow",
+        "Packaged": "2026-06-10 12:53:52 UTC; JREV0004",
         "Author": "Jacob Anhøj [aut, cre]",
         "Maintainer": "Jacob Anhøj <jacob@anhoej.net>",
-        "Built": "R 4.6.0; ; 2026-06-08 14:12:13 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-06-10 12:53:54 UTC; windows"
       }
     },
     "pillar": {
@@ -2568,7 +2866,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-09-17 11:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 11:14:26 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:35 UTC; windows"
       }
     },
     "pins": {
@@ -2598,7 +2896,12 @@
         "Maintainer": "Julia Silge <julia.silge@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-09 14:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:18:45 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:06:39 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "pins",
+        "RemoteRef": "pins",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.4.2"
       }
     },
     "pkgbuild": {
@@ -2627,7 +2930,7 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-05-26 14:10:06 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:15:34 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 02:14:00 UTC; windows"
       }
     },
     "pkgconfig": {
@@ -2651,7 +2954,7 @@
         "Packaged": "2019-09-22 08:42:40 UTC; gaborcsardi",
         "Repository": "CRAN",
         "Date/Publication": "2019-09-22 09:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:40:59 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:23 UTC; windows"
       }
     },
     "pkgload": {
@@ -2660,7 +2963,7 @@
       "description": {
         "Package": "pkgload",
         "Title": "Simulate Package Installation and Attach",
-        "Version": "1.5.2",
+        "Version": "1.5.3",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", role = \"aut\"),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Jim\", \"Hester\", role = \"aut\"),\n    person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(\"R Core team\", role = \"ctb\",\n           comment = \"Some namespace and vignette code extracted from base R\")\n  )",
         "Description": "Simulates the process of installing a package and then\n    attaching it. This is a key part of the 'devtools' package as it\n    allows you to rapidly iterate while developing a package.",
         "License": "MIT + file LICENSE",
@@ -2676,12 +2979,17 @@
         "Encoding": "UTF-8",
         "RoxygenNote": "7.3.2",
         "NeedsCompilation": "no",
-        "Packaged": "2026-04-21 17:18:59 UTC; lionel",
+        "Packaged": "2026-06-15 13:09:18 UTC; lionel",
         "Author": "Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Core team [ctb] (Some namespace and vignette code extracted from base\n    R)",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-22 06:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 11:10:20 UTC; unix"
+        "Date/Publication": "2026-06-15 15:00:11 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 02:30:46 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "pkgload",
+        "RemoteRef": "pkgload",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.3"
       }
     },
     "plyr": {
@@ -2709,8 +3017,13 @@
         "Maintainer": "Hadley Wickham <hadley@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-10-02 06:50:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:43:36 UTC; unix",
-        "Archs": "plyr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:03:54 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "plyr",
+        "RemoteRef": "plyr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.8.9"
       }
     },
     "png": {
@@ -2733,8 +3046,13 @@
         "Packaged": "2026-03-15 03:28:25 UTC; rforge",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-15 16:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:50:44 UTC; unix",
-        "Archs": "png.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-21 00:42:12 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "png",
+        "RemoteRef": "png",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.1-9"
       }
     },
     "prettyunits": {
@@ -2759,7 +3077,12 @@
         "Maintainer": "Gabor Csardi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-09-24 21:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:44:33 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:25 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "prettyunits",
+        "RemoteRef": "prettyunits",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.0"
       }
     },
     "processx": {
@@ -2788,7 +3111,13 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-22 12:00:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:18:04 UTC; unix"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 01:51:25 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "processx",
+        "RemoteRef": "processx",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.9.0"
       }
     },
     "progress": {
@@ -2816,7 +3145,12 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2023-12-06 10:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:16:07 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:04:57 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "progress",
+        "RemoteRef": "progress",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.3"
       }
     },
     "promises": {
@@ -2848,7 +3182,7 @@
         "Maintainer": "Barret Schloerke <barret@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-01 06:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:18:42 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:51 UTC; windows"
       }
     },
     "ps": {
@@ -2878,7 +3212,8 @@
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-20 13:40:03 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:33 UTC; unix"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:11:06 UTC; windows",
+        "Archs": "x64"
       }
     },
     "purrr": {
@@ -2911,8 +3246,13 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-10 17:00:09 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 11:14:29 UTC; unix",
-        "Archs": "purrr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 02:28:59 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "purrr",
+        "RemoteRef": "purrr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.2.2"
       }
     },
     "qicharts2": {
@@ -2939,7 +3279,12 @@
         "Maintainer": "Jacob Anhoej <jacob@anhoej.net>",
         "Repository": "CRAN",
         "Date/Publication": "2025-06-23 07:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 06:42:07 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:50:14 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "qicharts2",
+        "RemoteRef": "qicharts2",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.8.1"
       }
     },
     "ragg": {
@@ -2971,8 +3316,13 @@
         "Author": "Thomas Lin Pedersen [cre, aut] (ORCID:\n    <https://orcid.org/0000-0002-5147-4711>),\n  Maxim Shemanarev [aut, cph] (Author of AGG),\n  Tony Juricic [ctb, cph] (Contributor to AGG),\n  Milan Marusinec [ctb, cph] (Contributor to AGG),\n  Spencer Garrett [ctb] (Contributor to AGG),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-23 08:50:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:22:07 UTC; unix",
-        "Archs": "ragg.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 03:05:03 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ragg",
+        "RemoteRef": "ragg",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.2"
       }
     },
     "ragnar": {
@@ -3001,8 +3351,13 @@
         "Maintainer": "Tomasz Kalinowski <tomasz@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-23 19:40:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 20:52:26 UTC; unix",
-        "Archs": "ragnar.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 04:26:41 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "ragnar",
+        "RemoteRef": "ragnar",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.3.0"
       }
     },
     "rappdirs": {
@@ -3032,8 +3387,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-17 08:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:27:56 UTC; unix",
-        "Archs": "rappdirs.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:27 UTC; windows",
+        "Archs": "x64"
       }
     },
     "readr": {
@@ -3066,8 +3421,13 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-19 18:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 15:50:28 UTC; unix",
-        "Archs": "readr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 03:23:52 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "readr",
+        "RemoteRef": "readr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.2.0"
       }
     },
     "readxl": {
@@ -3099,8 +3459,13 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-05-16 21:50:23 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-05-17 02:16:09 UTC; unix",
-        "Archs": "readxl.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 03:40:49 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "readxl",
+        "RemoteRef": "readxl",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.5.0"
       }
     },
     "rematch": {
@@ -3123,7 +3488,12 @@
         "Packaged": "2023-08-30 12:10:51 UTC; gaborcsardi",
         "Repository": "CRAN",
         "Date/Publication": "2023-08-30 16:50:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:51:36 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:52 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rematch",
+        "RemoteRef": "rematch",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.0.0"
       }
     },
     "reticulate": {
@@ -3154,8 +3524,13 @@
         "Maintainer": "Tomasz Kalinowski <tomasz@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-09 11:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:18:57 UTC; unix",
-        "Archs": "reticulate.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:24:01 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "reticulate",
+        "RemoteRef": "reticulate",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.46.0"
       }
     },
     "rlang": {
@@ -3163,32 +3538,38 @@
       "Repository": "https://cloud.r-project.org",
       "description": {
         "Package": "rlang",
-        "Version": "1.2.0",
+        "Version": "1.3.0",
         "Title": "Functions for Base Types and Core R and 'Tidyverse' Features",
-        "Description": "A toolbox for working with base types, core R features\n  like the condition system, and core 'Tidyverse' features like tidy\n  evaluation.",
-        "Authors@R": "c(\n    person(\"Lionel\", \"Henry\", ,\"lionel@posit.co\", c(\"aut\", \"cre\")),\n    person(\"Hadley\", \"Wickham\", ,\"hadley@posit.co\", \"aut\"),\n    person(given = \"mikefc\",\n           email = \"mikefc@coolbutuseless.com\",\n           role = \"cph\",\n           comment = \"Hash implementation based on Mike's xxhashlite\"),\n    person(given = \"Yann\",\n           family = \"Collet\",\n           role = \"cph\",\n           comment = \"Author of the embedded xxHash library\"),\n    person(given = \"Posit, PBC\", role = c(\"cph\", \"fnd\"))\n    )",
+        "Authors@R": "c(\n    person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\"),\n    person(\"mikefc\", , , \"mikefc@coolbutuseless.com\", role = \"cph\",\n           comment = \"Hash implementation based on Mike's xxhashlite\"),\n    person(\"Yann\", \"Collet\", role = \"cph\",\n           comment = \"Author of the embedded xxHash library\"),\n    person(\"Posit, PBC\", role = c(\"cph\", \"fnd\"))\n  )",
+        "Description": "A toolbox for working with base types, core R features like\n    the condition system, and core 'Tidyverse' features like tidy\n    evaluation.",
         "License": "MIT + file LICENSE",
-        "ByteCompile": "true",
-        "Biarch": "true",
+        "URL": "https://rlang.r-lib.org, https://github.com/r-lib/rlang",
+        "BugReports": "https://github.com/r-lib/rlang/issues",
         "Depends": "R (>= 4.0.0)",
         "Imports": "utils",
         "Suggests": "cli (>= 3.1.0), covr, crayon, desc, fs, glue, knitr,\nmagrittr, methods, pillar, pkgload, rmarkdown, stats, testthat\n(>= 3.3.2), tibble, usethis, vctrs (>= 0.2.3), withr",
         "Enhances": "winch",
-        "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
-        "URL": "https://rlang.r-lib.org, https://github.com/r-lib/rlang",
-        "BugReports": "https://github.com/r-lib/rlang/issues",
+        "Biarch": "true",
+        "ByteCompile": "true",
         "Config/build/compilation-database": "true",
-        "Config/testthat/edition": "3",
         "Config/Needs/website": "dplyr, tidyverse/tidytemplate",
+        "Config/roxygen2/version": "8.0.0",
+        "Config/testthat/edition": "3",
+        "Config/testthat/parallel": "true",
+        "Encoding": "UTF-8",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-04-02 12:23:10 UTC; lionel",
+        "Packaged": "2026-07-01 15:54:09 UTC; lionel",
         "Author": "Lionel Henry [aut, cre],\n  Hadley Wickham [aut],\n  mikefc [cph] (Hash implementation based on Mike's xxhashlite),\n  Yann Collet [cph] (Author of the embedded xxHash library),\n  Posit, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-04-06 10:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:30 UTC; unix",
-        "Archs": "rlang.so.dSYM"
+        "Date/Publication": "2026-07-05 08:40:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:02:06 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rlang",
+        "RemoteRef": "rlang",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.0"
       }
     },
     "rmarkdown": {
@@ -3219,7 +3600,7 @@
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-26 16:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 11:07:48 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:04:59 UTC; windows"
       }
     },
     "rprojroot": {
@@ -3249,7 +3630,7 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-26 16:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:48:39 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-20 00:46:46 UTC; windows"
       }
     },
     "rstudioapi": {
@@ -3259,22 +3640,27 @@
         "Package": "rstudioapi",
         "Title": "Safely Access the RStudio API",
         "Description": "Access the RStudio API (if available) and provide informative error\n    messages when it's not.",
-        "Version": "0.18.0",
+        "Version": "0.19.0",
         "Authors@R": "c(\n    person(\"Kevin\", \"Ushey\", role = c(\"aut\", \"cre\"), email = \"kevin@rstudio.com\"),\n    person(\"JJ\", \"Allaire\", role = c(\"aut\"), email = \"jj@posit.co\"),\n    person(\"Hadley\", \"Wickham\", role = c(\"aut\"), email = \"hadley@posit.co\"),\n    person(\"Gary\", \"Ritchie\", role = c(\"aut\"), email = \"gary@posit.co\"),\n    person(family = \"RStudio\", role = \"cph\")\n    )",
         "Maintainer": "Kevin Ushey <kevin@rstudio.com>",
         "License": "MIT + file LICENSE",
         "URL": "https://rstudio.github.io/rstudioapi/,\nhttps://github.com/rstudio/rstudioapi",
         "BugReports": "https://github.com/rstudio/rstudioapi/issues",
-        "RoxygenNote": "7.3.3",
-        "Suggests": "testthat, knitr, rmarkdown, clipr, covr, curl, jsonlite,\nwithr",
+        "Suggests": "testthat, knitr, rmarkdown, clipr, covr, curl, jsonlite, R6,\nwithr",
         "VignetteBuilder": "knitr",
         "Encoding": "UTF-8",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "no",
-        "Packaged": "2026-01-15 18:05:24 UTC; kevin",
+        "Packaged": "2026-06-11 21:44:33 UTC; kevin",
         "Author": "Kevin Ushey [aut, cre],\n  JJ Allaire [aut],\n  Hadley Wickham [aut],\n  Gary Ritchie [aut],\n  RStudio [cph]",
         "Repository": "CRAN",
-        "Date/Publication": "2026-01-16 09:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:45:31 UTC; unix"
+        "Date/Publication": "2026-06-11 23:10:02 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 01:02:05 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rstudioapi",
+        "RemoteRef": "rstudioapi",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.19.0"
       }
     },
     "rvest": {
@@ -3305,7 +3691,12 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-08-29 14:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 05:22:36 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:20:14 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "rvest",
+        "RemoteRef": "rvest",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.0.5"
       }
     },
     "sass": {
@@ -3334,8 +3725,8 @@
         "Maintainer": "Carson Sievert <carson@rstudio.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-04-11 19:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 02:19:08 UTC; unix",
-        "Archs": "sass.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:23:48 UTC; windows",
+        "Archs": "x64"
       }
     },
     "scales": {
@@ -3365,7 +3756,12 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-04-24 11:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:14:37 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:23:46 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "scales",
+        "RemoteRef": "scales",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.4.0"
       }
     },
     "selectr": {
@@ -3375,22 +3771,28 @@
         "Package": "selectr",
         "Type": "Package",
         "Title": "Translate CSS Selectors to XPath Expressions",
-        "Version": "0.5-1",
+        "Version": "0.6-0",
         "Authors@R": "c(person(\"Simon\", \"Potter\",\n                    role = c(\"aut\", \"trl\", \"cre\"),\n                    email = \"simon@sjp.co.nz\"),\n             person(\"Simon\", \"Sapin\", role = \"aut\"),\n             person(\"Ian\", \"Bicking\", role = \"aut\"))",
         "License": "BSD_3_clause + file LICENCE",
-        "Depends": "R (>= 3.0)",
-        "Imports": "methods, stringr, R6",
+        "Encoding": "UTF-8",
+        "Depends": "R (>= 3.3)",
+        "Imports": "R6",
         "Suggests": "testthat, XML, xml2",
         "URL": "https://sjp.co.nz/projects/selectr/",
         "BugReports": "https://github.com/sjp/selectr/issues",
         "Description": "Translates a CSS selector into an equivalent XPath\n  expression. This allows us to use CSS selectors when working with\n  the XML package as it can only evaluate XPath expressions. Also\n  provided are convenience functions useful for using CSS selectors on\n  XML nodes. This package is a port of the Python package 'cssselect'\n  (<https://cssselect.readthedocs.io/>).",
         "NeedsCompilation": "no",
-        "Packaged": "2025-12-17 07:03:48 UTC; codespace",
+        "Packaged": "2026-06-22 23:18:36 UTC; vscode",
         "Author": "Simon Potter [aut, trl, cre],\n  Simon Sapin [aut],\n  Ian Bicking [aut]",
         "Maintainer": "Simon Potter <simon@sjp.co.nz>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-12-17 09:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:27:14 UTC; unix"
+        "Date/Publication": "2026-06-23 05:10:21 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 01:02:33 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "selectr",
+        "RemoteRef": "selectr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.6-0"
       }
     },
     "shiny": {
@@ -3400,7 +3802,7 @@
         "Type": "Package",
         "Package": "shiny",
         "Title": "Web Application Framework for R",
-        "Version": "1.13.0",
+        "Version": "1.14.0",
         "Authors@R": "c(\n    person(\"Winston\", \"Chang\", , \"winston@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-1576-2126\")),\n    person(\"Joe\", \"Cheng\", , \"joe@posit.co\", role = \"aut\"),\n    person(\"JJ\", \"Allaire\", , \"jj@posit.co\", role = \"aut\"),\n    person(\"Carson\", \"Sievert\", , \"carson@posit.co\", role = c(\"aut\", \"cre\"),\n           comment = c(ORCID = \"0000-0002-4958-2844\")),\n    person(\"Barret\", \"Schloerke\", , \"barret@posit.co\", role = \"aut\",\n           comment = c(ORCID = \"0000-0001-9986-114X\")),\n    person(\"Garrick\", \"Aden-Buie\", , \"garrick@adenbuie.com\", role = \"aut\",\n           comment = c(ORCID = \"0000-0002-7111-0077\")),\n    person(\"Yihui\", \"Xie\", , \"yihui@posit.co\", role = \"aut\"),\n    person(\"Jeff\", \"Allen\", role = \"aut\"),\n    person(\"Jonathan\", \"McPherson\", , \"jonathan@posit.co\", role = \"aut\"),\n    person(\"Alan\", \"Dipert\", role = \"aut\"),\n    person(\"Barbara\", \"Borges\", role = \"aut\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\")),\n    person(, \"jQuery Foundation\", role = \"cph\",\n           comment = \"jQuery library and jQuery UI library\"),\n    person(, \"jQuery contributors\", role = c(\"ctb\", \"cph\"),\n           comment = \"jQuery library; authors listed in inst/www/shared/jquery-AUTHORS.txt\"),\n    person(, \"jQuery UI contributors\", role = c(\"ctb\", \"cph\"),\n           comment = \"jQuery UI library; authors listed in inst/www/shared/jqueryui/AUTHORS.txt\"),\n    person(\"Mark\", \"Otto\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(\"Jacob\", \"Thornton\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Bootstrap contributors\", role = \"ctb\",\n           comment = \"Bootstrap library\"),\n    person(, \"Twitter, Inc\", role = \"cph\",\n           comment = \"Bootstrap library\"),\n    person(\"Prem Nawaz\", \"Khan\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Victor\", \"Tsaran\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Dennis\", \"Lembree\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Srinivasu\", \"Chakravarthula\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Cathy\", \"O'Connor\", role = \"ctb\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(, \"PayPal, Inc\", role = \"cph\",\n           comment = \"Bootstrap accessibility plugin\"),\n    person(\"Stefan\", \"Petre\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap-datepicker library\"),\n    person(\"Andrew\", \"Rowls\", role = c(\"ctb\", \"cph\"),\n           comment = \"Bootstrap-datepicker library\"),\n    person(\"Brian\", \"Reavis\", role = c(\"ctb\", \"cph\"),\n           comment = \"selectize.js library\"),\n    person(\"Salmen\", \"Bejaoui\", role = c(\"ctb\", \"cph\"),\n           comment = \"selectize-plugin-a11y library\"),\n    person(\"Denis\", \"Ineshin\", role = c(\"ctb\", \"cph\"),\n           comment = \"ion.rangeSlider library\"),\n    person(\"Sami\", \"Samhuri\", role = c(\"ctb\", \"cph\"),\n           comment = \"Javascript strftime library\"),\n    person(, \"SpryMedia Limited\", role = c(\"ctb\", \"cph\"),\n           comment = \"DataTables library\"),\n    person(\"Ivan\", \"Sagalaev\", role = c(\"ctb\", \"cph\"),\n           comment = \"highlight.js library\"),\n    person(\"R Core Team\", role = c(\"ctb\", \"cph\"),\n           comment = \"tar implementation from R\")\n  )",
         "Description": "Makes it incredibly easy to build interactive web\n    applications with R. Automatic \"reactive\" binding between inputs and\n    outputs and extensive prebuilt widgets make it possible to build\n    beautiful, responsive, and powerful applications with minimal effort.",
         "License": "MIT + file LICENSE",
@@ -3408,19 +3810,24 @@
         "BugReports": "https://github.com/rstudio/shiny/issues",
         "Depends": "methods, R (>= 3.1.2)",
         "Imports": "bslib (>= 0.6.0), cachem (>= 1.1.0), cli, commonmark (>=\n2.0.0), fastmap (>= 1.1.1), fontawesome (>= 0.4.0), glue (>=\n1.3.2), grDevices, htmltools (>= 0.5.4), httpuv (>= 1.5.2),\njsonlite (>= 0.9.16), later (>= 1.0.0), lifecycle (>= 0.2.0),\nmime (>= 0.3), otel, promises (>= 1.5.0), R6 (>= 2.0), rlang\n(>= 0.4.10), sourcetools, tools, utils, withr, xtable",
-        "Suggests": "Cairo (>= 1.5-5), coro (>= 1.1.0), datasets, DT, dygraphs,\nfuture, ggplot2, knitr (>= 1.6), magrittr, markdown, mirai,\notelsdk (>= 0.2.0), ragg, reactlog (>= 1.0.0), rmarkdown, sass,\nshowtext, testthat (>= 3.2.1), watcher, yaml",
-        "Config/Needs/check": "shinytest2",
+        "Suggests": "Cairo (>= 1.5-5), coro (>= 1.1.0), datasets, DT, dygraphs,\nfuture, ggplot2, knitr (>= 1.6), magrittr, markdown, mirai,\notelsdk (>= 0.2.0), ragg, reactlog (>= 1.0.0), rmarkdown, sass,\nshinytest2, showtext, testthat (>= 3.2.1), watcher, yaml",
+        "Config/Needs/check": "shinyjs",
+        "Config/roxygen2/version": "8.0.0",
         "Config/testthat/edition": "3",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.3",
-        "Collate": "'globals.R' 'app-state.R' 'app_template.R' 'bind-cache.R'\n'bind-event.R' 'bookmark-state-local.R' 'bookmark-state.R'\n'bootstrap-deprecated.R' 'bootstrap-layout.R' 'conditions.R'\n'map.R' 'utils.R' 'bootstrap.R' 'busy-indicators-spinners.R'\n'busy-indicators.R' 'cache-utils.R' 'deprecated.R' 'devmode.R'\n'diagnose.R' 'extended-task.R' 'fileupload.R' 'graph.R'\n'reactives.R' 'reactive-domains.R' 'history.R' 'hooks.R'\n'html-deps.R' 'image-interact-opts.R' 'image-interact.R'\n'imageutils.R' 'input-action.R' 'input-checkbox.R'\n'input-checkboxgroup.R' 'input-date.R' 'input-daterange.R'\n'input-file.R' 'input-numeric.R' 'input-password.R'\n'input-radiobuttons.R' 'input-select.R' 'input-slider.R'\n'input-submit.R' 'input-text.R' 'input-textarea.R'\n'input-utils.R' 'insert-tab.R' 'insert-ui.R' 'jqueryui.R'\n'knitr.R' 'middleware-shiny.R' 'middleware.R' 'timer.R'\n'shiny.R' 'mock-session.R' 'modal.R' 'modules.R'\n'notifications.R' 'otel-attr-srcref.R' 'otel-collect.R'\n'otel-enable.R' 'otel-error.R' 'otel-label.R'\n'otel-reactive-update.R' 'otel-session.R' 'otel-shiny.R'\n'otel-with.R' 'priorityqueue.R' 'progress.R' 'react.R'\n'reexports.R' 'render-cached-plot.R' 'render-plot.R'\n'render-table.R' 'run-url.R' 'runapp.R' 'serializers.R'\n'server-input-handlers.R' 'server-resource-paths.R' 'server.R'\n'shiny-options.R' 'shiny-package.R' 'shinyapp.R' 'shinyui.R'\n'shinywrappers.R' 'showcase.R' 'snapshot.R' 'staticimports.R'\n'tar.R' 'test-export.R' 'test-server.R' 'test.R'\n'update-input.R' 'utils-lang.R' 'utils-tags.R'\n'version_bs_date_picker.R' 'version_ion_range_slider.R'\n'version_jquery.R' 'version_jqueryui.R' 'version_selectize.R'\n'version_strftime.R' 'viewer.R'",
+        "Collate": "'app-handle.R' 'globals.R' 'app-state.R' 'app_template.R'\n'bind-cache.R' 'bind-event.R' 'bookmark-state-local.R'\n'bookmark-state.R' 'bootstrap-deprecated.R'\n'bootstrap-layout.R' 'conditions.R' 'map.R' 'utils.R'\n'bootstrap.R' 'busy-indicators-spinners.R' 'busy-indicators.R'\n'cache-utils.R' 'deprecated.R' 'devmode.R' 'diagnose.R'\n'extended-task.R' 'fileupload.R' 'graph.R' 'reactives.R'\n'reactive-domains.R' 'history.R' 'hooks.R' 'html-deps.R'\n'image-interact-opts.R' 'image-interact.R' 'imageutils.R'\n'input-action.R' 'input-checkbox.R' 'input-checkboxgroup.R'\n'input-date.R' 'input-daterange.R' 'input-file.R'\n'input-numeric.R' 'input-password.R' 'input-radiobuttons.R'\n'input-select.R' 'input-slider.R' 'input-submit.R'\n'input-text.R' 'input-textarea.R' 'input-utils.R'\n'insert-tab.R' 'insert-ui.R' 'jqueryui.R' 'knitr.R'\n'middleware-shiny.R' 'middleware.R' 'timer.R' 'shiny.R'\n'mock-session.R' 'modal.R' 'modules.R' 'notifications.R'\n'otel-attr-srcref.R' 'otel-collect.R' 'otel-enable.R'\n'otel-error.R' 'otel-label.R' 'otel-reactive-update.R'\n'otel-session.R' 'otel-shiny.R' 'otel-with.R' 'priorityqueue.R'\n'progress.R' 'react.R' 'reexports.R' 'render-cached-plot.R'\n'render-plot.R' 'render-table.R' 'run-url.R' 'runapp.R'\n'serializers.R' 'server-input-handlers.R'\n'server-resource-paths.R' 'server.R' 'shiny-options.R'\n'shiny-package.R' 'shinyapp.R' 'shinyui.R' 'shinywrappers.R'\n'showcase.R' 'snapshot.R' 'staticimports.R' 'tar.R'\n'test-export.R' 'test-server.R' 'test.R' 'update-input.R'\n'utils-lang.R' 'utils-tags.R' 'version_bs_date_picker.R'\n'version_ion_range_slider.R' 'version_jquery.R'\n'version_jqueryui.R' 'version_selectize.R' 'version_strftime.R'\n'viewer.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2026-02-19 20:25:10 UTC; cpsievert",
+        "Packaged": "2026-06-18 18:59:37 UTC; cpsievert",
         "Author": "Winston Chang [aut] (ORCID: <https://orcid.org/0000-0002-1576-2126>),\n  Joe Cheng [aut],\n  JJ Allaire [aut],\n  Carson Sievert [aut, cre] (ORCID:\n    <https://orcid.org/0000-0002-4958-2844>),\n  Barret Schloerke [aut] (ORCID: <https://orcid.org/0000-0001-9986-114X>),\n  Garrick Aden-Buie [aut] (ORCID:\n    <https://orcid.org/0000-0002-7111-0077>),\n  Yihui Xie [aut],\n  Jeff Allen [aut],\n  Jonathan McPherson [aut],\n  Alan Dipert [aut],\n  Barbara Borges [aut],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>),\n  jQuery Foundation [cph] (jQuery library and jQuery UI library),\n  jQuery contributors [ctb, cph] (jQuery library; authors listed in\n    inst/www/shared/jquery-AUTHORS.txt),\n  jQuery UI contributors [ctb, cph] (jQuery UI library; authors listed in\n    inst/www/shared/jqueryui/AUTHORS.txt),\n  Mark Otto [ctb] (Bootstrap library),\n  Jacob Thornton [ctb] (Bootstrap library),\n  Bootstrap contributors [ctb] (Bootstrap library),\n  Twitter, Inc [cph] (Bootstrap library),\n  Prem Nawaz Khan [ctb] (Bootstrap accessibility plugin),\n  Victor Tsaran [ctb] (Bootstrap accessibility plugin),\n  Dennis Lembree [ctb] (Bootstrap accessibility plugin),\n  Srinivasu Chakravarthula [ctb] (Bootstrap accessibility plugin),\n  Cathy O'Connor [ctb] (Bootstrap accessibility plugin),\n  PayPal, Inc [cph] (Bootstrap accessibility plugin),\n  Stefan Petre [ctb, cph] (Bootstrap-datepicker library),\n  Andrew Rowls [ctb, cph] (Bootstrap-datepicker library),\n  Brian Reavis [ctb, cph] (selectize.js library),\n  Salmen Bejaoui [ctb, cph] (selectize-plugin-a11y library),\n  Denis Ineshin [ctb, cph] (ion.rangeSlider library),\n  Sami Samhuri [ctb, cph] (Javascript strftime library),\n  SpryMedia Limited [ctb, cph] (DataTables library),\n  Ivan Sagalaev [ctb, cph] (highlight.js library),\n  R Core Team [ctb, cph] (tar implementation from R)",
         "Maintainer": "Carson Sievert <carson@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-02-20 09:00:03 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 11:08:04 UTC; unix"
+        "Date/Publication": "2026-06-21 14:10:08 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 02:51:00 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "shiny",
+        "RemoteRef": "shiny",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.14.0"
       }
     },
     "shinyjs": {
@@ -3447,7 +3854,12 @@
         "Maintainer": "Dean Attali <daattali@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-15 06:10:08 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 11:10:41 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:20:26 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "shinyjs",
+        "RemoteRef": "shinyjs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.1.1"
       }
     },
     "shinylogs": {
@@ -3473,7 +3885,12 @@
         "Maintainer": "Victor Perrier <victor.perrier@dreamrs.fr>",
         "Repository": "CRAN",
         "Date/Publication": "2022-04-18 16:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 15:09:14 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 03:14:47 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "shinylogs",
+        "RemoteRef": "shinylogs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.2.1"
       }
     },
     "sourcetools": {
@@ -3498,8 +3915,8 @@
         "Author": "Kevin Ushey [aut, cre]",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-28 06:10:35 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:30 UTC; unix",
-        "Archs": "sourcetools.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:45 UTC; windows",
+        "Archs": "x64"
       }
     },
     "stringi": {
@@ -3529,7 +3946,13 @@
         "License_is_FOSS": "yes",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-27 13:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:41:40 UTC; unix"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-04-21 00:41:07 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "stringi",
+        "RemoteRef": "stringi",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.8.7"
       }
     },
     "stringr": {
@@ -3560,7 +3983,7 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-11-04 14:00:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 11:14:29 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:35 UTC; windows"
       }
     },
     "svglite": {
@@ -3593,8 +4016,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-10-21 16:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 02:23:12 UTC; unix",
-        "Archs": "svglite.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 03:05:03 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "svglite",
+        "RemoteRef": "svglite",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "2.2.2"
       }
     },
     "sys": {
@@ -3620,8 +4048,13 @@
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2024-10-04 09:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:55 UTC; unix",
-        "Archs": "sys.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:25 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "sys",
+        "RemoteRef": "sys",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.4.3"
       }
     },
     "systemfonts": {
@@ -3654,8 +4087,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-05 13:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:16:44 UTC; unix",
-        "Archs": "systemfonts.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:23:53 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "systemfonts",
+        "RemoteRef": "systemfonts",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.2"
       }
     },
     "textshaping": {
@@ -3687,8 +4125,13 @@
         "Maintainer": "Thomas Lin Pedersen <thomas.pedersen@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-06 10:40:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:19:28 UTC; unix",
-        "Archs": "textshaping.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 02:43:40 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "textshaping",
+        "RemoteRef": "textshaping",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.0.5"
       }
     },
     "tibble": {
@@ -3723,8 +4166,13 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-11 10:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 05:14:40 UTC; unix",
-        "Archs": "tibble.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 02:47:37 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "tibble",
+        "RemoteRef": "tibble",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.3.1"
       }
     },
     "tidyr": {
@@ -3756,8 +4204,13 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-19 09:20:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 15:50:18 UTC; unix",
-        "Archs": "tidyr.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 03:23:48 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "tidyr",
+        "RemoteRef": "tidyr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.3.2"
       }
     },
     "tidyselect": {
@@ -3787,7 +4240,7 @@
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2024-03-11 14:10:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-26 02:19:10 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 02:43:35 UTC; windows"
       }
     },
     "timechange": {
@@ -3814,8 +4267,13 @@
         "Maintainer": "Vitalie Spinu <spinuvit@gmail.com>",
         "Repository": "CRAN",
         "Date/Publication": "2026-01-29 22:20:08 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:44:04 UTC; unix",
-        "Archs": "timechange.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 01:51:24 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "timechange",
+        "RemoteRef": "timechange",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.0"
       }
     },
     "tinytex": {
@@ -3825,7 +4283,7 @@
         "Package": "tinytex",
         "Type": "Package",
         "Title": "Helper Functions to Install and Maintain TeX Live, and Compile\nLaTeX Documents",
-        "Version": "0.59",
+        "Version": "0.60",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\")),\n  person(given = \"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\", comment = c(ORCID = \"0000-0003-4474-2498\")),\n  person(\"Devon\", \"Ryan\", role = \"ctb\", email = \"dpryan79@gmail.com\", comment = c(ORCID = \"0000-0002-8549-0971\")),\n  person(\"Ethan\", \"Heinzen\", role = \"ctb\"),\n  person(\"Fernando\", \"Cagua\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Helper functions to install and maintain the 'LaTeX' distribution\n  named 'TinyTeX' (<https://yihui.org/tinytex/>), a lightweight, cross-platform,\n  portable, and easy-to-maintain version of 'TeX Live'. This package also\n  contains helper functions to compile 'LaTeX' documents, and install missing\n  'LaTeX' packages automatically.",
         "Imports": "xfun (>= 0.48)",
@@ -3836,12 +4294,17 @@
         "Encoding": "UTF-8",
         "RoxygenNote": "7.3.3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-03-27 22:21:20 UTC; yihui",
+        "Packaged": "2026-06-15 22:44:20 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>),\n  Posit Software, PBC [cph, fnd],\n  Christophe Dervieux [ctb] (ORCID:\n    <https://orcid.org/0000-0003-4474-2498>),\n  Devon Ryan [ctb] (ORCID: <https://orcid.org/0000-0002-8549-0971>),\n  Ethan Heinzen [ctb],\n  Fernando Cagua [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-03-28 06:10:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 23:14:13 UTC; unix"
+        "Date/Publication": "2026-06-16 05:10:02 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 01:50:45 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "tinytex",
+        "RemoteRef": "tinytex",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.60"
       }
     },
     "tzdb": {
@@ -3870,8 +4333,13 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-03-15 22:50:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:44:31 UTC; unix",
-        "Archs": "tzdb.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 01:51:25 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "tzdb",
+        "RemoteRef": "tzdb",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.5.0"
       }
     },
     "utf8": {
@@ -3898,8 +4366,8 @@
         "Maintainer": "Kirill Müller <kirill@cynkra.com>",
         "Repository": "CRAN",
         "Date/Publication": "2025-06-08 19:00:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:41:06 UTC; unix",
-        "Archs": "utf8.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 01:10:23 UTC; windows",
+        "Archs": "x64"
       }
     },
     "vctrs": {
@@ -3932,8 +4400,13 @@
         "Maintainer": "Davis Vaughan <davis@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-04-11 06:20:03 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 23:15:23 UTC; unix",
-        "Archs": "vctrs.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-04 02:07:34 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "vctrs",
+        "RemoteRef": "vctrs",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.7.3"
       }
     },
     "viridisLite": {
@@ -3960,7 +4433,12 @@
         "Author": "Simon Garnier [aut, cre],\n  Noam Ross [ctb, cph],\n  Bob Rudis [ctb, cph],\n  Marco Sciaini [ctb, cph],\n  Antônio Pedro Camargo [ctb, cph],\n  Cédric Scherer [ctb, cph]",
         "Repository": "CRAN",
         "Date/Publication": "2026-02-04 06:40:10 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:40:19 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:25 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "viridisLite",
+        "RemoteRef": "viridisLite",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.3"
       }
     },
     "vroom": {
@@ -3995,8 +4473,13 @@
         "Maintainer": "Jennifer Bryan <jenny@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2026-03-31 05:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-26 11:09:05 UTC; unix",
-        "Archs": "vroom.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-28 03:20:12 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "vroom",
+        "RemoteRef": "vroom",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.7.1"
       }
     },
     "whisker": {
@@ -4019,7 +4502,12 @@
         "Packaged": "2022-12-05 15:15:55 UTC; hornik",
         "Repository": "CRAN",
         "Date/Publication": "2022-12-05 15:33:50 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:49:54 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:48 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "whisker",
+        "RemoteRef": "whisker",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.4.1"
       }
     },
     "withr": {
@@ -4028,7 +4516,7 @@
       "description": {
         "Package": "withr",
         "Title": "Run Code 'With' Temporarily Modified Global State",
-        "Version": "3.0.2",
+        "Version": "3.0.3",
         "Authors@R": "c(\n    person(\"Jim\", \"Hester\", role = \"aut\"),\n    person(\"Lionel\", \"Henry\", , \"lionel@posit.co\", role = c(\"aut\", \"cre\")),\n    person(\"Kirill\", \"Müller\", , \"krlmlr+r@mailbox.org\", role = \"aut\"),\n    person(\"Kevin\", \"Ushey\", , \"kevinushey@gmail.com\", role = \"aut\"),\n    person(\"Hadley\", \"Wickham\", , \"hadley@posit.co\", role = \"aut\"),\n    person(\"Winston\", \"Chang\", role = \"aut\"),\n    person(\"Jennifer\", \"Bryan\", role = \"ctb\"),\n    person(\"Richard\", \"Cotton\", role = \"ctb\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"))\n  )",
         "Description": "A set of functions to run code 'with' safely and temporarily\n    modified global state. Many of these functions were originally a part\n    of the 'devtools' package, this provides a simple package with limited\n    dependencies to provide access to these functions.",
         "License": "MIT + file LICENSE",
@@ -4044,12 +4532,17 @@
         "RoxygenNote": "7.3.2",
         "Collate": "'aaa.R' 'collate.R' 'connection.R' 'db.R' 'defer-exit.R'\n'standalone-defer.R' 'defer.R' 'devices.R' 'local_.R' 'with_.R'\n'dir.R' 'env.R' 'file.R' 'language.R' 'libpaths.R' 'locale.R'\n'makevars.R' 'namespace.R' 'options.R' 'par.R' 'path.R' 'rng.R'\n'seed.R' 'wrap.R' 'sink.R' 'tempfile.R' 'timezone.R'\n'torture.R' 'utils.R' 'with.R'",
         "NeedsCompilation": "no",
-        "Packaged": "2024-10-28 10:58:18 UTC; lionel",
+        "Packaged": "2026-06-17 11:51:00 UTC; lionel",
         "Author": "Jim Hester [aut],\n  Lionel Henry [aut, cre],\n  Kirill Müller [aut],\n  Kevin Ushey [aut],\n  Hadley Wickham [aut],\n  Winston Chang [aut],\n  Jennifer Bryan [ctb],\n  Richard Cotton [ctb],\n  Posit Software, PBC [cph, fnd]",
         "Maintainer": "Lionel Henry <lionel@posit.co>",
         "Repository": "CRAN",
-        "Date/Publication": "2024-10-28 13:30:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 09:28:00 UTC; unix"
+        "Date/Publication": "2026-06-19 05:30:02 UTC",
+        "Built": "R 4.6.1; ; 2026-07-21 01:02:05 UTC; windows",
+        "RemoteType": "standard",
+        "RemotePkgRef": "withr",
+        "RemoteRef": "withr",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.0.3"
       }
     },
     "xfun": {
@@ -4059,7 +4552,7 @@
         "Package": "xfun",
         "Type": "Package",
         "Title": "Supporting Functions for Packages Maintained by 'Yihui Xie'",
-        "Version": "0.58",
+        "Version": "0.60",
         "Authors@R": "c(\n  person(\"Yihui\", \"Xie\", role = c(\"aut\", \"cre\", \"cph\"), email = \"xie@yihui.name\", comment = c(ORCID = \"0000-0003-0645-5666\", URL = \"https://yihui.org\")),\n  person(\"Wush\", \"Wu\", role = \"ctb\"),\n  person(\"Daijiang\", \"Li\", role = \"ctb\"),\n  person(\"Xianying\", \"Tan\", role = \"ctb\"),\n  person(\"Salim\", \"Brüggemann\", role = \"ctb\", email = \"salim-b@pm.me\", comment = c(ORCID = \"0000-0002-5329-5987\")),\n  person(\"Christophe\", \"Dervieux\", role = \"ctb\"),\n  person()\n  )",
         "Description": "Miscellaneous functions commonly used in other packages maintained by 'Yihui Xie'.",
         "Depends": "R (>= 3.2.0)",
@@ -4072,13 +4565,18 @@
         "VignetteBuilder": "litedown",
         "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-05-31 16:49:17 UTC; yihui",
+        "Packaged": "2026-07-09 05:04:56 UTC; yihui",
         "Author": "Yihui Xie [aut, cre, cph] (ORCID:\n    <https://orcid.org/0000-0003-0645-5666>, URL: https://yihui.org),\n  Wush Wu [ctb],\n  Daijiang Li [ctb],\n  Xianying Tan [ctb],\n  Salim Brüggemann [ctb] (ORCID: <https://orcid.org/0000-0002-5329-5987>),\n  Christophe Dervieux [ctb]",
         "Maintainer": "Yihui Xie <xie@yihui.name>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-06-01 05:10:03 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-06-01 05:21:21 UTC; unix",
-        "Archs": "xfun.so.dSYM"
+        "Date/Publication": "2026-07-09 10:50:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:02:45 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "xfun",
+        "RemoteRef": "xfun",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "0.60"
       }
     },
     "xml2": {
@@ -4087,7 +4585,7 @@
       "description": {
         "Package": "xml2",
         "Title": "Parse XML",
-        "Version": "1.5.2",
+        "Version": "1.6.0",
         "Authors@R": "c(\n    person(\"Hadley\", \"Wickham\", role = \"aut\"),\n    person(\"Jim\", \"Hester\", role = \"aut\"),\n    person(\"Jeroen\", \"Ooms\", email = \"jeroenooms@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\")),\n    person(\"R Foundation\", role = \"ctb\",\n           comment = \"Copy of R-project homepage cached as example\")\n  )",
         "Description": "Bindings to 'libxml2' for working with XML data using a simple, \n    consistent interface based on 'XPath' expressions. Also supports XML schema\n    validation; for 'XSLT' transformations see the 'xslt' package.",
         "License": "MIT + file LICENSE",
@@ -4101,16 +4599,21 @@
         "Encoding": "UTF-8",
         "RoxygenNote": "7.3.3",
         "SystemRequirements": "libxml2: libxml2-dev (deb), libxml2-devel (rpm)",
-        "Collate": "'S4.R' 'as_list.R' 'xml_parse.R' 'as_xml_document.R'\n'classes.R' 'format.R' 'import-standalone-obj-type.R'\n'import-standalone-purrr.R' 'import-standalone-types-check.R'\n'init.R' 'nodeset_apply.R' 'paths.R' 'utils.R' 'xml2-package.R'\n'xml_attr.R' 'xml_children.R' 'xml_document.R' 'xml_find.R'\n'xml_missing.R' 'xml_modify.R' 'xml_name.R' 'xml_namespaces.R'\n'xml_node.R' 'xml_nodeset.R' 'xml_path.R' 'xml_schema.R'\n'xml_serialize.R' 'xml_structure.R' 'xml_text.R' 'xml_type.R'\n'xml_url.R' 'xml_write.R' 'zzz.R'",
+        "Collate": "'S4.R' 'as_list.R' 'xml_parse.R' 'as_xml_document.R'\n'classes.R' 'format.R' 'import-standalone-obj-type.R'\n'import-standalone-purrr.R' 'import-standalone-types-check.R'\n'init.R' 'nodeset_apply.R' 'paths.R' 'utils.R' 'xml2-package.R'\n'xml_attr.R' 'xml_children.R' 'xml_document.R' 'xml_find.R'\n'xml_missing.R' 'xml_modify.R' 'xml_name.R' 'xml_namespaces.R'\n'xml_node.R' 'xml_nodeset.R' 'xml_path.R' 'xml_schema.R'\n'xml_serialize.R' 'xml_structure.R' 'xml_text.R' 'xml_type.R'\n'xml_url.R' 'xml_write.R'",
         "Config/testthat/edition": "3",
         "NeedsCompilation": "yes",
-        "Packaged": "2026-01-17 13:03:05 UTC; jeroen",
+        "Packaged": "2026-06-22 13:32:25 UTC; jeroen",
         "Author": "Hadley Wickham [aut],\n  Jim Hester [aut],\n  Jeroen Ooms [aut, cre],\n  Posit Software, PBC [cph, fnd],\n  R Foundation [ctb] (Copy of R-project homepage cached as example)",
         "Maintainer": "Jeroen Ooms <jeroenooms@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2026-01-17 16:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:48:48 UTC; unix",
-        "Archs": "xml2.so.dSYM"
+        "Date/Publication": "2026-06-22 15:40:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:50:48 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "xml2",
+        "RemoteRef": "xml2",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.6.0"
       }
     },
     "xtable": {
@@ -4135,7 +4638,7 @@
         "Packaged": "2026-02-20 02:51:53 UTC; dsco0",
         "Author": "David B. Dahl [aut],\n  David Scott [aut, cre],\n  Charles Roosen [aut],\n  Arni Magnusson [aut],\n  Jonathan Swinton [aut],\n  Ajay Shah [ctb],\n  Arne Henningsen [ctb],\n  Benno Puetz [ctb],\n  Bernhard Pfaff [ctb],\n  Claudio Agostinelli [ctb],\n  Claudius Loehnert [ctb],\n  David Mitchell [ctb],\n  David Whiting [ctb],\n  Fernando da Rosa [ctb],\n  Guido Gay [ctb],\n  Guido Schulz [ctb],\n  Ian Fellows [ctb],\n  Jeff Laake [ctb],\n  John Walker [ctb],\n  Jun Yan [ctb],\n  Liviu Andronic [ctb],\n  Markus Loecher [ctb],\n  Martin Gubri [ctb],\n  Matthieu Stigler [ctb],\n  Robert Castelo [ctb],\n  Seth Falcon [ctb],\n  Stefan Edwards [ctb],\n  Sven Garbade [ctb],\n  Uwe Ligges [ctb]",
         "Date/Publication": "2026-02-22 11:20:02 UTC",
-        "Built": "R 4.6.0; ; 2026-04-25 15:39:58 UTC; unix"
+        "Built": "R 4.6.0; ; 2026-05-28 01:10:27 UTC; windows"
       }
     },
     "yaml": {
@@ -4163,8 +4666,8 @@
         "Maintainer": "Hadley Wickham <hadley@posit.co>",
         "Repository": "CRAN",
         "Date/Publication": "2025-12-10 07:00:01 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:39:54 UTC; unix",
-        "Archs": "yaml.so.dSYM"
+        "Built": "R 4.6.0; x86_64-w64-mingw32; 2026-05-20 00:46:29 UTC; windows",
+        "Archs": "x64"
       }
     },
     "zip": {
@@ -4173,25 +4676,34 @@
       "description": {
         "Package": "zip",
         "Title": "Cross-Platform 'zip' Compression",
-        "Version": "2.3.3",
-        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(\"Kuba\", \"Podgórski\", role = \"ctb\"),\n    person(\"Rich\", \"Geldreich\", role = \"ctb\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\"))\n  )",
+        "Version": "3.0.1",
+        "Authors@R": "c(\n    person(\"Gábor\", \"Csárdi\", , \"csardi.gabor@gmail.com\", role = c(\"aut\", \"cre\")),\n    person(\"Kuba\", \"Podgórski\", role = \"ctb\"),\n    person(\"Rich\", \"Geldreich\", role = \"ctb\"),\n    person(\"Arm Limited\", role = c(\"ctb\", \"cph\"),\n           comment = \"bundled Mbed TLS crypto subset in src/mbedtls/ (Apache-2.0)\"),\n    person(\"Posit Software, PBC\", role = c(\"cph\", \"fnd\"),\n           comment = c(ROR = \"03wc8by49\"))\n  )",
         "Description": "Cross-Platform 'zip' Compression Library. A replacement for\n    the 'zip' function, that does not require any additional external\n    tools on any platform.",
         "License": "MIT + file LICENSE",
         "URL": "https://github.com/r-lib/zip, https://r-lib.github.io/zip/",
         "BugReports": "https://github.com/r-lib/zip/issues",
-        "Suggests": "covr, pillar, processx, R6, testthat, withr",
+        "LinkingTo": "cli",
+        "Suggests": "callr, cli, curl, pillar, processx, R6, testthat, webfakes,\nwithr",
         "Config/Needs/website": "tidyverse/tidytemplate",
         "Config/testthat/edition": "3",
+        "Config/testthat/parallel": "true",
+        "Config/testthat/start-first": "large-files, http",
         "Config/usethis/last-upkeep": "2025-05-07",
         "Encoding": "UTF-8",
-        "RoxygenNote": "7.3.2.9000",
+        "Config/roxygen2/version": "8.0.0",
         "NeedsCompilation": "yes",
-        "Packaged": "2025-05-13 13:31:44 UTC; gaborcsardi",
-        "Author": "Gábor Csárdi [aut, cre],\n  Kuba Podgórski [ctb],\n  Rich Geldreich [ctb],\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
+        "Packaged": "2026-07-13 07:41:12 UTC; gaborcsardi",
+        "Author": "Gábor Csárdi [aut, cre],\n  Kuba Podgórski [ctb],\n  Rich Geldreich [ctb],\n  Arm Limited [ctb, cph] (bundled Mbed TLS crypto subset in src/mbedtls/\n    (Apache-2.0)),\n  Posit Software, PBC [cph, fnd] (ROR: <https://ror.org/03wc8by49>)",
         "Maintainer": "Gábor Csárdi <csardi.gabor@gmail.com>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-05-13 14:10:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 15:49:42 UTC; unix"
+        "Date/Publication": "2026-07-13 10:00:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-21 01:03:23 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "zip",
+        "RemoteRef": "zip",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "3.0.1"
       }
     },
     "zoo": {
@@ -4199,48 +4711,55 @@
       "Repository": "https://cloud.r-project.org",
       "description": {
         "Package": "zoo",
-        "Version": "1.8-15",
-        "Date": "2025-12-15",
+        "Version": "1.9-0",
+        "Date": "2026-07-30",
         "Title": "S3 Infrastructure for Regular and Irregular Time Series (Z's\nOrdered Observations)",
-        "Authors@R": "c(person(given = \"Achim\", family = \"Zeileis\", role = c(\"aut\", \"cre\"), email = \"Achim.Zeileis@R-project.org\",\n                    comment = c(ORCID = \"0000-0003-0918-3766\")),\n             person(given = \"Gabor\", family = \"Grothendieck\", role = \"aut\", email = \"ggrothendieck@gmail.com\"),\n             person(given = c(\"Jeffrey\", \"A.\"), family = \"Ryan\", role = \"aut\", email = \"jeff.a.ryan@gmail.com\"),\n             person(given = c(\"Joshua\", \"M.\"), family = \"Ulrich\", role = \"ctb\", email = \"josh.m.ulrich@gmail.com\"),\n             person(given = \"Felix\", family = \"Andrews\", role = \"ctb\", email = \"felix@nfrac.org\"))",
-        "Description": "An S3 class with methods for totally ordered indexed\n             observations. It is particularly aimed at irregular time series\n             of numeric vectors/matrices and factors. zoo's key design goals\n             are independence of a particular index/date/time class and\n             consistency with ts and base R by providing methods to extend\n             standard generics.",
+        "Authors@R": "c(person(given = \"Achim\", family = \"Zeileis\", role = c(\"aut\", \"cre\"), email = \"Achim.Zeileis@R-project.org\", comment = c(ORCID = \"0000-0003-0918-3766\")),\n             person(given = \"Gabor\", family = \"Grothendieck\", role = \"aut\", email = \"ggrothendieck@gmail.com\"),\n             person(given = c(\"Jeffrey\", \"A.\"), family = \"Ryan\", role = \"aut\", email = \"jeff.a.ryan@gmail.com\"),\n             person(given = c(\"Joshua\", \"M.\"), family = \"Ulrich\", role = \"ctb\", email = \"josh.m.ulrich@gmail.com\"),\n             person(given = \"Felix\", family = \"Andrews\", role = \"ctb\", email = \"felix@nfrac.org\"))",
+        "Description": "An S3 class with methods for working with regular and irregular time series.\n             The class stores data as numeric vectors/matrices (or factors) along with a time index of arbitrary class\n             (including numeric, Date, POSIXct, chron, yearmon, yearqtr, etc.). Functions and methods\n             are consistent with the ts class and base R and also extend standard generics. Tools include:\n             Data import/export, coercion, visualization (with base R, 'ggplot2', 'lattice', 'tinyplot'), alignment and merging,\n             aggregation, lags and subsets, rolling analytics, and time-based interpolation/filling.\n             The design is introduced in Zeileis and Grothendieck (2005) <doi:10.18637/jss.v014.i06>.",
         "Depends": "R (>= 3.1.0), stats",
-        "Suggests": "AER, coda, chron, ggplot2 (>= 3.5.0), mondate, scales,\nstinepack, strucchange, timeDate, timeSeries, tinyplot, tis,\ntseries, xts",
+        "Suggests": "AER, coda, chron, ggplot2 (>= 3.5.0), knitr, mondate, scales,\nstinepack, strucchange, timeDate, timeSeries (>= 4021.104),\ntinyplot, tis, tseries, xts",
         "Imports": "utils, graphics, grDevices, lattice (>= 0.20-27)",
         "License": "GPL-2 | GPL-3",
-        "URL": "https://zoo.R-Forge.R-project.org/",
+        "VignetteBuilder": "knitr",
+        "URL": "https://zeileis.codeberg.page/zoo/",
+        "BugReports": "https://codeberg.org/zeileis/zoo/issues",
         "NeedsCompilation": "yes",
-        "Packaged": "2025-12-15 12:01:09 UTC; zeileis",
+        "Packaged": "2026-07-30 22:27:31 UTC; zeileis",
         "Author": "Achim Zeileis [aut, cre] (ORCID:\n    <https://orcid.org/0000-0003-0918-3766>),\n  Gabor Grothendieck [aut],\n  Jeffrey A. Ryan [aut],\n  Joshua M. Ulrich [ctb],\n  Felix Andrews [ctb]",
         "Maintainer": "Achim Zeileis <Achim.Zeileis@R-project.org>",
         "Repository": "CRAN",
-        "Date/Publication": "2025-12-15 14:30:02 UTC",
-        "Built": "R 4.6.0; aarch64-apple-darwin23; 2026-04-25 09:28:22 UTC; unix",
-        "Archs": "zoo.so.dSYM"
+        "Date/Publication": "2026-07-31 06:00:02 UTC",
+        "Built": "R 4.6.1; x86_64-w64-mingw32; 2026-07-31 23:51:10 UTC; windows",
+        "Archs": "x64",
+        "RemoteType": "standard",
+        "RemotePkgRef": "zoo",
+        "RemoteRef": "zoo",
+        "RemoteRepos": "https://cran.rstudio.com",
+        "RemoteSha": "1.9-0"
       }
     }
   },
   "files": {
     ".Rbuildignore": {
-      "checksum": "87f9d4ec0ffedff42d9aa1a7e04c6c96"
+      "checksum": "17f847933966777e7397760158d3dc05"
     },
     "app.R": {
-      "checksum": "3229dcd4aabe33a327543f3081c6a86b"
+      "checksum": "1eabc37e56e29f274f2e5b8eb4d2cf58"
     },
     "DESCRIPTION": {
-      "checksum": "23dd34389dd9214b8082d4e8306bc90b"
+      "checksum": "b36ee123613337d060c8eadcf60cc53b"
     },
     "inst/app/www/analytics-client.js": {
-      "checksum": "2ed67aade811d126e30272f5e6e0d035"
+      "checksum": "9f3554011b310b942c12109f347d92b0"
     },
     "inst/app/www/BISPCHARTS.png": {
       "checksum": "2b4446c6fc018b83919a15e41e225cf0"
     },
     "inst/app/www/cookie-consent.css": {
-      "checksum": "3d3dfe6b34d0c73432bdeca1b3686c3b"
+      "checksum": "8f5e154471f73a21f290acbd860b8934"
     },
     "inst/app/www/cookie-consent.js": {
-      "checksum": "7189fd2166a28917be429a708f9a0234"
+      "checksum": "79d47e8f08398c9aa8a44ccccba70ab3"
     },
     "inst/app/www/help/01-run-chart-stabil.png": {
       "checksum": "52fe486fe9191060c766afa64afe24f3"
@@ -4288,61 +4807,70 @@
       "checksum": "c652ae32097799977cbbd103e8cb3a2c"
     },
     "inst/app/www/local-storage.js": {
-      "checksum": "9558a2ff148618b70b3eab1e2544b05d"
+      "checksum": "ddc29e2d43ce1ce5f692f905aa589d6b"
     },
     "inst/app/www/shiny-handlers.js": {
-      "checksum": "3c42f98057432471266dee6c066a4ea2"
+      "checksum": "2e8f8ec614b9e86c96f0ecca3ce3bb4c"
     },
     "inst/app/www/SPCify.png": {
       "checksum": "add4ce5c2fc35cef938e935ad4f873f4"
     },
     "inst/app/www/viewport-ready.js": {
-      "checksum": "b888c376118cc359a5b7902eb65e1eed"
+      "checksum": "37009bf25612c20fb7dfc8d93da71636"
     },
     "inst/app/www/wizard-nav.js": {
-      "checksum": "3be30466bdbb018a2ae71101b0fe191d"
+      "checksum": "35bf9d9714779c1c5f1e689587625c7b"
     },
     "inst/config/brand.yml": {
-      "checksum": "8097b52693ae309bf2bd587bb6a487b9"
+      "checksum": "399b26e788c84abada3cfc5279623ca9"
     },
     "inst/extdata/sample_c.csv": {
-      "checksum": "754d8d80b545bf90842892c40fedea44"
+      "checksum": "7da9fbec6f716ffe839853b6f6ae1cc9"
     },
     "inst/extdata/sample_g.csv": {
-      "checksum": "fdbfd0e8f57659ba48cb34a6c0868812"
+      "checksum": "5ef8b4b20628c8c16aa37f946fc40a4d"
     },
     "inst/extdata/sample_i_mr.csv": {
-      "checksum": "0a0569612c2ce4bf19fd8421e3de2347"
+      "checksum": "8913ced12073366f9c55b0938cbb6875"
     },
     "inst/extdata/sample_p.csv": {
-      "checksum": "f85cd2e63272f8ff2e565a2055c4734c"
+      "checksum": "9d5962ec9d031e62489e4b213a4aa0e6"
     },
     "inst/extdata/sample_pp.csv": {
-      "checksum": "ac8a5cac4cf75613c160f657ea864af7"
+      "checksum": "8b1ee89ec56863609698049e310df2ce"
     },
     "inst/extdata/sample_run.csv": {
-      "checksum": "31659605e5e73729ac19bbe61c7f6929"
+      "checksum": "81764bddbbee3b53c4d102acecc21731"
     },
     "inst/extdata/sample_spc_data.csv": {
-      "checksum": "63a6810d13568aebaf0ea0a9a2ae2132"
+      "checksum": "db36724cf87f03ec6c64c93ea82ec4ff"
     },
     "inst/extdata/sample_t.csv": {
-      "checksum": "aa3d95a96ed048ed5d54b79f39170af2"
+      "checksum": "37064c5928dc4f66823b526fa0e4b20a"
     },
     "inst/extdata/sample_u.csv": {
-      "checksum": "bc43b1470c60521dd690ba2542732e3b"
+      "checksum": "2e1c38c4f94984a71dd371d0151c861f"
     },
     "inst/extdata/sample_up.csv": {
-      "checksum": "aadcfa3a68c28a2e95849b2278b771cc"
-    },
-    "inst/extdata/spc_exampledata_utf8.csv": {
-      "checksum": "948baf92ad30f422a7b9049af46cbbd8"
+      "checksum": "68c73feca98b8619377e249243f58143"
     },
     "inst/extdata/spc_exampledata.csv": {
-      "checksum": "bbecb64486db3e1f07b180e5334046b6"
+      "checksum": "93bd3a219736c6808f1503d5082e72dc"
+    },
+    "inst/extdata/spc_exampledata.xlsx": {
+      "checksum": "6f7ba06ac2393bee7dee08d20d9ce560"
+    },
+    "inst/extdata/spc_exampledata_utf8.csv": {
+      "checksum": "0c850e4e1cbe3e767e877e152e4a3a08"
+    },
+    "inst/extdata/SPC_Session_SPC_Analyse_2025-09-02.xlsx": {
+      "checksum": "1edc674ad3d433b5e6a0942bc0b09075"
     },
     "inst/extdata/SPC_test_data_forskellige.csv": {
-      "checksum": "72feb6fef51f3898baa4746313b3d94a"
+      "checksum": "31252ff9b9597ae551bbc5725beb79df"
+    },
+    "inst/extdata/SPC_test_data_forskellige.xlsx": {
+      "checksum": "06514758c3f9bec65d6b968b1972bbf7"
     },
     "inst/fonts/Lato-Bold.ttf": {
       "checksum": "26af1ab89ca07c82f244395a9849e150"
@@ -4354,7 +4882,7 @@
       "checksum": "c5c3b9b91ff2c85ab6dcf666f5d852b0"
     },
     "inst/fonts/LICENSE": {
-      "checksum": "86d3f3a95c324c9479bd8986968f4327"
+      "checksum": "d229da563da18fe5d58cd95a6467d584"
     },
     "inst/fonts/Roboto-Bold.ttf": {
       "checksum": "8ce868dab82f3f36896915aff1ff0dab"
@@ -4363,445 +4891,442 @@
       "checksum": "c9436ead5ef4f265e585d9e4c27db08f"
     },
     "inst/golem-config.yml": {
-      "checksum": "2f81323257d2eae56db8ea16bce6203d"
+      "checksum": "257763e93ba6f582145c840626437cf3"
     },
     "inst/templates/typst/README.md": {
-      "checksum": "5f4913fc0a1e497e314621369145b916"
-    },
-    "manifest.json": {
-      "checksum": "35cf38bf0cb7098cb5a95526410a8cd7"
+      "checksum": "ac16d15120d354be1d859cd1562aa8b7"
     },
     "NAMESPACE": {
-      "checksum": "b9cf8aced2ef17dc040af58c1db3c830"
+      "checksum": "69521a32a37e01b673fd4f0562311f7f"
     },
     "R/app_initialization.R": {
-      "checksum": "923f453cac3cedeb4e61705aa623f904"
+      "checksum": "a84dd4235f2d7cdbb9eede5b1dbde6a6"
     },
     "R/app_run.R": {
-      "checksum": "1378705b6faf3c5eb37ad6694f9c351b"
+      "checksum": "e7b41e0810d3588e05fc28a5f4c90d56"
     },
     "R/app_runtime_config.R": {
-      "checksum": "d85bbd8c1967f0d78e01081616a4e723"
-    },
-    "R/app_server_main.R": {
-      "checksum": "0ab839bfb85391ec70e0da6361fd8d44"
+      "checksum": "f0c43d75c1952f54420d5963a6553f21"
     },
     "R/app_server.R": {
-      "checksum": "c97a964c3c2b954be459b38cc6fef0e4"
+      "checksum": "572bc294c5749b43da4bc452a289326f"
+    },
+    "R/app_server_main.R": {
+      "checksum": "dee741db8388bcea840eb83d83025d80"
     },
     "R/app_ui.R": {
-      "checksum": "feae2fa63f1e6e8fe78a81e4dd40a6f7"
+      "checksum": "3aa3e848a98ff10f201ff3f22e87670d"
     },
     "R/config_analytics.R": {
-      "checksum": "5a2e6a33573869e94ac5b43e6f27f0b9"
+      "checksum": "d8ebaa1cdd1b550d54770f53717f5d74"
     },
     "R/config_branding_getters.R": {
-      "checksum": "cb066b1eac8c4724f030e0006c1b6fbc"
+      "checksum": "4182225928e5db4d9ad811c21faa09fc"
     },
     "R/config_chart_type_groups.R": {
-      "checksum": "08e6842003c325ade7fd8001b64eb9a5"
+      "checksum": "127972437dd614b9772cc249f43895a5"
     },
     "R/config_chart_types.R": {
-      "checksum": "a2df867a75348d9e5974be2fb7c53065"
+      "checksum": "24dec7b34e8aaa9293ff9b4511283d4b"
     },
     "R/config_export_config.R": {
-      "checksum": "410356d2c0c0ff25130cefeb609bfa32"
+      "checksum": "d5985f4dbd7fe55ba5b64734312c83c5"
     },
     "R/config_log_contexts.R": {
-      "checksum": "f4d5b2b046c48bf81b967abdd6288460"
+      "checksum": "be6fce833f5b8db973b73752e0727e66"
     },
     "R/config_observer_priorities.R": {
-      "checksum": "8ef87af445b04aef959c7f62199ea414"
+      "checksum": "1d459c2d05c15b2366c4fdca783d0d96"
     },
     "R/config_performance_getters.R": {
-      "checksum": "fe8ecc8838a34f5f209d3b4bd3b8477b"
+      "checksum": "9417a0a6ce0da0cea8782f26bfbdc59e"
     },
     "R/config_plot_contexts.R": {
-      "checksum": "0d896f77a7c0f726de856af20c4020e6"
+      "checksum": "749667ba68edc84b0249e0a802a0ef97"
     },
     "R/config_sample_data.R": {
-      "checksum": "eb8ed5ccb830e1c4e41ddaa3300731e8"
+      "checksum": "ceb31ef3e2b30dd885bd166a94db13b2"
     },
     "R/config_spc_config.R": {
-      "checksum": "0d6f652d8227943b71624ea7abf5dc7c"
+      "checksum": "7ea9ab36afb42e759725d7293d149587"
     },
     "R/config_support.R": {
-      "checksum": "6ae38812b6d116755650f5f7277a12db"
+      "checksum": "aab231227b4d9403f0bc16d8011ae88c"
     },
     "R/config_system_config.R": {
-      "checksum": "7b615d801bba01f16b5659f654c5e9b7"
-    },
-    "R/config_ui_getters.R": {
-      "checksum": "dfa25d660497e624791243e9e23bd5b0"
+      "checksum": "f712d0ff3dda870d3a3eda00eb33018a"
     },
     "R/config_ui.R": {
-      "checksum": "4899617210cfd5f8ef34e87ec1125cb8"
+      "checksum": "1e98222a312b2e4d8d55caca2d6dcc1d"
+    },
+    "R/config_ui_getters.R": {
+      "checksum": "92b67720659e63afc687174469a9f4c9"
     },
     "R/config_y_axis_classes.R": {
-      "checksum": "10ad01820ef64ff38ec61d0e6d55f20a"
+      "checksum": "a0a34b4a9fb9ed9b2081055bce784be2"
     },
     "R/fct_ai_improvement_suggestions.R": {
-      "checksum": "d05768191ab5ac6675a48f5ea917cfbd"
+      "checksum": "2758d7727ad570de8ba097ff661cd0ae"
     },
     "R/fct_anhoej_rules.R": {
-      "checksum": "3c7935916a4b2abb4792c9e3d5513e0c"
+      "checksum": "73d34e1ea476cb0340e95ac269ef83ba"
     },
     "R/fct_autodetect_helpers.R": {
-      "checksum": "2e79ca25b0d26df0f3c8106f9f732001"
+      "checksum": "50613d67ab2b171876c7bb7c7b62cf9c"
     },
     "R/fct_autodetect_pure.R": {
-      "checksum": "30136b33cf82447e1a98bd03a9d30a59"
+      "checksum": "3fda03eb3254007a7b75767399d9d428"
     },
     "R/fct_autodetect_unified.R": {
-      "checksum": "33119b85be78d5364f40139cca54b452"
+      "checksum": "9bd36ab48199ee9a0f87f2fd5eae431b"
     },
     "R/fct_chart_type_transition.R": {
-      "checksum": "22dd4c99b98b95be202a66cd9caa68da"
+      "checksum": "f0f12858020d44125c019f7af90b9840"
     },
     "R/fct_excel_sheet_detection.R": {
-      "checksum": "d4d7e0569dc318ba62f75738d391238b"
+      "checksum": "387f919597ff8fbda67ca2ab81569cb2"
     },
     "R/fct_file_operations.R": {
-      "checksum": "34f1fda5219513fcf2ec14b45ce74c7b"
+      "checksum": "f8112e3694d0e9c42209b61f52fec9e7"
     },
     "R/fct_file_parse_pure.R": {
-      "checksum": "7e3744188e2cd07ec98a7c6a489f3550"
+      "checksum": "ab3302f5322d00b84216baf5a70a949b"
     },
     "R/fct_file_validation.R": {
-      "checksum": "54fb273d08ec403b0d20c1486edd2d11"
+      "checksum": "1253ef03ecb4fc4802926e1538c90ffa"
     },
     "R/fct_spc_anhoej_derivation.R": {
-      "checksum": "6d56eb21965ae4ed0350e23260f5e6cd"
+      "checksum": "becbed596ed19a6fc60d50d2f7090f7b"
     },
     "R/fct_spc_bfh_facade.R": {
-      "checksum": "fd6a74c91390f66dc80cd722b7bc5143"
+      "checksum": "3d4f38e2bb32ef5202cba34a554ad800"
     },
     "R/fct_spc_bfh_invocation.R": {
-      "checksum": "d3a5d5a6d6f75bc929b94277ccd8f745"
+      "checksum": "06f926af89a0d510d7808e46a73d917b"
     },
     "R/fct_spc_bfh_output.R": {
-      "checksum": "06d9b6808569487628fd8370b556bfdc"
+      "checksum": "7dcb64a04750eab5074b24e3957f1cc2"
     },
     "R/fct_spc_bfh_params.R": {
-      "checksum": "2183c1774f959d083607ad36eca3417f"
+      "checksum": "c5782ffd7b58af8acbf5d65a933d923a"
     },
     "R/fct_spc_bfh_signals.R": {
-      "checksum": "8b4d3ad2da3ecd752dff1853d8513f98"
+      "checksum": "3c1b10e8ddeca1df79a9fe051be40bce"
     },
     "R/fct_spc_contracts.R": {
-      "checksum": "cffca287393a6e68877e5066158e8497"
+      "checksum": "73657d64545e37248929353c20bfb0f1"
     },
     "R/fct_spc_decorate.R": {
-      "checksum": "026c3d389d6197dd72e166ddcb87e4d3"
+      "checksum": "ea18e402307a75b31a98049bd42f025c"
     },
     "R/fct_spc_excel_analysis.R": {
-      "checksum": "acafefe585a7c3c8b4935da7e717f76b"
+      "checksum": "b188f5b97a303d70e728143e401110c9"
     },
     "R/fct_spc_execute.R": {
-      "checksum": "aec7a62736731e9fcefdd295899891fc"
+      "checksum": "c407541de96eaeda7b1a5fb563b4cc89"
     },
     "R/fct_spc_file_save_load.R": {
-      "checksum": "ce1e71cec2afe3f34144e8febef607dd"
+      "checksum": "761df7a44710fc72c33d13f834fa6e76"
     },
     "R/fct_spc_helpers.R": {
-      "checksum": "d72626a55c1e9e7034fd4aedeaea42cd"
+      "checksum": "63cfe0e7ef9ac6a21f86037348ff868b"
     },
     "R/fct_spc_plot_generation.R": {
-      "checksum": "6d7047f1a8228376410eebdc2d24c9e3"
+      "checksum": "b8fcafec624dcc71136786052f2f68bb"
     },
     "R/fct_spc_prepare.R": {
-      "checksum": "8d151fe0b6346dbad722113200f7ef2e"
+      "checksum": "ef528f55ea63493da7385a0335966d10"
     },
     "R/fct_spc_validate.R": {
-      "checksum": "14a70f563188ae4c75d4d9c550f6b722"
+      "checksum": "b8629808be5d2a159c8cb1d1f6a77640"
     },
     "R/fct_visualization_config_pure.R": {
-      "checksum": "67e9cbe0f7b526bd2a54021847be61f5"
+      "checksum": "4dcdb1428de35a492a6cc021f9786a79"
     },
     "R/golem_utils.R": {
-      "checksum": "ba1180b923c7f4425ff5b7788c734336"
+      "checksum": "1173662a3e59c50bac1b18f24df239b1"
     },
     "R/mod_about_server.R": {
-      "checksum": "a83e2c12d1e07745310dc0e1e7c98683"
+      "checksum": "981e01adcce11747991223d64693cbe9"
     },
     "R/mod_about_ui.R": {
-      "checksum": "8b2d58e256221443ed2d2a9524534aa1"
+      "checksum": "bdbfb9bdc4a0c3de3fbe02c8d6dd8bdb"
     },
     "R/mod_app_guide_ui.R": {
-      "checksum": "da34aedc88073594c3f2fea3f8fa4df5"
+      "checksum": "73d319919de5fba57288527f605642bb"
     },
     "R/mod_export_ai.R": {
-      "checksum": "3e05bee8423d5db8e433202bf34e5d66"
+      "checksum": "f2475730a6fcd252f84d60cc015fb3f0"
     },
     "R/mod_export_analysis.R": {
-      "checksum": "9c0ecdd409037ca33ca3743ce6145525"
+      "checksum": "e942f896587223643f9f68bdc2465386"
     },
     "R/mod_export_download.R": {
-      "checksum": "f0358316a0476dea3715532573300aa7"
+      "checksum": "71934c8f5f6ac7184ebcf7c10dbe3ed6"
     },
     "R/mod_export_server.R": {
-      "checksum": "40ba4680fa08ffed664ebfcece59c7bd"
+      "checksum": "d529520ce262f8c9f59bfe73be270584"
     },
     "R/mod_export_ui.R": {
-      "checksum": "35573e91ef3737e5e8fc2484dcca9f29"
+      "checksum": "5b9d3c60e4a974d9808229d2ab6d1c43"
     },
     "R/mod_help_server.R": {
-      "checksum": "1dbd9afb732efdf03222ebab03e29762"
+      "checksum": "bc903a866ceb1b2ce449375f7987a750"
     },
     "R/mod_help_ui.R": {
-      "checksum": "280b5ecbe74b97189eeba1b966c0a18c"
+      "checksum": "6faba674af1523782c9a8823ba193570"
     },
     "R/mod_landing_server.R": {
-      "checksum": "81da0c8c3f74ad1a37ec39e7c35444d8"
+      "checksum": "1db51a27e77e74c3ddccf3906fff22f0"
     },
     "R/mod_landing_ui.R": {
-      "checksum": "f3a303e87e5040b6e0455f17ba6aa1bb"
+      "checksum": "2fe93b75af7f1b2ea165c5375c4c9425"
     },
     "R/mod_report_bug_server.R": {
-      "checksum": "0fda8b12eb1539b1164ffad60337e893"
+      "checksum": "deb993950fc5b46cc5de1e524e287261"
     },
     "R/mod_report_bug_ui.R": {
-      "checksum": "083c17739e20efc9f95a5ec9ed11694f"
+      "checksum": "274f3970a95308d3d6a978ebf34c04f4"
     },
     "R/mod_spc_chart_compute.R": {
-      "checksum": "513a0fbafebc8ec46fe53fe7811602f2"
+      "checksum": "273caff213c80dd14d0f0b0c64bfa136"
     },
     "R/mod_spc_chart_config.R": {
-      "checksum": "e9d769f9a0ac84e375ecb01800c0fc5a"
+      "checksum": "b8f1c622d9a1ef6ce3d009c07cf0d299"
     },
     "R/mod_spc_chart_inputs.R": {
-      "checksum": "1575f7897a1a29c794e1caf65e8fe551"
+      "checksum": "73bc40decef1c8dad880aeced762b2d7"
     },
     "R/mod_spc_chart_observers.R": {
-      "checksum": "4d6320e958a8d35e0818501e7dfd098c"
+      "checksum": "afa9ff82b6d401a4ad723a29aacd7ff0"
     },
     "R/mod_spc_chart_server.R": {
-      "checksum": "f31a1693cee075c3e24a4a4e4273fe3e"
+      "checksum": "e76593e667ee38d0811e54fdeccf13e9"
     },
     "R/mod_spc_chart_state.R": {
-      "checksum": "088fc48c3a84be768aa72d20dc19a316"
+      "checksum": "2bf9b9be6af4cfcf21aedcbdc8988ba0"
     },
     "R/mod_spc_chart_ui.R": {
-      "checksum": "b797c2e9ec4fadc824725b48533f5eb3"
+      "checksum": "29f0c721dea9095acb7ef67ad989d298"
     },
     "R/package_imports.R": {
-      "checksum": "f4f19053aeee0722067869808f5dd8a5"
+      "checksum": "67bc9e371517a133e146e906f9ecead8"
     },
     "R/state_management.R": {
-      "checksum": "194b30cd81c368a91a989211a2af7ced"
+      "checksum": "886d0b9f35c2570284909b61d70a23ad"
     },
     "R/utils_advanced_debug.R": {
-      "checksum": "bb69b58ed176374775a59c5afd142de0"
+      "checksum": "f206673c2d2baf0ee2a293652a84e325"
     },
     "R/utils_analytics_consent.R": {
-      "checksum": "ccfb359da8772d1f446db125b0092613"
+      "checksum": "80bebc0c54e48d29e927351b9a14b6d4"
     },
     "R/utils_analytics_github.R": {
-      "checksum": "e3d41ac7edf185ef93f87887507ac3e1"
+      "checksum": "fd99d934297d3f84dbe009421438f77a"
     },
     "R/utils_analytics_pins.R": {
-      "checksum": "df54acec01e386ecc0bdb28651b5b445"
+      "checksum": "1340057800072537e0d9c4f7b1a0affd"
     },
     "R/utils_anhoej_results.R": {
-      "checksum": "0da716b6a4b805c42d3477ad8f582127"
+      "checksum": "10ff2e6e4503fd9069dec84d0a300f23"
     },
     "R/utils_async_helpers.R": {
-      "checksum": "d8c5dc6a8429afae190b8433610bcc25"
+      "checksum": "d882f8fbede24cf81237eddf78ec9e45"
     },
     "R/utils_bfhllm_integration.R": {
-      "checksum": "3ac2436241b437d29a0126fc7235a568"
+      "checksum": "86fef91c90bacf9739c3f2ec8674c802"
     },
     "R/utils_cache_generators.R": {
-      "checksum": "9ddd22e6cb24b986659758b4ab0143b7"
+      "checksum": "491a57fbb94ed56310a60d0fea16ff5c"
     },
     "R/utils_csv_delimiter_detection.R": {
-      "checksum": "e1f5a724400aecc2d5804ea95e471eae"
+      "checksum": "d2b35e446571c0de9402d8422c19b590"
     },
     "R/utils_danish_locale.R": {
-      "checksum": "4aa6dceb469e70d9cc4a2b7ac61d27f9"
+      "checksum": "234e1ebe9e88cd18462021b1c5e94ad2"
     },
     "R/utils_data_signatures.R": {
-      "checksum": "76f5ac82424b25ff0024981aad12da84"
+      "checksum": "1c5be8d4c4685ea027eb1e9189a437d6"
     },
     "R/utils_error_handling.R": {
-      "checksum": "1ec34acbdce034bed3641c48b83f9d52"
+      "checksum": "6a315ba3a987b7610352736b3ab5e757"
     },
     "R/utils_event_context_handlers.R": {
-      "checksum": "ad29bacba617e29a0d3f6c3e210046b4"
+      "checksum": "ebbbfb765fe6d371335c624c30cc19cd"
     },
     "R/utils_export_analysis_metadata.R": {
-      "checksum": "ebe72626be3692e4e8efb941434c5dc9"
+      "checksum": "9f1ab17c618632b95e2493bf6e610997"
     },
     "R/utils_export_filename.R": {
-      "checksum": "6239f32d74045acbca25463fd89d8132"
+      "checksum": "f2a36c4510ffd3a4458b89147f5df2c3"
     },
     "R/utils_export_helpers.R": {
-      "checksum": "7f3f4c4de2fcef6e94d3c7d7a271e360"
+      "checksum": "c9ef418b16b686352dab461811991f76"
     },
     "R/utils_export_validation.R": {
-      "checksum": "f1901f35087860ff18513fa7950eaaaf"
+      "checksum": "b14840771e20f80c7f0d722ed27effa3"
     },
     "R/utils_font_registration.R": {
-      "checksum": "d32421365235aab1dc2542d636feee30"
+      "checksum": "7a3bf626638b441c28c5cefa96865157"
     },
     "R/utils_input_sanitization.R": {
-      "checksum": "fcb9fcc29230abed0088050748bf7868"
+      "checksum": "7fb6379b0ce21c5f4078bfbb53fc5216"
     },
     "R/utils_label_formatting.R": {
-      "checksum": "67fcf5ab59ba448478a1eace7a0521d9"
+      "checksum": "32794da463650fdc910dcf609952e444"
     },
     "R/utils_lazy_loading.R": {
-      "checksum": "be1cf2da615d708f873e68caa27150d4"
+      "checksum": "96abdc32dea96c98e7cdde9e2a331bcb"
     },
     "R/utils_local_storage.R": {
-      "checksum": "9d4ffec108a28ccf354cb656fa084729"
+      "checksum": "bcb615345caeacee74195c08823f8f85"
     },
     "R/utils_logging.R": {
-      "checksum": "29006c6add3022c86c8cdfc7b26b396f"
+      "checksum": "89893846eca93b975c2edc94669f2aaf"
     },
     "R/utils_memory_management.R": {
-      "checksum": "bfe536e1834aa017443d665963af9000"
+      "checksum": "4f1321a2a35a4ee0ef9cf74d12108eef"
     },
     "R/utils_microbenchmark.R": {
-      "checksum": "b99ffea3e15ed45ff818b722d80b4ad7"
-    },
-    "R/utils_performance_caching.R": {
-      "checksum": "b12d3fe797933899b542388cb196835a"
-    },
-    "R/utils_performance_monitoring.R": {
-      "checksum": "9c9594288167cd3f9de0cd55ca6e8dbd"
+      "checksum": "2d960b1d49c43f92d60700c2022dc41e"
     },
     "R/utils_performance.R": {
-      "checksum": "c15416ac539ae371a01a932bd223d097"
+      "checksum": "d859910d80df47924bf6293d1cc5564d"
+    },
+    "R/utils_performance_caching.R": {
+      "checksum": "5b94593bdfece726a3d2e5ac0fa261db"
+    },
+    "R/utils_performance_monitoring.R": {
+      "checksum": "04fbb9b6563dd1c5cec1d636cf8b9e5a"
     },
     "R/utils_qic_cache_invalidation.R": {
-      "checksum": "f7ed7adde968e2c3004e47693d339ac1"
+      "checksum": "9d870a79bdae6ccd6cb2a9ec7761c9f8"
     },
     "R/utils_qic_caching.R": {
-      "checksum": "d6ccb5cd13dd74994ca9aad30833cb1e"
+      "checksum": "c5121d5008c6ee95f170fef394d6286f"
     },
     "R/utils_server_column_input.R": {
-      "checksum": "68908bd7f0038bcbeb637e0c56ab9569"
+      "checksum": "ab1b11b49ae728b6226ff5a13c60d333"
     },
     "R/utils_server_column_management.R": {
-      "checksum": "547dd3d3bc4d4ba6e35105239dfb9fb5"
+      "checksum": "51b121459aa6bd46d04a70460833c9eb"
     },
     "R/utils_server_event_listeners.R": {
-      "checksum": "456128f7233f32e0bf62161edb8e6e55"
+      "checksum": "f1ee68bcac3f962ffdcddbb8f75a327c"
     },
     "R/utils_server_events_autodetect.R": {
-      "checksum": "60614a7b4afebc57ccbe80442e63cf9a"
+      "checksum": "7e2cec70f906ae056ca42f3b876764e6"
     },
     "R/utils_server_events_chart.R": {
-      "checksum": "f980bd04d476812ee5d9f9c975238495"
+      "checksum": "c2f0cc7d5fa63bde7b1c11301342ba74"
     },
     "R/utils_server_events_data.R": {
-      "checksum": "ddbbb46f800c8e25322ee6f4dc3e13c9"
+      "checksum": "4dd5b1943a57cfac698634f9c6949a9a"
     },
     "R/utils_server_events_navigation.R": {
-      "checksum": "275c5b76863dbf206e7147c0b5233e7e"
+      "checksum": "ba7ef04629afd2d691dcb0ecc26774e5"
     },
     "R/utils_server_events_ui.R": {
-      "checksum": "af9e37a623e61ce3043091ea00d7548a"
+      "checksum": "de424077e92ebd945ebaf61b7199be97"
     },
     "R/utils_server_export.R": {
-      "checksum": "483549e2c2149b5968eeea2164e8dfd7"
+      "checksum": "4195677e023385c26140241e55dee57d"
     },
     "R/utils_server_initialization.R": {
-      "checksum": "94e76a069570922e6df19146cf2b463d"
+      "checksum": "90d09e2b927088ebe830f2c10d7e1c06"
     },
     "R/utils_server_navigation_guard.R": {
-      "checksum": "f54d766c9668302221e6ec3aed001a94"
+      "checksum": "7470e32b7b196a6b09266abcad0c944a"
     },
     "R/utils_server_observer_manager.R": {
-      "checksum": "99793a6fe76515d1eaee0204be77c26a"
+      "checksum": "28ee3016d72a01d4c68313692f78c37e"
     },
     "R/utils_server_paste_data.R": {
-      "checksum": "e33196c14e2d621e42bc529c4cd9f808"
+      "checksum": "08fecd55c122eb6eb94d0aac6dca75c0"
     },
     "R/utils_server_server_management.R": {
-      "checksum": "a0fd02f0f83d18c8f558946fbbac1216"
+      "checksum": "11a12a1c93a55802c2d816fda51ba6f7"
     },
     "R/utils_server_session_helpers.R": {
-      "checksum": "fea262aa9aa6b10b9f7178bfd690fe46"
+      "checksum": "e73984db5e21e249e266e5acfaea81c6"
     },
     "R/utils_server_session_persistence.R": {
-      "checksum": "29e54bbb3df84175c5df750add58303c"
+      "checksum": "60b78c96a295c17867fc476bc5e4d464"
     },
     "R/utils_server_session_status.R": {
-      "checksum": "1a2af18a328a7548b7fa91df0cff8511"
+      "checksum": "3f9f809d384cc1d47f34b02cb0582d2b"
     },
     "R/utils_server_spc_save.R": {
-      "checksum": "41bc790bb280fd04ad7f7a07c607583d"
+      "checksum": "28343903673380a8571eee44c08cd80b"
     },
     "R/utils_server_visualization.R": {
-      "checksum": "d750e76fc69fde29d518090d8e4febbf"
+      "checksum": "4c9285679510293f96f60e9cf79cc59c"
     },
     "R/utils_server_wizard_gates.R": {
-      "checksum": "c092927e0a8bf1ffbd15223629de87b4"
+      "checksum": "ae9fcf785fe21255a0f6658676d100af"
     },
     "R/utils_shinylogs_config.R": {
-      "checksum": "d70582982f337504eeb67e0689c46e7b"
+      "checksum": "eaf4a77f134cd047bdf0530d12104b99"
     },
     "R/utils_spc_cache.R": {
-      "checksum": "402ed626f076b65088ef19d909cae196"
+      "checksum": "8bc84fb32e6a97e2131c7cc3ba2f1147"
     },
     "R/utils_spc_chart_ui_helpers.R": {
-      "checksum": "5cf348dcb531651a6772b3cd81ab1ef7"
+      "checksum": "3412762b36010619239ef00770ce5c11"
     },
     "R/utils_spc_data_processing.R": {
-      "checksum": "3dec2b2a539957c81b1221375f4029d5"
+      "checksum": "15d36b67bb80395b8c0eeb5aa396e9bb"
     },
     "R/utils_startup_cache.R": {
-      "checksum": "dc34f9a3705ea40924010753ec6dc4a2"
+      "checksum": "2f1af25e1b35f6c7c0177a7694e3947f"
     },
     "R/utils_state_accessors.R": {
-      "checksum": "42ab11735e2f227e1275bc8d230484ad"
+      "checksum": "fa0cc58aee8b214f8a40e3d77b903956"
     },
     "R/utils_state_transitions.R": {
-      "checksum": "c844beb6cf159c6452eecceadf94f6ad"
+      "checksum": "1f446ddbbe0b46a8b1d4b6b7f12ff469"
     },
     "R/utils_time_formatting.R": {
-      "checksum": "8e8378e9549f2e00b3ebc9864a0f95bf"
+      "checksum": "2d202708b8ec529c205072d57cf5e701"
     },
     "R/utils_time_parsing.R": {
-      "checksum": "2a89e70626500a1b8267ecb603047ff5"
+      "checksum": "ae13d64e3d72d7c54ea90a1c479df463"
     },
     "R/utils_ui_app_layout.R": {
-      "checksum": "02f6670291e0add0fe4c525a0aa93983"
+      "checksum": "c85e507e6592013922dc6bf2c73d840e"
     },
     "R/utils_ui_column_sync.R": {
-      "checksum": "cfb8a0e40df0094e786ba865c1caef30"
+      "checksum": "46d3e59554669f2a9b94253eb832fe9f"
     },
     "R/utils_ui_column_update_service.R": {
-      "checksum": "29b13bca4cdc753a8491af2eadf5687a"
+      "checksum": "dc8dea3195f093bfbcda7ca4e8b0546d"
     },
     "R/utils_ui_form_update_service.R": {
-      "checksum": "2623daa0e0e58461e516f5ec2b75ddd7"
+      "checksum": "f689a87a7767676d2abfb1d641ba2725"
     },
     "R/utils_ui_table_update_service.R": {
-      "checksum": "4cf6cb607f94317f89e8e2209604b873"
+      "checksum": "bb67e9797702f530174fd5f38059fc47"
     },
     "R/utils_ui_ui_helpers.R": {
-      "checksum": "4c3cf8bcc1310491faeaa8aa02c643ce"
+      "checksum": "a080a9db89b70f01ee136b54ed013c5f"
     },
     "R/utils_ui_ui_updates.R": {
-      "checksum": "c29c94a482678085b2ebfbd8e4267bed"
+      "checksum": "41e296b1077e73117aa0fd54eede7c99"
     },
     "R/utils_visualization_dimensions.R": {
-      "checksum": "b32d7aa699f03a96986b07b749fd06b0"
+      "checksum": "7eade97e6f7d9eddea54faef0c6c3e9f"
     },
     "R/utils_y_axis_formatting.R": {
-      "checksum": "a43315bd81b9b8e9c4c8d7eb9e5e853c"
+      "checksum": "307058f71e581a56b8ce75d689db1241"
     },
     "R/utils_y_axis_model.R": {
-      "checksum": "62c5fe0b350a2997174b38d141fee69b"
+      "checksum": "7377e9d852ecefc3c204c62449cb15e7"
     },
     "R/utils_y_axis_scaling.R": {
-      "checksum": "f894af4a40bcf6f45db307687e3cef20"
+      "checksum": "57023e9f3e368a065295af6ae8b544c6"
     },
     "R/zzz.R": {
-      "checksum": "179e6232b79a8e3613f42bb7a97d0272"
+      "checksum": "50c8d8fd919b80844834ce977ac1ece2"
     }
   },
   "users": null

--- a/manifest.json
+++ b/manifest.json
@@ -48,10 +48,10 @@
         "GithubRef": "v0.27.0",
         "GithubSHA1": "e5cc1ef8844f7c3c4b547f43dc091c573254704e",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 15:37:21 UTC; JREV0004",
+        "Packaged": "2026-08-11 16:49:08 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 15:37:32 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-11 16:49:12 UTC; windows"
       }
     },
     "BFHchartsAssets": {
@@ -81,21 +81,21 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 15:40:49 UTC; JREV0004",
+        "Packaged": "2026-08-11 16:50:51 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 15:40:56 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-11 16:50:55 UTC; windows"
       }
     },
     "BFHllm": {
-      "Source": "https://johanreventlow.r-universe.dev",
+      "Source": "github",
       "Repository": null,
       "description": {
         "Package": "BFHllm",
         "Title": "LLM Integration Framework for BFH Packages",
         "Version": "0.2.0",
         "Authors@R": "\n    person(\"Johan\", \"Reventlow\", , \"johan.reventlow@regionh.dk\", role = c(\"aut\", \"cre\"))",
-        "Description": "AI-driven insights and text generation for healthcare\n        quality improvement. Provides LLM chat interface, RAG\n        (Retrieval Augmented Generation) integration with knowledge\n        stores, and SPC-specific improvement suggestions. Designed for\n        standalone use with BFHcharts or integration in Shiny\n        applications.",
+        "Description": "AI-driven insights and text generation for healthcare quality\n    improvement. Provides LLM chat interface, RAG (Retrieval Augmented\n    Generation) integration with knowledge stores, and SPC-specific\n    improvement suggestions. Designed for standalone use with BFHcharts\n    or integration in Shiny applications.",
         "License": "MIT + file LICENSE",
         "URL": "https://github.com/johanreventlow/BFHllm",
         "BugReports": "https://github.com/johanreventlow/BFHllm/issues",
@@ -106,17 +106,21 @@
         "Suggests": "testthat (>= 3.0.0), shiny (>= 1.7.0), mockery, withr,\nBFHcharts (>= 0.4.0)",
         "Remotes": "johanreventlow/BFHcharts",
         "Config/testthat/edition": "3",
-        "Config/pak/sysreqs": "cmake libicu-dev libpng-dev libxml2-dev libssl-dev\npython3 xz-utils",
-        "Repository": "https://johanreventlow.r-universe.dev",
-        "Date/Publication": "2026-05-09 08:27:54 UTC",
-        "RemoteUrl": "https://github.com/johanreventlow/BFHllm",
-        "RemoteRef": "HEAD",
+        "RemoteType": "github",
+        "RemoteHost": "api.github.com",
+        "RemoteRepo": "BFHllm",
+        "RemoteUsername": "johanreventlow",
+        "RemoteRef": "v0.2.0",
         "RemoteSha": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
+        "GithubRepo": "BFHllm",
+        "GithubUsername": "johanreventlow",
+        "GithubRef": "v0.2.0",
+        "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
         "NeedsCompilation": "no",
-        "Packaged": "2026-05-09 09:19:40 UTC; root",
+        "Packaged": "2026-08-11 16:53:49 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-05-09 09:21:10 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-11 16:53:53 UTC; windows"
       }
     },
     "BFHtheme": {
@@ -148,10 +152,10 @@
         "GithubRef": "v0.5.5",
         "GithubSHA1": "8fc1eb9809de13af00aeaafcc5a791fe3bfb4330",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 16:34:06 UTC; JREV0004",
+        "Packaged": "2026-08-11 16:49:54 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 16:34:09 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-11 16:49:56 UTC; windows"
       }
     },
     "BH": {
@@ -4747,7 +4751,7 @@
       "checksum": "1eabc37e56e29f274f2e5b8eb4d2cf58"
     },
     "DESCRIPTION": {
-      "checksum": "b36ee123613337d060c8eadcf60cc53b"
+      "checksum": "945b803011eb0dc08db399abc1d4fbd9"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "9f3554011b310b942c12109f347d92b0"

--- a/tests/testthat/helper-mocks.R
+++ b/tests/testthat/helper-mocks.R
@@ -175,10 +175,10 @@ mock_board_connect <- function(auth = c("auto", "manual", "envvar"),
 #' Mock for gert::git_clone
 #'
 #' Returnerer path uden faktisk git-clone.
-#' formals() matcher gert::git_clone (gert 2.1.5+).
+#' formals() matcher gert::git_clone (gert 2.4.0+, inkl. depth-param).
 mock_git_clone <- function(url, path = NULL, branch = NULL, password = NULL,
                            ssh_key = NULL, bare = FALSE, mirror = FALSE,
-                           verbose = interactive()) {
+                           depth = 0, verbose = interactive()) {
   path <- path %||% tempfile("mock-clone-")
   if (!dir.exists(path)) dir.create(path, recursive = TRUE)
   invisible(path)

--- a/tests/testthat/test-spc-plot-generation-comprehensive.R
+++ b/tests/testthat/test-spc-plot-generation-comprehensive.R
@@ -322,7 +322,10 @@ test_that("generateSPCPlot centerline label bruger geom_marquee", {
   expect_equal(length(text_layers), 1)
 
   layer <- text_layers[[1]]
-  expect_equal(rlang::as_name(layer$mapping$label), "label")
+  # BFHcharts 0.26.1+ bygger label-aesthetic som .data[["label"]] (call) i
+  # stedet for et symbol — rlang::as_name() håndterer kun symboler, så vi
+  # evaluerer quosure'en direkte mod layer$data i stedet.
+  expect_equal(rlang::eval_tidy(layer$mapping$label, layer$data), layer$data$label)
   expect_equal(layer$aes_params$size, 6)
 
   # 'type'-kolonne fjernet i BFHcharts 0.10.x — identificér centrallinjerækker via label-indhold
@@ -365,7 +368,10 @@ test_that("generateSPCPlot target label bruger geom_marquee", {
   expect_equal(length(text_layers), 1)
 
   layer <- text_layers[[1]]
-  expect_equal(rlang::as_name(layer$mapping$label), "label")
+  # BFHcharts 0.26.1+ bygger label-aesthetic som .data[["label"]] (call) i
+  # stedet for et symbol — rlang::as_name() håndterer kun symboler, så vi
+  # evaluerer quosure'en direkte mod layer$data i stedet.
+  expect_equal(rlang::eval_tidy(layer$mapping$label, layer$data), layer$data$label)
   expect_equal(layer$aes_params$size, 6)
 
   # 'type'-kolonne fjernet i BFHcharts 0.10.x — identificér målrækker via label-indhold


### PR DESCRIPTION
## Summary

- Bumper BFHcharts fra 0.26.0 til 0.27.0 (lower-bound i `DESCRIPTION` + `Remotes`-tag)
- Regenererer `manifest.json` (BFHcharts 0.27.0, samt BFHtheme geninstalleret fra korrekt tag v0.5.5 under processen — DESCRIPTION's BFHtheme-pin er uændret v0.5.2, ren manifest-artefakt)

## BFHcharts 0.27.0 highlights

- **Kalenderforankret x-akse for dags- og ugedata.** Lange serier fik tidligere labels på vilkårlige datoer; nu forankres breaks til kalenderen.
- **Granularitets-bevidst periodelinje.** Uge-, dags-, kvartals- og årsdata vises nu med matchende periodeformat i stedet for altid måned+år. Ugenumre parres med ISO-året.

Se [BFHcharts NEWS 0.27.0](https://github.com/johanreventlow/BFHcharts/blob/main/NEWS.md) for fuld changelog.

## Test plan

- [x] Fuld testsuite kørt mod BFHcharts 0.27.0: 6624 pass
- [x] 6 fail ved fuld kørsel (test-e2e-workflows.R) undersøgt — Chromote/shinytest2-miljøflakiness, ikke relateret til BFHcharts. Bekræftet ved isoleret kørsel af samme fil: 0 fail / 28 pass / 8 skip-on-CRAN
- [x] manifest.json regenereret og verificeret (BFHcharts 0.27.0)

## Noter

`dev/publish_prepare.R`'s manifest-fase ramte en pre-eksisterende gap: `rsconnect::writeManifest()` afviser source-installerede pakker (`biSPCharts` selv + lokalt out-of-date `BFHtheme`). Krævede manuel fjernelse af biSPCharts fra library samt geninstallation af BFHtheme fra et registreret tag før manifest kunne regenereres. Kan være værd at adressere i et separat opfølgende issue, så fremtidige bumps ikke rammer samme friktion.