### PR TITLE
Release: develop -> master (biSPCharts 0.8.0)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: biSPCharts
 Title: Statistical Process Control for Clinical Quality Improvement
-Version: 0.7.0
+Version: 0.8.0
 Authors@R:
     person("Johan", "Reventlow", , "johan@reventlow.dk", role = c("aut", "cre"))
 Description:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# biSPCharts (development)
+# biSPCharts 0.8.0
 
 ## Interne ændringer
 


### PR DESCRIPTION
## Summary

Release-PR for biSPCharts 0.8.0 (develop → master), jf. GIT_WORKFLOW.md-flowet hvor master kun modtager develop→master release-PR'er.

Indeholder version-bumpet fra #869 (DESCRIPTION 0.7.0→0.8.0, NEWS.md-header omdøbt), som følger op på BFHcharts 0.27.0-dependency-opgraderingen fra #867/#868.

Naar denne merges, opretter jeg det annoterede tag `v0.8.0` på master-mergecommiten (VERSIONING_POLICY.md §B/§D).