### PR TITLE
chore(deps): bump BFHcharts to 0.27.1 + BFHllm-version-sync

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     ggplot2 (>= 3.4.0),
     htmltools (>= 0.5.0),
     rlang (>= 1.0.0),
-    BFHcharts (>= 0.27.0),
+    BFHcharts (>= 0.27.1),
     readr (>= 2.0.0),
     readxl (>= 1.4.0),
     scales (>= 1.2.0),
@@ -63,7 +63,7 @@ Suggests:
     covr (>= 3.6.0),
     qicharts2 (>= 0.7.0),
     curl (>= 4.3.0),
-    BFHllm (>= 0.2.0),
+    BFHllm (>= 0.2.1),
     BFHchartsAssets (>= 0.1.2),
     BFHtheme (>= 0.5.5),
     pins (>= 1.2.0),
@@ -79,9 +79,9 @@ Suggests:
     pbcharts (>= 0.1.0)
 Config/testthat/edition: 3
 Config/Notes: pbcharts i Suggests+Remotes — kraeves af BFHcharts for ip/i-prime + Laney P'/U'-charts (eksponeret som foersteklasses chart-typer). Refereres via requireNamespace() i .onAttach (R/zzz.R) saa rsconnect-scanneren medtager den i Connect-manifestet; uden kode-reference scanner rsconnect den ikke. SHA-pinnet (anhoej/pbcharts utagget upstream) — validate_connect_manifest.R tillader fuld 40-char SHA for tredjeparts-repos. qicharts2 i Suggests — bruges til Anhøj-beregninger, guarded med require_qicharts2(). BFHllm i Suggests — optional AI-forbedringer, degraderer gracefully hvis ikke installeret. pins, gert, shinylogs i Suggests — analytics-features, guarded med requireNamespace(). DO NOT REMOVE svglite fra Imports — workaround for BFHcharts svglite-Suggests-bug (BFHcharts issue #268). Tidligere fjernet i #293 ("0 direkte brug i grep R/") og #382 (manifest regen) → produktions-PDF-eksport fejler med "package svglite is required to save as SVG". svglite kaldes indirekte via BFHcharts::bfh_export_pdf() i export_chart_svg(). Fjern KUN når BFHcharts promoter svglite til Imports.
-Remotes: johanreventlow/BFHcharts@v0.27.0,
+Remotes: johanreventlow/BFHcharts@v0.27.1,
     johanreventlow/BFHtheme@v0.5.5,
-    johanreventlow/BFHllm@v0.2.0,
+    johanreventlow/BFHllm@v0.2.2,
     johanreventlow/BFHchartsAssets@v0.1.2,
     anhoej/pbcharts@d37a8ec1864528ece1f5cd60ac152d06c013515f
 Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# biSPCharts (development)
+
+## Interne ændringer
+
+* **BFHcharts bumpet til 0.27.1** (PATCH fra 0.27.0). Afdelinger der
+  præsterer over målet får ikke længere en tekst, der lyder som en
+  bebrejdelse: når målet angives som et bart tal uden retningsoperator
+  (fx `target_value = 0.85`), rapporterer analysen nu retningen neutralt
+  ("Niveauet ligger stabilt over målet. Vurdér, om det er
+  tilfredsstillende.") i stedet for at antage målet er et minimum. Se
+  BFHcharts NEWS 0.27.1 for detaljer.
+
+* **BFHllm bumpet til 0.2.1** (fra 0.2.0). Ren version-sync-fix i BFHllm
+  selv (BFHllm PR #11) — ingen funktionel ændring for biSPCharts.
+
 # biSPCharts 0.8.0
 
 ## Interne ændringer

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
       "description": {
         "Package": "BFHcharts",
         "Title": "SPC Visualization for Healthcare Quality Improvement",
-        "Version": "0.27.0",
+        "Version": "0.27.1",
         "Authors@R": "c(\n    person(\n      \"Johan\", \"Reventlow\",\n      email = \"johan.reventlow@regionh.dk\",\n      role = c(\"aut\", \"cre\")\n    )\n  )",
         "Description": "A modern R package for creating Statistical Process Control (SPC)\n    charts in healthcare settings. Built on ggplot2 and qicharts2, BFHcharts\n    provides beautiful, publication-ready SPC visualizations with configurable\n    themes and multi-organizational branding support. Inspired by BBC's bbplot\n    design philosophy.",
         "License": "GPL-3",
@@ -41,17 +41,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHcharts",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.27.0",
-        "RemoteSha": "e5cc1ef8844f7c3c4b547f43dc091c573254704e",
+        "RemoteRef": "v0.27.1",
+        "RemoteSha": "6c30136bc0d043104330687d4e79bbcbdadcee73",
         "GithubRepo": "BFHcharts",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.27.0",
-        "GithubSHA1": "e5cc1ef8844f7c3c4b547f43dc091c573254704e",
+        "GithubRef": "v0.27.1",
+        "GithubSHA1": "6c30136bc0d043104330687d4e79bbcbdadcee73",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 16:49:08 UTC; JREV0004",
+        "Packaged": "2026-08-12 11:04:04 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 16:49:12 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-12 11:04:12 UTC; windows"
       }
     },
     "BFHchartsAssets": {
@@ -81,10 +81,10 @@
         "GithubRef": "v0.1.2",
         "GithubSHA1": "afae3a0c9f7f0f36f6131feadf69c480a9733d4b",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 16:50:51 UTC; JREV0004",
+        "Packaged": "2026-08-12 11:05:16 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 16:50:55 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-12 11:05:19 UTC; windows"
       }
     },
     "BFHllm": {
@@ -93,7 +93,7 @@
       "description": {
         "Package": "BFHllm",
         "Title": "LLM Integration Framework for BFH Packages",
-        "Version": "0.2.0",
+        "Version": "0.2.1",
         "Authors@R": "\n    person(\"Johan\", \"Reventlow\", , \"johan.reventlow@regionh.dk\", role = c(\"aut\", \"cre\"))",
         "Description": "AI-driven insights and text generation for healthcare quality\n    improvement. Provides LLM chat interface, RAG (Retrieval Augmented\n    Generation) integration with knowledge stores, and SPC-specific\n    improvement suggestions. Designed for standalone use with BFHcharts\n    or integration in Shiny applications.",
         "License": "MIT + file LICENSE",
@@ -110,17 +110,17 @@
         "RemoteHost": "api.github.com",
         "RemoteRepo": "BFHllm",
         "RemoteUsername": "johanreventlow",
-        "RemoteRef": "v0.2.0",
-        "RemoteSha": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
+        "RemoteRef": "v0.2.2",
+        "RemoteSha": "5b3f38f18af815aa7e6ff59ec07db7d1f814a279",
         "GithubRepo": "BFHllm",
         "GithubUsername": "johanreventlow",
-        "GithubRef": "v0.2.0",
-        "GithubSHA1": "23f10472e40ecfb8b8b682e4ca395bc4e07b74b3",
+        "GithubRef": "v0.2.2",
+        "GithubSHA1": "5b3f38f18af815aa7e6ff59ec07db7d1f814a279",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 16:53:49 UTC; JREV0004",
+        "Packaged": "2026-08-12 11:35:23 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 16:53:53 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-12 11:35:35 UTC; windows"
       }
     },
     "BFHtheme": {
@@ -152,10 +152,10 @@
         "GithubRef": "v0.5.5",
         "GithubSHA1": "8fc1eb9809de13af00aeaafcc5a791fe3bfb4330",
         "NeedsCompilation": "no",
-        "Packaged": "2026-08-11 16:49:54 UTC; JREV0004",
+        "Packaged": "2026-08-12 11:04:38 UTC; JREV0004",
         "Author": "Johan Reventlow [aut, cre]",
         "Maintainer": "Johan Reventlow <johan.reventlow@regionh.dk>",
-        "Built": "R 4.6.0; ; 2026-08-11 16:49:56 UTC; windows"
+        "Built": "R 4.6.0; ; 2026-08-12 11:04:42 UTC; windows"
       }
     },
     "BH": {
@@ -4751,7 +4751,7 @@
       "checksum": "1eabc37e56e29f274f2e5b8eb4d2cf58"
     },
     "DESCRIPTION": {
-      "checksum": "945b803011eb0dc08db399abc1d4fbd9"
+      "checksum": "23ee929299f1bf4113b3f606a043cf00"
     },
     "inst/app/www/analytics-client.js": {
       "checksum": "9f3554011b310b942c12109f347d92b0"


### PR DESCRIPTION
## Summary

- Bumper BFHcharts fra 0.27.0 til 0.27.1 (PATCH-bugfix)
- Bumper BFHllm fra 0.2.0 til 0.2.1 (version-sync-fix i BFHllm selv, se BFHllm PR #11)
- Regenererer `manifest.json`

## BFHcharts 0.27.1

Afdelinger der præsterer over målet får ikke længere en tekst, der lyder som en bebrejdelse. Når et udviklingsmål angives som et bart tal (fx `target_value = 0.85`) uden retningsoperator, rapporterer analysen nu retningen neutralt ("Niveauet ligger stabilt over målet. Vurdér, om det er tilfredsstillende.") i stedet for at antage målet er et minimum.

## BFHllm-version-sync (sidenote)

Under bumpet blev `dev/publish_prepare.R install` blokeret af et upstream-problem i BFHllm: `v0.2.1`-tagget pegede på en commit hvor `DESCRIPTION` stadig rapporterede `Version: 0.2.0` (tag-release.yaml auto-inkrementerer PATCH-taggen ved merge uden at committe det bumpede versionsnummer tilbage). Rettet i [BFHllm PR #11](https://github.com/johanreventlow/BFHllm/pull/11) (merged) — BFHllm's auto-tag-workflow oprettede derefter `v0.2.2` med korrekt `Version: 0.2.1`, som biSPCharts nu pinner til. Ingen funktionel ændring i BFHllm ud over version-sync.

## Test plan

- [x] Fuld testsuite kørt mod BFHcharts 0.27.1: 6637 pass
- [x] 8 fail ved fuld kørsel (test-e2e-workflows.R) — samme kendte Chromote/shinytest2-miljøflakiness som ved forrige bump. Bekræftet ved isoleret kørsel af samme fil: 0 fail / 28 pass / 8 skip-on-CRAN
- [x] manifest.json regenereret og verificeret (`dev/validate_connect_manifest.R` → OK)