### PR TITLE
chore(release): bump version til 0.8.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biSPCharts
 Title: Statistical Process Control for Clinical Quality Improvement
-Version: 0.7.0
+Version: 0.8.0
 Authors@R:
     person("Johan", "Reventlow", , "johan@reventlow.dk", role = c("aut", "cre"))
 Description:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# biSPCharts (development)
+# biSPCharts 0.8.0
 
 ## Interne ændringer
 


### PR DESCRIPTION
## Summary

- Bumper biSPCharts fra 0.7.0 til 0.8.0 (MINOR — dependency-opgradering, ikke-breaking for egen public API)
- Omdøber NEWS.md's `(development)`-header til `0.8.0`

Dækker versionsbumpet for BFHcharts 0.27.0-dependency-opgraderingen der blev merget i #867 (via #868 til master), jf. VERSIONING_POLICY.md §D (versionsbump + tag ved release til master).

## Test plan

- [x] Ingen kodeændringer — kun `DESCRIPTION` Version og `NEWS.md`-header
- [x] CI (lint/testthat/manifest) upåvirket af rene metadata-ændringer